### PR TITLE
feat: light mode + theme toggle (#49 phase 3.1)

### DIFF
--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -315,7 +315,7 @@
 
   .clear-filters-link:hover {
     background: var(--pop-pink);
-    color: #000;
+    color: var(--on-accent);
   }
 
   /* --- Empty state --- */
@@ -350,7 +350,7 @@
     align-items: center;
     justify-content: center;
     background: var(--pop-pink);
-    color: #000;
+    color: var(--on-accent);
     font-weight: 700;
     padding: 0.625rem 1.5rem;
     font-size: 0.875rem;
@@ -365,12 +365,12 @@
 
   .btn-clear-all:hover {
     transform: translate(-2px, -2px);
-    box-shadow: 4px 4px 0 #000;
+    box-shadow: 4px 4px 0 var(--shadow-color);
   }
 
   .btn-clear-all:active {
     transform: translate(0, 0);
-    box-shadow: 0 0 0 #000;
+    box-shadow: 0 0 0 var(--shadow-color);
   }
 
   /* --- Book card grid --- */
@@ -412,7 +412,7 @@
 
   .book-card:hover {
     transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 #000;
+    box-shadow: 6px 6px 0 var(--shadow-color);
     border-color: var(--pop-pink);
     color: var(--text);
   }
@@ -548,11 +548,11 @@
     border-color: var(--pop-pink);
     color: var(--text);
     transform: translate(-1px, -1px);
-    box-shadow: 3px 3px 0 #000;
+    box-shadow: 3px 3px 0 var(--shadow-color);
   }
 
   .btn-load-more:active {
     transform: translate(0, 0);
-    box-shadow: 0 0 0 #000;
+    box-shadow: 0 0 0 var(--shadow-color);
   }
 </style>

--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -214,7 +214,7 @@
     margin: 15vh auto 0;
     background: var(--bg-surface);
     border: var(--border-width) solid var(--border);
-    box-shadow: 8px 8px 0 #000;
+    box-shadow: 8px 8px 0 var(--shadow-color);
     overflow: hidden;
   }
 

--- a/src/components/ShareButton.svelte
+++ b/src/components/ShareButton.svelte
@@ -63,12 +63,12 @@
     border-color: var(--pop-pink);
     color: var(--text);
     transform: translate(-1px, -1px);
