### PR TITLE
chore(search): wrap inputEl/modalEl in $state() for Svelte 5

### DIFF
--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -14,8 +14,8 @@
   let items = $state<SearchItem[]>([]);
   let loaded = $state(false);
   let loadError = $state(false);
-  let inputEl: HTMLInputElement;
-  let modalEl: HTMLDivElement;
+  let inputEl = $state<HTMLInputElement | undefined>();
+  let modalEl = $state<HTMLDivElement | undefined>();
   let triggerEl: HTMLButtonElement | null = null;
   let activeIndex = $state(-1);
 


### PR DESCRIPTION
## What

Silence the two Svelte 5 \`non_reactive_update\` warnings emitted on every dev compile:

\`\`\`
[vite-plugin-svelte] src/components/SearchModal.svelte:17:6 \`inputEl\` is updated, but is not declared with \`\$state(...)\`
[vite-plugin-svelte] src/components/SearchModal.svelte:18:6 \`modalEl\` is updated, but is not declared with \`\$state(...)\`
\`\`\`

Two-line change. \`bind:this\` targets need to be reactive in Svelte 5.

## Test plan
- [x] Typecheck clean
- [x] 33/33 tests pass
- [x] No more warnings on \`npm run dev\`
- [x] Verified in /chrome: ⌘K opens modal, input focuses, typing returns results, Escape closes

Closes #95. Part of epic #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)