### PR TITLE
chore(deps): migrate z import to astro/zod (clears 41 deprecation hints)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const books = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/books' }),

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -250,5 +250,5 @@
     "shelf_meters": 91.1,
     "books_with_pages": 3267
   },
-  "generated_at": "2026-03-22T21:12:27.958118"
+  "generated_at": "2026-05-01T11:27:01.219645"
 }


### PR DESCRIPTION
## Summary

\`import { z } from 'astro:content'\` is deprecated since Astro 6 and will be removed in Astro 7. The deprecation source ([\`astro/types/content.d.ts\`](https://github.com/withastro/astro/blob/main/packages/astro/types/content.d.ts)):

\`\`\`ts
// TODO: remove in Astro 7
/**
 * @deprecated
 * \`import { z } from 'astro:content'\` is deprecated and will be removed
 * in Astro 7. Use \`import { z } from 'astro/zod'\` instead.
 */
export const z = zod.z;
\`\`\`

This swaps the single import in \`src/content.config.ts\`. No schema changes, no behavior changes — purely a future-proofing pre-bump for the eventual Astro 7 upgrade.

## Test plan
- [x] \`npm run typecheck\` — 0 errors / 0 warnings; **45 → 4 hints** (the remaining 4 are addressed in #87)
- [x] \`npm test\` — 33/33 passing
- [x] \`npm run build\` — 5,352 pages built, exit 0
- [x] Verified content collection schemas still resolve and pages render with the same data

🤖 Generated with [Claude Code](https://claude.com/claude-code)