-    box-shadow: 3px 3px 0 #000;
+    box-shadow: 3px 3px 0 var(--shadow-color);
   }
 
   .share-btn:active {
     transform: translate(0, 0);
-    box-shadow: 0 0 0 #000;
+    box-shadow: 0 0 0 var(--shadow-color);
   }
 
   .share-icon {

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  type Theme = 'light' | 'dark';
+
+  let theme = $state<Theme>('dark');
+
+  function readCurrentTheme(): Theme {
+    if (typeof document === 'undefined') return 'dark';
+    const attr = document.documentElement.getAttribute('data-theme');
+    if (attr === 'light' || attr === 'dark') return attr;
+    return window.matchMedia?.('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  }
+
+  function applyTheme(next: Theme) {
+    document.documentElement.setAttribute('data-theme', next);
+    try {
+      localStorage.setItem('theme', next);
+    } catch {
+      // localStorage may be unavailable (private mode); fall through
+    }
+    theme = next;
+  }
+
+  function toggle() {
+    applyTheme(theme === 'dark' ? 'light' : 'dark');
+  }
+
+  onMount(() => {
+    theme = readCurrentTheme();
+    // Sync across page transitions in case the inline pre-paint script ran with a different value
+    const handler = () => { theme = readCurrentTheme(); };
+    document.addEventListener('astro:after-swap', handler);
+    return () => document.removeEventListener('astro:after-swap', handler);
+  });
+</script>
+
+<button
+  type="button"
+  class="theme-toggle"
+  onclick={toggle}
+  aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+  title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+>
+  {#if theme === 'dark'}
+    <svg class="theme-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+    </svg>
+  {:else}
+    <svg class="theme-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+    </svg>
+  {/if}
+</button>
+
+<style>
+  .theme-toggle {
+    padding: 0.5rem;
+    color: var(--text-muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .theme-toggle:hover {
+    color: var(--text);
+  }
+
+  .theme-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import SearchModal from '../components/SearchModal.svelte';
 import RandomBook from '../components/RandomBook.svelte';
+import ThemeToggle from '../components/ThemeToggle.svelte';
 import stats from '../data/stats.json';
 
 interface Props {
@@ -31,6 +32,19 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
     {siteUrl && <link rel="canonical" href={siteUrl} />}
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <title>{title} — Tsundoku</title>
+    {/* Pre-paint theme application: read stored choice, fall back to system preference. Runs before body to prevent FOUC. */}
+    <script is:inline>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          if (stored === 'light' || stored === 'dark') {
+            document.documentElement.setAttribute('data-theme', stored);
+          }
+        } catch (e) {
+          // localStorage unavailable — system preference handles it via @media
+        }
+      })();
+    </script>
     <ClientRouter />
   </head>
   <body>
@@ -44,6 +58,7 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
         <div class="nav-links">
           <SearchModal client:idle baseUrl={base} />
           <RandomBook client:idle baseUrl={base} />
+          <ThemeToggle client:idle />
           <a href={`${base}browse/`} class="nav-link">Browse</a>
           <a href={`${base}categories/`} class="nav-link">Categories</a>
           <a href={`${base}authors/`} class="nav-link">Authors</a>
@@ -53,6 +68,7 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
         <div class="mobile-controls">
           <SearchModal client:idle baseUrl={base} />
           <RandomBook client:idle baseUrl={base} />
+          <ThemeToggle client:idle />
           <button
             id="mobile-menu-btn"
             class="mobile-toggle"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,7 +1,9 @@
 /* ===== Neo-Brutalist Pop Art Design System ===== */
 
-/* ===== Design Tokens ===== */
+/* ===== Design Tokens — Dark (default) ===== */
 :root {
+  color-scheme: dark;
+
   /* Base palette */
   --bg: #0f0f0f;
   --bg-surface: #1a1a1a;
@@ -14,8 +16,12 @@
   --border: #333;
   --border-strong: #f0f0f0;
   --border-width: 2px;
-  --shadow: 4px 4px 0 #000;
-  --shadow-sm: 2px 2px 0 #000;
+  --shadow-color: #000;
+  --shadow: 4px 4px 0 var(--shadow-color);
+  --shadow-sm: 2px 2px 0 var(--shadow-color);
+
+  /* Color used for text on filled accent backgrounds (e.g. .btn on pop-pink) */
+  --on-accent: #000;
 
   /* Pop Art accent palette — CMYK-inspired, high saturation */
   --pop-pink: oklch(70% 0.22 350);
@@ -35,6 +41,52 @@
   /* Spacing */
   --max-width: 80rem;
   --gutter: clamp(1rem, 3vw, 2rem);
+}
+
+/* ===== Design Tokens — Light ===== */
+/* Applied either by system preference (when user has not chosen) or explicit data-theme="light". */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    color-scheme: light;
+    --bg: #f5f3ee;
+    --bg-surface: #ffffff;
+    --bg-elevated: #ebe7df;
+    --text: #0f0f0f;
+    --text-muted: #4a4a4a;
+    --text-dim: #5e5e5e;
+    --border: #1a1a1a;
+    --border-strong: #0f0f0f;
+    --shadow-color: #0f0f0f;
+    /* Slightly darker pop colors for sufficient contrast on light surfaces */
+    --pop-pink: oklch(55% 0.22 350);
+    --pop-blue: oklch(48% 0.2 250);
+    --pop-green: oklch(48% 0.18 145);
+    --pop-yellow: oklch(60% 0.18 90);
+    --pop-orange: oklch(58% 0.2 55);
+    --pop-purple: oklch(50% 0.2 300);
+    --pop-red: oklch(50% 0.22 25);
+    --pop-cyan: oklch(55% 0.15 200);
+  }
+}
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f5f3ee;
+  --bg-surface: #ffffff;
+  --bg-elevated: #ebe7df;
+  --text: #0f0f0f;
+  --text-muted: #4a4a4a;
+  --text-dim: #5e5e5e;
+  --border: #1a1a1a;
+  --border-strong: #0f0f0f;
+  --shadow-color: #0f0f0f;
+  --pop-pink: oklch(55% 0.22 350);
+  --pop-blue: oklch(48% 0.2 250);
+  --pop-green: oklch(48% 0.18 145);
+  --pop-yellow: oklch(60% 0.18 90);
+  --pop-orange: oklch(58% 0.2 55);
+  --pop-purple: oklch(50% 0.2 300);
+  --pop-red: oklch(50% 0.22 25);
+  --pop-cyan: oklch(55% 0.15 200);
 }
 
 /* ===== Category Colors (static allowlist — 30 categories) ===== */
@@ -92,7 +144,7 @@ a:hover { color: var(--pop-pink); }
 /* ===== Skip Link ===== */
 .skip-link {
   position: absolute; left: -9999px; z-index: 999;
-  padding: 0.75rem 1rem; background: var(--pop-yellow); color: #000;
+  padding: 0.75rem 1rem; background: var(--pop-yellow); color: var(--on-accent);
   font-weight: 700; text-decoration: none;
 }
 .skip-link:focus { left: 0.5rem; top: 0.5rem; }
@@ -213,7 +265,7 @@ a:hover { color: var(--pop-pink); }
 }
 .card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #000;
+  box-shadow: 6px 6px 0 var(--shadow-color);
   border-color: var(--pop-pink);
 }
 
