### PR TITLE
fix(browse): fetch-on-hydrate — drop /browse/ from 1.93 MB to 157 KB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ data/enrichment-errors.jsonl
 
 # Generated at build time
 public/search-index.json
+public/browse-data.json
 data/.~lock.*

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "astro dev",
     "stats": "python3 scripts/generate-stats.py",
-    "prebuild": "python3 scripts/apply-reading-status.py && python3 scripts/generate-author-stubs.py && python3 scripts/generate-stats.py && python3 scripts/generate-search-index.py",
+    "prebuild": "python3 scripts/apply-reading-status.py && python3 scripts/generate-author-stubs.py && python3 scripts/generate-stats.py && python3 scripts/generate-search-index.py && python3 scripts/generate-browse-data.py",
     "build": "astro build",
     "typecheck": "astro check",
     "lint": "astro check",

--- a/scripts/generate-browse-data.py
+++ b/scripts/generate-browse-data.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate browse-data.json for the Browse page's BookGrid island.
+
+Same pattern as search-index.json: instead of inlining 3,644 books'
+worth of props into every page's HTML (current /browse/ ships ~1.9 MB),
+we ship a small page shell and let the island fetch this JSON on mount.
+
+Short field names keep the wire size small. BookGrid maps them to the
+internal type when consuming.
+"""
+
+import json
+from pathlib import Path
+
+BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
+OUTPUT = Path(__file__).parent.parent / "public" / "browse-data.json"
+
+
+def main() -> None:
+    books = []
+    categories = set()
+    tag_counts: dict[str, int] = {}
+
+    for bp in sorted(BOOKS_DIR.glob("*.json")):
+        d = json.loads(bp.read_text())
+        entry = {
+            "t": d["title"],
+            "a": d.get("author", ""),
+            "s": d["slug"],
+            "p": d.get("priority", 3),
+            "cat": d.get("category", ""),
+        }
+        # Only include optional fields when set — fewer null bytes on the wire.
+        if d.get("cover_url"):
+            entry["co"] = d["cover_url"]
+        if d.get("first_published"):
+            entry["y"] = d["first_published"]
+        if d.get("reading_status"):
+            entry["rs"] = d["reading_status"]
+        tags = d.get("tags") or []
+        if tags:
+            entry["g"] = tags
+            for t in tags:
+                tag_counts[t] = tag_counts.get(t, 0) + 1
+        if entry["cat"]:
+            categories.add(entry["cat"])
+        books.append(entry)
+
+    payload = {
+        "books": books,
+        "categories": sorted(categories),
+        # Tags sorted by frequency descending (matches existing UI behavior).
+        "tags": [t for t, _ in sorted(tag_counts.items(), key=lambda kv: (-kv[1], kv[0]))],
+    }
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(payload, separators=(",", ":")))
+
+    size_kb = OUTPUT.stat().st_size / 1024
+    print(
+        f"Browse data: {len(books)} books, "
+        f"{len(payload['categories'])} categories, "
+        f"{len(payload['tags'])} tags ({size_kb:.0f}KB)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { thumbnailUrl } from '../utils/formatting';
 
   interface Book {
@@ -13,7 +14,20 @@
     tags?: string[];
   }
 
-  let { books = [], categories = [], tags = [], baseUrl = '/' }: { books: Book[]; categories: string[]; tags?: string[]; baseUrl?: string } = $props();
+  // Compact wire format from /browse-data.json — keep keys short to shrink payload.
+  interface WireBook {
+    t: string; a: string; s: string; p: number; cat: string;
+    co?: string; y?: number; rs?: 'want' | 'reading' | 'read'; g?: string[];
+  }
+  interface BrowseData { books: WireBook[]; categories: string[]; tags: string[]; }
+
+  let { baseUrl = '/' }: { baseUrl?: string } = $props();
+
+  let books = $state<Book[]>([]);
+  let categories = $state<string[]>([]);
+  let tags = $state<string[]>([]);
+  let loaded = $state(false);
+  let loadError = $state(false);
 
   let search = $state('');
   let selectedCategory = $state('');
@@ -21,6 +35,30 @@
   let selectedStatus = $state('');
   let selectedTag = $state('');
   let showCount = $state(100);
+
+  onMount(async () => {
+    try {
+      const res = await fetch(`${baseUrl}browse-data.json`);
+      if (!res.ok) { loadError = true; return; }
+      const data: BrowseData = await res.json();
+      books = data.books.map(b => ({
+        title: b.t,
+        author: b.a,
+        category: b.cat,
+        priority: b.p,
+        slug: b.s,
+        cover_url: b.co,
+        first_published: b.y,
+        reading_status: b.rs,
+        tags: b.g,
+      }));
+      categories = data.categories;
+      tags = data.tags;
+      loaded = true;
+    } catch {
+      loadError = true;
+    }
+  });
 
   let filtered = $derived(
     books.filter(b => {
@@ -119,7 +157,9 @@
   <!-- Results bar -->
   <div class="results-bar">
     <p class="results-count" aria-live="polite" aria-atomic="true">
-      {#if sortedBooks.length === books.length}
+      {#if !loaded && !loadError}
+        Loading…
+      {:else if sortedBooks.length === books.length}
         {books.length.toLocaleString()} books
       {:else}
         {sortedBooks.length.toLocaleString()} of {books.length.toLocaleString()} books
@@ -132,8 +172,20 @@
     {/if}
   </div>
 
-  <!-- Empty state -->
-  {#if sortedBooks.length === 0}
+  {#if loadError}
+    <div class="empty-state">
+      <p class="empty-title">Couldn't load the book list</p>
+      <p class="empty-subtitle">Something went wrong loading <code>browse-data.json</code>. Try refreshing.</p>
+    </div>
+  {:else if !loaded}
+    <!-- Loading skeleton — empty placeholder boxes that fade out when data arrives -->
+    <div class="book-cards-grid" aria-hidden="true">
+      {#each Array(12) as _}
+        <div class="book-card book-card-skeleton"></div>
+      {/each}
+    </div>
+  {:else if sortedBooks.length === 0}
+    <!-- Empty state -->
     <div class="empty-state">
       <p class="empty-title">No books found</p>
       <p class="empty-subtitle">Try adjusting your search or filters.</p>
@@ -415,6 +467,23 @@
     box-shadow: 6px 6px 0 var(--shadow-color);
     border-color: var(--pop-pink);
     color: var(--text);
+  }
+
+  /* Skeleton placeholder while browse-data.json is loading. Same dimensions as a
+     real card so the layout doesn't shift when data arrives. */
+  .book-card-skeleton {
+    height: 6rem;
+    background: var(--bg-elevated);
+    opacity: 0.5;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .book-card-skeleton {
+      animation: skeleton-pulse 1.4s ease-in-out infinite;
+    }
+  }
+  @keyframes skeleton-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 0.7; }
   }
 
   .book-card-inner {

--- a/src/pages/browse.astro
+++ b/src/pages/browse.astro
@@ -1,31 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { getCollection } from 'astro:content';
 import BookGrid from '../components/BookGrid.svelte';
+import stats from '../data/stats.json';
 
 const base = import.meta.env.BASE_URL;
-const books = await getCollection('books');
-const categories = [...new Set(books.map(b => b.data.category))].sort();
-// Only pass fields needed by BookGrid to minimize client payload
-const bookData = books.map(b => ({
-  title: b.data.title,
-  author: b.data.author,
-  category: b.data.category,
-  priority: b.data.priority,
-  slug: b.data.slug,
-  cover_url: b.data.cover_url,
-  first_published: b.data.first_published,
-  reading_status: b.data.reading_status,
-  tags: b.data.tags,
-}));
-// Extract unique genre tags sorted by frequency
-const tagCounts = new Map<string, number>();
-bookData.forEach(b => b.tags?.forEach(t => tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1)));
-const allTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]).map(([t]) => t);
 ---
 
 <Layout title="Browse">
   <h1 class="heading-xl mb-2">Browse Books</h1>
-  <p class="text-muted text-sm mb-6">All {books.length.toLocaleString()} of them. Filters are your friend.</p>
-  <BookGrid client:load books={bookData} categories={categories} tags={allTags} baseUrl={base} />
+  <p class="text-muted text-sm mb-6">All {stats.total_books.toLocaleString()} of them. Filters are your friend.</p>
+  <BookGrid client:load baseUrl={base} />
 </Layout>


### PR DESCRIPTION
## What

Same pattern as the existing \`search-index.json\`: instead of inlining 3,644 books' worth of props into every render of \`/browse/\`, emit them once into a static \`public/browse-data.json\` and let \`BookGrid\` fetch on mount.

## Numbers (verified live)

| Metric | Before | After |
|---|---|---|
| /browse/ HTML payload | **1,931,559 bytes** | **157,513 bytes** (92% smaller) |
| DOM size, initial paint | 1,361 nodes | ~250 nodes |
| browse-data.json | — | 815 KB raw / ~150 KB gzipped (one-time, cached) |

The astro-island serialization format inflated the inline JSON by ~3.5× (HTML entity encoding + tagged-value wrapper). Moving to a fetched JSON file sidesteps that entirely and lets the browser cache it across navigations.

## How

- **\`scripts/generate-browse-data.py\`** (new) — emits \`public/browse-data.json\` with short field names \`{t,a,s,p,cat,co?,y?,rs?,g?}\` to keep wire size tight; null/empty fields omitted entirely (so 'no cover' costs zero bytes per book).
- Wired into \`prebuild\` after \`generate-search-index.py\`.
- **\`src/pages/browse.astro\`** renders just the page shell now; \`stats.json\` provides the \"3,644 books\" headline number.
- **\`BookGrid.svelte\`** fetches \`browse-data.json\` on mount, maps short keys back to the readable internal \`Book\` type, sets \`loaded\` state. Skeleton placeholders (animated, \`prefers-reduced-motion\` honored) render in the meantime. Error state if fetch fails.
- \`public/browse-data.json\` gitignored.

## Test plan
- [x] \`npm run typecheck\` — 0/0/0
- [x] \`npm test\` — 33/33
- [x] /chrome verification:
  - 100 cards render after fetch
  - Filter Literature → \"1,140 of 3,644 books\" still works
  - Clear-filters works
  - 0 broken images
  - axe-core (WCAG 2.1 AA): 0 violations

Closes #92. Part of epic #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)