### PR TITLE
feat(motion): book cover + author photo morph (#49 phase 3.3)

### DIFF
--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -148,7 +148,7 @@
         <a href="{baseUrl}books/{book.slug}/" class="book-card">
           <div class="book-card-inner">
             {#if book.cover_url}
-              <img src={thumbnailUrl(book.cover_url)} alt="" width="48" height="72" class="book-thumb" loading="lazy" />
+              <img src={thumbnailUrl(book.cover_url)} alt="" width="48" height="72" class="book-thumb" loading="lazy" style:view-transition-name={`cover-${book.slug}`} />
             {:else}
               <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
             {/if}

--- a/src/pages/authors/[slug].astro
+++ b/src/pages/authors/[slug].astro
@@ -57,6 +57,7 @@ const lifespan = author.birth_year
         alt={author.name}
         class="author-photo"
         loading="eager"
+        transition:name={`author-${author.slug}`}
       />
     ) : (
       <div class="author-photo-placeholder" aria-hidden="true">
@@ -100,7 +101,7 @@ const lifespan = author.birth_year
     {books.map(book => (
       <a href={`${base}books/${book.data.slug}/`} class="card book-cover-group book-card-compact">
         {book.data.cover_url ? (
-          <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" />
+          <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" transition:name={`cover-${book.data.slug}`} />
         ) : (
           <div class="book-thumb-placeholder" aria-hidden="true">
             <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -62,7 +62,7 @@ const letters = [...new Set(authors.map(a => a.name[0].toUpperCase()))].sort();
             const inner = (
               <>
                 {author.photo_url ? (
-                  <img src={author.photo_url} alt="" class="author-avatar" loading="lazy" />
+                  <img src={author.photo_url} alt="" class="author-avatar" loading="lazy" transition:name={`author-${author.slug}`} />
                 ) : (
                   <div class="author-avatar-placeholder">
                     <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -21,8 +21,9 @@ const sameAuthor = allBooks
   .map(b => b.data)
   .sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title));
 
+const sameAuthorSlugs = new Set(sameAuthor.map(b => b.slug));
 const sameCategory = allBooks
-  .filter(b => b.data.category === book.category && b.data.slug !== book.slug)
+  .filter(b => b.data.category === book.category && b.data.slug !== book.slug && !sameAuthorSlugs.has(b.data.slug))
   .map(b => b.data)
   .sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title))
   .slice(0, 12);
@@ -61,6 +62,7 @@ const categorySlug = toSlug(book.category);
             alt={`Cover of ${book.title}`}
             class="book-detail-cover"
             loading="eager"
+            transition:name={`cover-${book.slug}`}
           />
         </div>
       ) : (
@@ -197,7 +199,7 @@ const categorySlug = toSlug(book.category);
           {sameAuthor.slice(0, 6).map(b => (
             <a href={`${base}books/${b.slug}/`} class="card related-book">
               {b.cover_url ? (
-                <img src={b.cover_url} alt={b.title} class="related-book-cover" loading="lazy" />
+                <img src={b.cover_url} alt={b.title} class="related-book-cover" loading="lazy" transition:name={`cover-${b.slug}`} />
               ) : (
                 <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
               )}
@@ -221,7 +223,7 @@ const categorySlug = toSlug(book.category);
           {sameCategory.slice(0, 6).map(b => (
             <a href={`${base}books/${b.slug}/`} class="card related-book">
               {b.cover_url ? (
-                <img src={b.cover_url} alt={b.title} class="related-book-cover" loading="lazy" />
+                <img src={b.cover_url} alt={b.title} class="related-book-cover" loading="lazy" transition:name={`cover-${b.slug}`} />
               ) : (
                 <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
               )}

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -45,7 +45,7 @@ const base = import.meta.env.BASE_URL;
     {books.map(book => (
       <a href={`${base}books/${book.data.slug}/`} class="card book-cover-group book-card-compact">
         {book.data.cover_url ? (
-          <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" />
+          <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" transition:name={`cover-${book.data.slug}`} />
         ) : (
           <div class="book-thumb-placeholder" aria-hidden="true">
             <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">


### PR DESCRIPTION
## Summary

Phase 3.3 of #49 — wires Astro view transitions so book covers and author photos **morph between list and detail pages**, replacing the default page fade with a continuous element-level animation. ClientRouter was already enabled; this PR just adds the \`transition:name\` mappings.

**Branches off \`main\` directly** — independent of #82 and #83. Lands cleanly regardless of merge order.

## Mappings

| Element | Name | Source pages | Destination |
|---|---|---|---|
| Book cover | \`cover-{slug}\` | BookGrid (browse), category detail, author detail book list, related books on a book detail page | Book detail hero |
| Author photo | \`author-{slug}\` | Authors index avatar | Author detail hero |

## Uniqueness — the easy way to break view transitions

\`view-transition-name\` must be unique within a single rendered page, or the browser logs an error and **skips the transition entirely**. Two changes guarantee this:

1. **Dedupe related book sections.** On a book detail page, a book matching both author and category would have rendered \`cover-{slug}\` twice (once in *More by author*, once in *More in category*). The \`sameCategory\` list now excludes any book already in \`sameAuthor\`.
2. **Svelte ≠ Astro directives.** \`transition:name\` is an Astro directive. BookGrid is a Svelte island, so it sets the underlying CSS property directly via \`style:view-transition-name\` instead.

## Reduced motion

Astro and Chromium-based browsers honor \`prefers-reduced-motion\` natively for the \`::view-transition-old\` / \`::view-transition-new\` pseudo-elements. No extra CSS guard needed; reduced-motion users see a snap cut between pages.

## Test plan
- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm test\` — 33/33
- [x] \`npm run build\` — 5,352 pages (~220s, in line with prior runs)
- [x] Built HTML emits \`data-astro-transition-scope\` on each cover and the matching \`view-transition-name: cover-{slug}\` CSS rule per element.
- [x] BookGrid emits inline \`style=\"view-transition-name: cover-{slug}\"\` on every visible thumb.
- [ ] Visual: morph a book cover from /browse → book detail (Chromium)
- [ ] Visual: morph a book cover from /authors/{slug} → book detail
- [ ] Visual: morph a book cover from /categories/{slug} → book detail
- [ ] Visual: morph an author photo from /authors → /authors/{slug}
- [ ] Visual: confirm no duplicate-name console warnings on book detail pages with overlapping author/category lists
- [ ] Reduced-motion: confirm transitions snap rather than morph

## Cost note

Astro emits a small inline \`<style>\` block per scoped element to map \`data-astro-transition-scope\` → \`view-transition-name\`. On a book detail page with hero + 12 related items, this is roughly 13 inline style blocks (~2.5 KB of HTML per page, gzipped tighter). Acceptable for the morph payoff but worth flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)