### PR TITLE
fix(a11y): focus trap + ARIA progressbars + cover alt (#49)

### DIFF
--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -118,7 +118,7 @@
 
   <!-- Results bar -->
   <div class="results-bar">
-    <p class="results-count">
+    <p class="results-count" aria-live="polite" aria-atomic="true">
       {#if sortedBooks.length === books.length}
         {books.length.toLocaleString()} books
       {:else}

--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -15,7 +15,27 @@
   let loaded = $state(false);
   let loadError = $state(false);
   let inputEl: HTMLInputElement;
+  let modalEl: HTMLDivElement;
+  let triggerEl: HTMLButtonElement | null = null;
   let activeIndex = $state(-1);
+
+  function trapTab(e: KeyboardEvent) {
+    if (e.key !== 'Tab' || !modalEl) return;
+    const focusable = modalEl.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
 
   let results = $derived(() => {
     if (query.length < 2 || !loaded) return [];
@@ -41,9 +61,10 @@
     }
   }
 
-  function toggle() {
+  function toggle(e?: Event) {
     open = !open;
     if (open) {
+      triggerEl = (e?.currentTarget as HTMLButtonElement) ?? document.activeElement as HTMLButtonElement | null;
       query = '';
       activeIndex = -1;
       void loadIndex();
@@ -55,6 +76,8 @@
     open = false;
     query = '';
     activeIndex = -1;
+    // Restore focus to whatever opened the modal so screen-reader and keyboard users land back at the trigger.
+    triggerEl?.focus();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -65,6 +88,7 @@
     if (e.key === 'Escape' && open) {
       close();
     }
+    if (open) trapTab(e);
   }
 
   function handleResultKeydown(e: KeyboardEvent) {
@@ -106,6 +130,7 @@
   >
     <div
       class="modal"
+      bind:this={modalEl}
       onclick={(e) => e.stopPropagation()}
       role="dialog"
       aria-modal="true"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ const yearSpan = stats.newest_year - stats.oldest_year;
     <!-- Progress -->
     {stats.reading_progress.read > 0 && (
       <div class="max-w-xl mx-auto mb-8">
-        <div class="progress-bar">
+        <div class="progress-bar" role="progressbar" aria-valuenow={readPct} aria-valuemin="0" aria-valuemax="100" aria-label={`${readPct}% of books read`}>
           <div class="progress-fill-read" style={`width: ${readPct}%`}></div>
           <div class="progress-fill-reading" style={`width: ${100 * stats.reading_progress.reading / stats.total_books}%`}></div>
         </div>
@@ -103,7 +103,7 @@ const yearSpan = stats.newest_year - stats.oldest_year;
           <div class="grid grid-2 sm-grid-4 lg-grid-8 gap-4">
             {featured.map(b => (
               <a href={`${base}books/${b.data.slug}/`} class="book-cover-group">
-                <img src={b.data.cover_url_large || b.data.cover_url} alt={b.data.title}
+                <img src={b.data.cover_url_large || b.data.cover_url} alt={`Cover of ${b.data.title}`}
                   class="book-cover" loading="lazy" />
                 <p class="featured-title">{b.data.title}</p>
                 <p class="featured-author truncate text-dim">{b.data.author}</p>

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -66,8 +66,8 @@ const base = import.meta.env.BASE_URL;
       </div>
     </div>
     <div class="card card-padded">
-      <div class="progress-bar">
-        <div class="progress-fill-read" style={`width: ${100 * stats.reading_progress.read / stats.total_books}%`} title={`Read: ${stats.reading_progress.read}`}></div>
+      <div class="progress-bar" role="progressbar" aria-valuenow={Math.round(100 * stats.reading_progress.read / stats.total_books)} aria-valuemin="0" aria-valuemax="100" aria-label={`${Math.round(100 * stats.reading_progress.read / stats.total_books)}% of books read`}>
+        <div class="progress-fill-read" style={`width: ${100 * stats.reading_progress.read / stats.total_books}%`}></div>
       </div>
       <p class="text-xs text-dim mt-2">
         {stats.reading_progress.read.toLocaleString()} of {stats.total_books.toLocaleString()} read ({Math.round(100 * stats.reading_progress.read / stats.total_books)}%). The time spent tracking the other {(stats.total_books - stats.reading_progress.read).toLocaleString()} could have been spent reading them.
@@ -89,7 +89,7 @@ const base = import.meta.env.BASE_URL;
             <span class="text-muted">{p.label}</span>
             <span class="text-dim">{p.count} ({Math.round(100 * p.count / stats.total_books)}%)</span>
           </div>
-          <div class="progress-bar">
+          <div class="progress-bar" role="progressbar" aria-valuenow={Math.round(100 * p.count / stats.total_books)} aria-valuemin="0" aria-valuemax="100" aria-label={`${p.label}: ${p.count} books`}>
             <div style={`width: ${100 * p.count / stats.total_books}%; background: ${p.color};`}></div>
           </div>
         </div>
@@ -114,7 +114,7 @@ const base = import.meta.env.BASE_URL;
             <span class="text-sm text-muted">{e.label}</span>
             <span class="font-bold heading-md">{e.pct}%</span>
           </div>
-          <div class="progress-bar">
+          <div class="progress-bar" role="progressbar" aria-valuenow={e.pct} aria-valuemin="0" aria-valuemax="100" aria-label={`${e.label} coverage: ${e.pct}%`}>
             <div style={`width: ${e.pct}%; background: var(--pop-pink);`}></div>
           </div>
           <p class="text-xs text-dim mt-2">{e.count.toLocaleString()} of {stats.total_books.toLocaleString()}</p>
@@ -140,7 +140,7 @@ const base = import.meta.env.BASE_URL;
             <span class="text-muted">{era.label}</span>
             <span class="text-dim">{era.count}</span>
           </div>
-          <div class="progress-bar">
+          <div class="progress-bar" role="progressbar" aria-valuenow={Math.round(100 * era.count / stats.total_books)} aria-valuemin="0" aria-valuemax="100" aria-label={`${era.label}: ${era.count} books`}>
             <div style={`width: ${100 * era.count / stats.total_books}%; background: var(--pop-purple);`}></div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Static a11y review of the codebase. Most of the site already passes (landmarks, heading hierarchy, skip link, form labels, semantic HTML, reduced-motion all clean) — these are the four real fixes.

Closes the remaining audit deliverable on #49 to the extent possible without a deployed-axe-core run; recommend keeping #49 open if you want to schedule a real browser audit.

## Fixes

### 1. SearchModal — proper modal focus semantics
The dialog had \`role=\"dialog\"\` and \`aria-modal=\"true\"\` but Tab moved focus out of the modal to elements beneath, and Esc/click-outside didn't return focus to the trigger. Now:
- Focus trap on Tab / Shift+Tab — wraps from last → first and first → last among focusable descendants of the modal.
- On close, focus returns to whatever opened the dialog (captured via \`event.currentTarget\` at toggle time so desktop and mobile triggers each restore correctly).

### 2. ARIA progressbars — index.astro + stats.astro
All five \`.progress-bar\` elements (1 on home, 4 on stats) gain \`role=\"progressbar\"\`, \`aria-valuenow/min/max\`, and a descriptive \`aria-label\`. Screen readers now announce e.g. *\"89% of books read\"*, *\"Cover Art coverage: 98.3%\"*, *\"Before 1800: 158 books\"*. Removed a redundant \`title\` attribute that was the only label before.

### 3. Cover alt text — index.astro
Featured covers in *Must-Reads (Allegedly)* used \`alt={title}\` which reads ambiguously (*\"The Plague\"* — image of what?). Now \`alt=\"Cover of {title}\"\`, matching the convention on the book detail hero.

### 4. BookGrid filter results — polite live region
Wrapped the results count in \`aria-live=\"polite\" aria-atomic=\"true\"\` so screen-reader users filtering or hitting *Show more* hear e.g. *\"127 of 5,352 books\"* without navigating back to the count.

## Verified
- \`npm run typecheck\` — 0 errors
- \`npm test\` — 33/33
- \`npm run build\` — 5,352 pages
- Built HTML emits \`role=\"progressbar\"\` + \`aria-valuenow\` on all five bars and \`aria-live=\"polite\"\` on the results count.

## Test plan
- [x] Static review: no \`<div onclick>\`, all images have alt, all form controls labeled
- [x] Builds clean
- [ ] Visual: open SearchModal, hold Tab — confirm focus stays inside; press Escape — confirm focus returns to the search button
- [ ] Visual: filter on /browse — confirm screen reader announces the new count
- [ ] axe-core run against deployed URL (separate session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)