@@ -363,7 +415,7 @@ a:hover { color: var(--pop-pink); }
 }
 .cat-tile:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 4px 4px 0 #000;
+  box-shadow: 4px 4px 0 var(--shadow-color);
   border-color: var(--cat-accent, var(--pop-pink));
   color: var(--cat-accent, var(--pop-pink));
 }
@@ -392,19 +444,19 @@ a:hover { color: var(--pop-pink); }
   text-decoration: none;
   border: 3px solid var(--text);
   background: var(--pop-pink);
-  color: #000;
+  color: var(--on-accent);
   box-shadow: var(--shadow);
   cursor: pointer;
   transition: transform 80ms ease, box-shadow 80ms ease;
 }
 .btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #000;
-  color: #000;
+  box-shadow: 6px 6px 0 var(--shadow-color);
+  color: var(--on-accent);
 }
 .btn:active {
   transform: translate(0, 0);
-  box-shadow: 0 0 0 #000;
+  box-shadow: 0 0 0 var(--shadow-color);
 }
 .btn-outline {
   background: transparent;
@@ -491,7 +543,7 @@ a:hover { color: var(--pop-pink); }
 }
 .list-item:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #000;
+  box-shadow: 3px 3px 0 var(--shadow-color);
   border-color: var(--pop-pink);
   color: var(--text);
 }
@@ -537,7 +589,7 @@ a:hover { color: var(--pop-pink); }
 }
 .resource-btn:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 3px 3px 0 #000;
+  box-shadow: 3px 3px 0 var(--shadow-color);
   color: var(--text);
 }
 .resource-btn-gutenberg { border-color: var(--pop-green); }
@@ -601,7 +653,7 @@ a:hover { color: var(--pop-pink); }
   width: 2.5rem; height: 2.5rem;
   object-fit: cover; flex-shrink: 0;
   border: 2px solid var(--border);
-  box-shadow: 2px 2px 0 #000;
+  box-shadow: 2px 2px 0 var(--shadow-color);
 }
 .author-avatar-placeholder {
   width: 2.5rem; height: 2.5rem;
@@ -609,7 +661,7 @@ a:hover { color: var(--pop-pink); }
   display: flex; align-items: center; justify-content: center;
   color: var(--text-dim);
   border: 2px solid var(--border);
-  box-shadow: 2px 2px 0 #000;
+  box-shadow: 2px 2px 0 var(--shadow-color);
 }
 .author-header {
   display: flex; gap: 1.5rem; flex-wrap: wrap;


### PR DESCRIPTION
## Summary

First slice of #49 (Neo-Brutalist Phase 3): adds light mode tokens + a manual theme toggle. Defers micro-animations, custom display font, and full a11y audit to follow-up phases.

## How it works
- **New token `--shadow-color`** replaces 23 hardcoded \`#000\` values across \`global.css\` and 4 Svelte components, so neo-brutalist drop shadows recolor with the theme.
- **New token `--on-accent`** (\`#000\` in both themes) — high-contrast text on filled accent backgrounds (\`.btn\`, \`.skip-link\`, etc).
- **Light palette**: warm off-white surfaces (\`#f5f3ee\` / \`#ffffff\`), near-black text, darker pop-art accents (oklch L=48-60%) so they retain ~4.5:1 contrast on white.
- **`:root[data-theme=\"light\"]`** explicit override **+** a `@media (prefers-color-scheme: light) { :root:not([data-theme=\"dark\"]) {...} }` fallback that respects system preference only when the user has not chosen.
- **`ThemeToggle.svelte`** (sun/moon icon button) sits in the nav next to the random-book button on both desktop and mobile. Persists choice to \`localStorage\`, syncs with \`astro:after-swap\` view transitions.
- **Inline pre-paint script** in \`Layout.astro\` reads \`localStorage\` and sets \`data-theme\` synchronously before the body renders to prevent flash-of-wrong-theme.

## Test plan
- [x] \`npm run typecheck\` — 0 errors, 0 warnings
- [x] \`npm test\` — 33/33
- [x] \`npm run build\` — 5352 pages built
- [x] Built CSS contains both \`@media(prefers-color-scheme: light)\` and \`:root[data-theme=\"light\"]\` blocks
- [x] Rendered HTML mounts the toggle into both nav slots (desktop + mobile)
- [ ] Visual: confirm light/dark toggle on home, browse, book detail, author detail
- [ ] Visual: confirm system-pref fallback works on a fresh browser/private window
- [ ] Visual: confirm shadows recolor in both themes (no leftover dark-only #000)
- [ ] A11y: confirm WCAG 4.5:1 contrast for text on light surfaces

## Notes
- Independent of #81 (deps batch). PR #81 fixes CI; this PR just exercises the design tokens.
- Modal scrim (\`rgba(0,0,0,0.6)\`) is intentionally left as a dark overlay in both themes — it dims the bright background to make the modal pop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)