### PR TITLE
fix(ui): consolidate nav islands + theme-aware borders + a11y cleanup

### DIFF
--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -223,7 +223,7 @@
   .search-input {
     width: 100%;
     background: var(--bg-surface);
-    border: 3px solid #555;
+    border: 3px solid var(--border);
     color: var(--text);
     padding: 0.625rem 1rem 0.625rem 2.5rem;
     font-size: 1rem;
@@ -262,7 +262,7 @@
   .filter-select {
     flex: 1;
     background: var(--bg-surface);
-    border: 3px solid #555;
+    border: 3px solid var(--border);
     color: var(--text);
     padding: 0.625rem 0.75rem;
     font-size: 0.875rem;
@@ -401,7 +401,7 @@
   /* --- Book card --- */
   .book-card {
     display: block;
-    border: 3px solid #555;
+    border: 3px solid var(--border);
     background: var(--bg-surface);
     padding: 0.75rem;
     box-shadow: var(--shadow);
@@ -530,7 +530,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 3px solid #555;
+    border: 3px solid var(--border);
     background: transparent;
     color: var(--text-muted);
     font-weight: 800;

--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -125,7 +125,6 @@
   <div
     class="overlay"
     onclick={close}
-    onkeydown={(e) => e.key === 'Escape' && close()}
     role="presentation"
   >
     <div

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -250,5 +250,5 @@
     "shelf_meters": 91.1,
     "books_with_pages": 3267
   },
-  "generated_at": "2026-03-22T21:12:27.958118"
+  "generated_at": "2026-05-01T11:09:00.920077"
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,30 +59,30 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
         <a href={`${base}`} class="nav-brand">
           積ん読 <span>Tsundoku</span>
         </a>
-        <div class="nav-links">
-          <SearchModal client:idle baseUrl={base} />
-          <RandomBook client:idle baseUrl={base} />
-          <ThemeToggle client:idle />
-          <a href={`${base}browse/`} class="nav-link">Browse</a>
-          <a href={`${base}categories/`} class="nav-link">Categories</a>
-          <a href={`${base}authors/`} class="nav-link">Authors</a>
-          <a href={`${base}stats/`} class="nav-link">Stats</a>
-          <a href={`${base}about/`} class="nav-link">About</a>
-        </div>
-        <div class="mobile-controls">
-          <SearchModal client:idle baseUrl={base} />
-          <RandomBook client:idle baseUrl={base} />
-          <ThemeToggle client:idle />
-          <button
-            id="mobile-menu-btn"
-            class="mobile-toggle"
-            aria-label="Toggle menu"
-            aria-expanded="false"
-          >
-            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-            </svg>
-          </button>
+        <div class="nav-right">
+          <div class="nav-links">
+            <a href={`${base}browse/`} class="nav-link">Browse</a>
+            <a href={`${base}categories/`} class="nav-link">Categories</a>
+            <a href={`${base}authors/`} class="nav-link">Authors</a>
+            <a href={`${base}stats/`} class="nav-link">Stats</a>
+            <a href={`${base}about/`} class="nav-link">About</a>
+          </div>
+          <div class="nav-utility">
+            <SearchModal client:idle baseUrl={base} />
+            <RandomBook client:idle baseUrl={base} />
+            <ThemeToggle client:idle />
+            <button
+              id="mobile-menu-btn"
+              class="mobile-toggle"
+              aria-label="Toggle menu"
+              aria-expanded="false"
+              aria-controls="mobile-menu"
+            >
+              <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
       <div id="mobile-menu" class="mobile-menu">

--- a/src/pages/authors/[slug].astro
+++ b/src/pages/authors/[slug].astro
@@ -30,7 +30,7 @@ const lifespan = author.birth_year
 ---
 
 <Layout title={author.name} description={`${books.length} books by ${author.name} in the tsundoku collection`} image={author.photo_url}>
-  <script type="application/ld+json" set:html={JSON.stringify({
+  <script is:inline type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Person",
     "name": author.name,

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { toSlug, pluralize } from '../../utils/formatting';
+import { toSlug } from '../../utils/formatting';
 
 const books = await getCollection('books');
 const enrichedAuthors = await getCollection('authors');

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -32,7 +32,7 @@ const categorySlug = toSlug(book.category);
 ---
 
 <Layout title={book.title} description={book.description || `${book.title} by ${book.author} — ${book.category}`} image={book.cover_url_large || book.cover_url}>
-  <script type="application/ld+json" set:html={JSON.stringify({
+  <script is:inline type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Book",
     "name": book.title,
@@ -136,14 +136,14 @@ const categorySlug = toSlug(book.category);
       </dl>
 
       {book.subjects && book.subjects.length > 0 && (
-        <div class="detail-section">
+        <dl class="detail-section">
           <dt class="text-dim text-sm mb-2">Subjects</dt>
-          <div class="flex flex-wrap gap-2">
+          <dd class="flex flex-wrap gap-2">
             {book.subjects.map(s => (
               <span class="meta-tag">{s}</span>
             ))}
-          </div>
-        </div>
+          </dd>
+        </dl>
       )}
 
       {(book.gutenberg_url || book.hathitrust_url || book.librivox_url) && (
@@ -199,7 +199,7 @@ const categorySlug = toSlug(book.category);
           {sameAuthor.slice(0, 6).map(b => (
             <a href={`${base}books/${b.slug}/`} class="card related-book">
               {b.cover_url ? (
-                <img src={b.cover_url} alt={b.title} class="related-book-cover" loading="lazy" transition:name={`cover-${b.slug}`} />
+                <img src={b.cover_url} alt={`Cover of ${b.title}`} class="related-book-cover" loading="lazy" transition:name={`cover-${b.slug}`} />
               ) : (
                 <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
               )}
@@ -223,7 +223,7 @@ const categorySlug = toSlug(book.category);
           {sameCategory.slice(0, 6).map(b => (
             <a href={`${base}books/${b.slug}/`} class="card related-book">
               {b.cover_url ? (
-                <img src={b.cover_url} alt={b.title} class="related-book-cover" loading="lazy" transition:name={`cover-${b.slug}`} />
+                <img src={b.cover_url} alt={`Cover of ${b.title}`} class="related-book-cover" loading="lazy" transition:name={`cover-${b.slug}`} />
               ) : (
                 <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
               )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import stats from '../data/stats.json';
-import { toSlug, seededShuffle } from '../utils/formatting';
+import { seededShuffle } from '../utils/formatting';
 
 const base = import.meta.env.BASE_URL;
 const books = await getCollection('books');

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -178,6 +178,7 @@ a:hover { color: var(--pop-pink); }
 .nav-brand span { display: none; }
 @media (min-width: 640px) { .nav-brand span { display: inline; } }
 
+.nav-right { display: flex; align-items: center; gap: 1.25rem; }
 .nav-links { display: none; align-items: center; gap: 1.25rem; }
 @media (min-width: 640px) { .nav-links { display: flex; } }
 
@@ -188,15 +189,16 @@ a:hover { color: var(--pop-pink); }
 }
 .nav-link:hover { color: var(--text); }
 
-/* Mobile nav */
-.mobile-controls { display: flex; align-items: center; gap: 0.25rem; }
-@media (min-width: 640px) { .mobile-controls { display: none; } }
+/* Utility cluster (search, random, theme, mobile toggle) — single instance, visible at all breakpoints */
+.nav-utility { display: flex; align-items: center; gap: 0.25rem; }
 
 .mobile-toggle {
   padding: 0.5rem; background: none; border: none;
   color: var(--text-muted); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
 }
 .mobile-toggle:hover { color: var(--text); }
+@media (min-width: 640px) { .mobile-toggle { display: none; } }
 
 .mobile-menu {
   display: none; padding-bottom: 0.75rem;
@@ -264,7 +266,7 @@ a:hover { color: var(--pop-pink); }
 
 /* ===== Neo-Brutalist Cards ===== */
 .card {
-  border: 3px solid #555;
+  border: 3px solid var(--border);
   background: var(--bg-surface);
   box-shadow: var(--shadow);
   text-decoration: none;


### PR DESCRIPTION
## Summary

Phase 3.x merge stack (PRs #82, #84, #85, #86) introduced a few regressions visible on the live site. This bundles the fixes into one focused PR. All findings were verified in Chrome against the production site (`williamzujkowski.github.io/tsundoku`) and the live local preview.

### 1. Critical — duplicate hydration of nav islands
`SearchModal`, `RandomBook`, `ThemeToggle` were each rendered twice — once in `.nav-links` (desktop) and once in `.mobile-controls` (mobile). Live HTML confirmed:

| | Live (before) | Local (after) |
|---|---|---|
| `astro-island` count | **6** | 3 |
| Duplicate UIDs | `195MJp`, `ZXfVn8`, `4aHK9` | none |
| Modals on ⌘K | **2 simultaneous** with colliding `id=\"search-results\"` | 1 |
| `<svelte:window onkeydown>` listeners | duplicated | single |

Fix: hoist to a single `.nav-utility` cluster visible at all breakpoints, parallel to `.nav-links` and the mobile-toggle. One instance of each component, no duplicate IDs, half the hydration cost across all 5,352 prerendered pages.

### 2. Light-mode regression — hardcoded `#555` borders
`.card`, `.search-input`, `.filter-select`, `.book-card`, `.btn-load-more` all had a literal `border: 3px solid #555` that bypassed the `--border` token. Light mode shows strong black borders elsewhere (`--border: #1a1a1a`), but these stayed washed-out gray. Replaced with `var(--border)` for theme parity.

### 3. A11y — orphan `<dt>` (axe serious)
Discovered while running axe-core in-browser: the book detail \"Subjects\" section used a bare `<dt>` with no `<dl>` parent. Wrapped properly in `<dl>`/`<dt>`/`<dd>`.

### 4. A11y — inconsistent cover alt text
Phase 3.4 (#86) standardized featured covers as `\"Cover of {title}\"` but missed the \"More by author\" / \"More in category\" sections of book detail. Brought to parity.

### 5. Cleanup
- `is:inline` directive on JSON-LD `<script>` (astro 4000 hint × 2)
- Drop unused imports (`toSlug` in `index.astro`, `pluralize` in `authors/index.astro`)
- Drop redundant `onkeydown` on SearchModal overlay (Escape is handled by the global keydown handler already)

## Headless axe-core results (closes the #49 deliverable)

WCAG 2.1 A + AA, axe-core 4.11.2, run in-browser against the local preview build:

| Page | Violations |
|---|---|
| `/` | **0** |
| `/browse/` | **0** |
| `/books/american-gods/` | **0** (was 1 — orphan `<dt>`) |
| `/authors/neil-gaiman/` | **0** |
| `/categories/philosophy/` | **0** |
| `/stats/` | **0** |
| `/about/` | **0** |

## Test plan
- [x] `npm run typecheck` — 0 errors / 0 warnings; hints 45 → 41 (cleaned 4)
- [x] `npm test` — 33/33 passing
- [x] Live URL verification: confirmed regression on prod, then verified fix on local preview
- [x] Mobile (~536px) and desktop (1280px) viewport — utility row visible at both, hamburger appears only mobile, nav links only desktop
- [x] Theme toggle: light ↔ dark swap still works
- [x] axe-core: 7 representative pages clean

Closes #49 (a11y audit deliverable on a deployed-style URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)