### PR TITLE
feat(cache): persistent HTTP response cache for enrichment scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ data/enrichment-errors.jsonl
 public/search-index.json
 public/browse-data.json
 data/.~lock.*
+
+# HTTP response cache (per-developer, regenerable)
+data/http-cache.sqlite
+data/http-cache.sqlite-wal
+data/http-cache.sqlite-shm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Computed from existing metadata (no API calls):
 | **Enrichment state** | `scripts/enrichment_state.py` (+ `data/enrichment-state.json`) |
 | **Title matching** | `scripts/matching.py` |
 | **Additive JSON merge** | `scripts/json_merge.py` (never overwrites non-empty fields — see #90) |
+| **HTTP response cache** | `scripts/http_cache.py` + `data/http-cache.sqlite` (gitignored — see #91) |
 | **Enrichment runner** | `scripts/run-all-enrichments.py` |
 | **Data integrity tests** | `scripts/test_data_integrity.py` |
 | **CI workflow** | `.github/workflows/deploy.yml` |

--- a/scripts/enrich-authors.py
+++ b/scripts/enrich-authors.py
@@ -22,6 +22,7 @@ from urllib.error import URLError, HTTPError
 from urllib.parse import quote
 
 from json_merge import additive_merge, load_existing, save_json
+from http_cache import cached_fetch
 
 BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
 AUTHORS_DIR = Path(__file__).parent.parent / "src" / "content" / "authors"
@@ -83,7 +84,7 @@ def fetch_wikipedia(author_name: str) -> dict:
     # Try the name as-is first, then with underscores
     encoded = quote(author_name.replace(" ", "_"), safe="")
     url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{encoded}"
-    data = fetch_json(url)
+    data = cached_fetch("wikipedia", author_name, lambda: fetch_json(url), url=url)
 
     if not data or data.get("type") == "disambiguation":
         return result
@@ -136,7 +137,7 @@ def fetch_open_library(author_name: str) -> dict:
     result = {}
     encoded = quote(author_name, safe="")
     url = f"https://openlibrary.org/search/authors.json?q={encoded}"
-    data = fetch_json(url)
+    data = cached_fetch("open_library", author_name, lambda: fetch_json(url), url=url)
 
     if not data or not data.get("docs"):
         return result

--- a/scripts/enrichment_base.py
+++ b/scripts/enrichment_base.py
@@ -25,6 +25,7 @@ from urllib.request import urlopen, Request
 
 from enrichment_config import BOOKS_DIR, USER_AGENT, DEFAULT_TIMEOUT, RATE_LIMITS, ERROR_LOG
 from enrichment_state import EnrichmentState
+from http_cache import cached_fetch
 
 
 class EnrichmentScript(ABC):
@@ -62,8 +63,20 @@ class EnrichmentScript(ABC):
         """Filter to books missing the enrichment field."""
         return [(bp, b) for bp, b in books if not b.get(self.enrichment_field)]
 
-    def safe_request(self, url: str) -> dict | None:
-        """Make an HTTP request with error classification."""
+    def safe_request(self, url: str, *, cache_key: str | None = None) -> dict | None:
+        """Make an HTTP request with error classification.
+
+        Goes through the on-disk cache (data/http-cache.sqlite) keyed on
+        (source_name, cache_key). Caller may pass a logical cache_key (e.g.
+        an ISBN, OCLC id, or normalized title); falls back to the URL when
+        omitted, which is the conservative default for callers that haven't
+        been migrated yet.
+        """
+        key = cache_key if cache_key is not None else url
+        return cached_fetch(self.source_name, key, lambda: self._raw_request(url), url=url)
+
+    def _raw_request(self, url: str) -> dict | None:
+        """Underlying HTTP+JSON fetch. Same error semantics as before."""
         req = Request(url, headers={"User-Agent": USER_AGENT})
         try:
             with urlopen(req, timeout=DEFAULT_TIMEOUT) as resp:

--- a/scripts/http_cache.py
+++ b/scripts/http_cache.py
@@ -1,0 +1,234 @@
+"""HTTP response cache for enrichment scripts.
+
+Backs `data/http-cache.sqlite` with a single `responses` table keyed on
+(source, key). Callers think in logical keys ("Plato", ISBN, OCLC id) so
+URL-encoding drift doesn't cause cache misses for the same logical thing.
+
+Usage:
+    from http_cache import cached_fetch
+
+    def _fetch():
+        return safe_request(url)  # caller-supplied; may return None for 404
+
+    data = cached_fetch(
+        source="wikipedia",
+        key=author_name,
+        fetch=_fetch,
+        ttl=7 * 86400,           # optional, falls back to per-source default
+        negative_ttl=86400,      # optional, separate TTL for None / negatives
+    )
+
+Negative results (None) cache too, with their own shorter TTL — a 404
+today might be a name-spelling fix tomorrow.
+
+This module never imports urllib. Callers do their own HTTP. Keeps the
+cache module trivially testable with a fake `fetch` closure.
+"""
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+DEFAULT_DB_PATH = Path(__file__).parent.parent / "data" / "http-cache.sqlite"
+
+# Per-source TTL defaults, in seconds. Override per-call via `ttl=`.
+DEFAULT_TTLS = {
+    "wikipedia": 7 * 86400,        # bios change, but slowly
+    "open_library": 30 * 86400,    # pretty stable
+    "google_books": 30 * 86400,
+    "gutenberg": 365 * 86400,      # public-domain catalog ~never changes
+    "librivox": 30 * 86400,
+    "hathitrust": 30 * 86400,
+}
+DEFAULT_FALLBACK_TTL = 7 * 86400
+DEFAULT_NEGATIVE_TTL = 86400  # 24h — 404s should retry sooner than hits
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS responses (
+  source        TEXT NOT NULL,
+  key           TEXT NOT NULL,
+  url           TEXT,
+  status        INTEGER NOT NULL,
+  body          BLOB,
+  etag          TEXT,
+  last_modified TEXT,
+  fetched_at    INTEGER NOT NULL,
+  expires_at    INTEGER NOT NULL,
+  PRIMARY KEY (source, key)
+);
+CREATE INDEX IF NOT EXISTS idx_expires ON responses(expires_at);
+"""
+
+
+class Cache:
+    """SQLite-backed cache. Use as a context manager or call .close() yourself."""
+
+    def __init__(self, db_path: Path | str = DEFAULT_DB_PATH):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(self.db_path))
+        # WAL allows concurrent reads while a write is in flight — useful when
+        # multiple enrichment scripts run in parallel.
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.executescript(_SCHEMA)
+        self.conn.commit()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def get(self, source: str, key: str, *, now: Optional[int] = None) -> tuple[bool, Any]:
+        """Return (hit, value). value is the cached payload (None for negative).
+
+        Returns (False, None) on miss or expiry. Caller must distinguish hit-with-None
+        from miss using the `hit` boolean.
+        """
+        now = now if now is not None else int(time.time())
+        row = self.conn.execute(
+            "SELECT body, expires_at FROM responses WHERE source=? AND key=?",
+            (source, key),
+        ).fetchone()
+        if row is None:
+            return False, None
+        body, expires_at = row
+        if expires_at != 0 and expires_at <= now:
+            return False, None
+        if body is None:
+            return True, None  # cached negative
+        return True, json.loads(body.decode("utf-8"))
+
+    def put(
+        self,
+        source: str,
+        key: str,
+        value: Any,
+        *,
+        ttl: int,
+        url: Optional[str] = None,
+        status: int = 200,
+        etag: Optional[str] = None,
+        last_modified: Optional[str] = None,
+        now: Optional[int] = None,
+    ) -> None:
+        now = now if now is not None else int(time.time())
+        body = None if value is None else json.dumps(value, ensure_ascii=False).encode("utf-8")
+        # ttl=0 is the sentinel for "never expires". Any other value (positive,
+        # zero-relative, or negative) produces a real expires_at — negatives are
+        # useful in tests to seed pre-expired rows.
+        expires_at = 0 if ttl == 0 else now + ttl
+        self.conn.execute(
+            """
+            INSERT INTO responses (source, key, url, status, body, etag, last_modified, fetched_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source, key) DO UPDATE SET
+              url=excluded.url, status=excluded.status, body=excluded.body,
+              etag=excluded.etag, last_modified=excluded.last_modified,
+              fetched_at=excluded.fetched_at, expires_at=excluded.expires_at
+            """,
+            (source, key, url, status, body, etag, last_modified, now, expires_at),
+        )
+        self.conn.commit()
+
+    def invalidate(self, source: str, key: Optional[str] = None) -> int:
+        """Drop one row, or every row for a source if key is None. Returns rows deleted."""
+        if key is None:
+            cur = self.conn.execute("DELETE FROM responses WHERE source=?", (source,))
+        else:
+            cur = self.conn.execute(
+                "DELETE FROM responses WHERE source=? AND key=?", (source, key)
+            )
+        self.conn.commit()
+        return cur.rowcount
+
+    def purge_expired(self, *, now: Optional[int] = None) -> int:
+        """Remove rows past expiry. Returns rows deleted."""
+        now = now if now is not None else int(time.time())
+        cur = self.conn.execute(
+            "DELETE FROM responses WHERE expires_at != 0 AND expires_at <= ?", (now,)
+        )
+        self.conn.commit()
+        return cur.rowcount
+
+    def stats(self) -> dict:
+        """Return per-source row counts. Useful for runner status output."""
+        rows = self.conn.execute(
+            "SELECT source, COUNT(*) FROM responses GROUP BY source ORDER BY source"
+        ).fetchall()
+        total = self.conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
+        return {"total": total, "by_source": {s: c for s, c in rows}}
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience: a default singleton + cached_fetch().
+# ---------------------------------------------------------------------------
+
+_default_cache: Optional[Cache] = None
+
+
+def _get_default_cache() -> Cache:
+    global _default_cache
+    if _default_cache is None:
+        _default_cache = Cache()
+    return _default_cache
+
+
+def reset_default_cache(db_path: Path | str = DEFAULT_DB_PATH) -> Cache:
+    """Drop the singleton and rebuild it (useful in tests)."""
+    global _default_cache
+    if _default_cache is not None:
+        _default_cache.close()
+    _default_cache = Cache(db_path)
+    return _default_cache
+
+
+def cached_fetch(
+    source: str,
+    key: str,
+    fetch: Callable[[], Any],
+    *,
+    ttl: Optional[int] = None,
+    negative_ttl: Optional[int] = None,
+    cache: Optional[Cache] = None,
+    url: Optional[str] = None,
+) -> Any:
+    """Look up (source, key); on miss, call `fetch()` and store the result.
+
+    `fetch` returns the parsed payload (e.g. dict from JSON), or None to
+    indicate "no result" (404, search returned nothing). Both kinds of
+    answers cache, with separate TTLs.
+    """
+    c = cache if cache is not None else _get_default_cache()
+    hit, value = c.get(source, key)
+    if hit:
+        return value
+
+    value = fetch()
+
+    if value is None:
+        eff_ttl = negative_ttl if negative_ttl is not None else DEFAULT_NEGATIVE_TTL
+    else:
+        eff_ttl = ttl if ttl is not None else DEFAULT_TTLS.get(source, DEFAULT_FALLBACK_TTL)
+
+    c.put(source, key, value, ttl=eff_ttl, url=url)
+    return value
+
+
+def invalidate(source: str, key: Optional[str] = None) -> int:
+    return _get_default_cache().invalidate(source, key)
+
+
+def purge_expired() -> int:
+    return _get_default_cache().purge_expired()
+
+
+def stats() -> dict:
+    return _get_default_cache().stats()

--- a/scripts/test_http_cache.py
+++ b/scripts/test_http_cache.py
@@ -1,0 +1,154 @@
+"""Tests for http_cache. Uses tmp_path for the SQLite DB and a fake fetch
+closure (no urllib mocking) — the whole point of the closure API."""
+
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from http_cache import Cache, cached_fetch, DEFAULT_NEGATIVE_TTL
+
+
+@pytest.fixture
+def cache(tmp_path):
+    """Fresh Cache backed by a per-test SQLite file."""
+    c = Cache(tmp_path / "cache.sqlite")
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def counting_fetch():
+    """A fake fetch closure that records call count and returns programmable values."""
+
+    class Counter:
+        calls = 0
+        next_value = {"answer": 42}
+
+        def __call__(self):
+            self.calls += 1
+            return self.next_value
+
+    return Counter()
+
+
+class TestHitMiss:
+    def test_miss_calls_fetch_and_caches(self, cache, counting_fetch):
+        result = cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        assert result == {"answer": 42}
+        assert counting_fetch.calls == 1
+
+    def test_hit_does_not_call_fetch_again(self, cache, counting_fetch):
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        assert counting_fetch.calls == 1
+
+    def test_per_source_isolation(self, cache, counting_fetch):
+        """Same key under two sources doesn't collide."""
+        counting_fetch.next_value = {"src": "wiki"}
+        a = cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        counting_fetch.next_value = {"src": "open_library"}
+        b = cached_fetch("open_library", "Plato", counting_fetch, cache=cache)
+        assert a == {"src": "wiki"}
+        assert b == {"src": "open_library"}
+        assert counting_fetch.calls == 2
+
+
+class TestExpiry:
+    def test_expired_row_triggers_refetch(self, cache):
+        """Manually insert a row in the past and assert next call refetches."""
+        # Seed an expired row
+        past = int(time.time()) - 100
+        cache.put("wikipedia", "Plato", {"old": True}, ttl=-1, now=past)
+        # Sanity: row exists but is past-expiry
+        hit, _ = cache.get("wikipedia", "Plato")
+        assert not hit
+
+        calls = []
+
+        def fetch():
+            calls.append(1)
+            return {"new": True}
+
+        result = cached_fetch("wikipedia", "Plato", fetch, cache=cache)
+        assert result == {"new": True}
+        assert len(calls) == 1
+
+
+class TestNegativeCache:
+    def test_none_caches_with_negative_ttl(self, cache):
+        calls = []
+
+        def fetch():
+            calls.append(1)
+            return None  # 404 / search returned nothing
+
+        cached_fetch("wikipedia", "ZZZ Nonexistent", fetch, cache=cache)
+        cached_fetch("wikipedia", "ZZZ Nonexistent", fetch, cache=cache)
+        assert len(calls) == 1  # Second call hit the negative cache
+
+    def test_distinguishes_negative_hit_from_miss(self, cache):
+        """A cached None must be a HIT (returns None without calling fetch),
+        not a MISS that re-runs the fetch."""
+        cache.put("wikipedia", "Plato", None, ttl=DEFAULT_NEGATIVE_TTL)
+        hit, value = cache.get("wikipedia", "Plato")
+        assert hit is True
+        assert value is None
+
+
+class TestInvalidation:
+    def test_invalidate_one_row(self, cache, counting_fetch):
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        cache.invalidate("wikipedia", "Plato")
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        assert counting_fetch.calls == 2
+
+    def test_invalidate_whole_source(self, cache, counting_fetch):
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        cached_fetch("wikipedia", "Aristotle", counting_fetch, cache=cache)
+        n = cache.invalidate("wikipedia")
+        assert n == 2
+
+    def test_invalidate_returns_zero_for_missing(self, cache):
+        assert cache.invalidate("wikipedia", "DoesNotExist") == 0
+
+
+class TestPurge:
+    def test_purge_expired_clears_only_expired(self, cache):
+        now = int(time.time())
+        cache.put("wikipedia", "expired", {"x": 1}, ttl=-100, now=now)
+        cache.put("wikipedia", "fresh", {"x": 2}, ttl=86400, now=now)
+        n = cache.purge_expired(now=now)
+        assert n == 1
+        # Fresh row still readable
+        hit, val = cache.get("wikipedia", "fresh")
+        assert hit and val == {"x": 2}
+
+
+class TestStats:
+    def test_stats_reports_per_source_counts(self, cache, counting_fetch):
+        cached_fetch("wikipedia", "Plato", counting_fetch, cache=cache)
+        cached_fetch("wikipedia", "Aristotle", counting_fetch, cache=cache)
+        cached_fetch("open_library", "Plato", counting_fetch, cache=cache)
+        s = cache.stats()
+        assert s["total"] == 3
+        assert s["by_source"] == {"open_library": 1, "wikipedia": 2}
+
+
+class TestPersistence:
+    def test_data_survives_reopen(self, tmp_path):
+        """Cache file persists across process-equivalent restarts."""
+        path = tmp_path / "persist.sqlite"
+        c1 = Cache(path)
+        c1.put("wikipedia", "Plato", {"survives": True}, ttl=86400)
+        c1.close()
+
+        c2 = Cache(path)
+        try:
+            hit, val = c2.get("wikipedia", "Plato")
+            assert hit and val == {"survives": True}
+        finally:
+            c2.close()


### PR DESCRIPTION
## What

Every enrichment run hit upstream APIs live, with \`time.sleep(1)\` as the only throttle. Wikipedia has been rate-limiting us recently. This ships a SQLite-backed cache so repeated runs don't re-fetch what hasn't changed.

## How

### \`scripts/http_cache.py\` (new)

- **Backing**: SQLite at \`data/http-cache.sqlite\` (gitignored). WAL journal so parallel enrichers don't lock each other.
- **Key design**: \`(source, key)\` not \`(url)\`. Callers think in logical keys (\"Plato\", ISBN, OCLC) — URL-encoding drift never causes a cache miss for the same logical thing.
- **Per-source TTLs** with sensible defaults (Wikipedia 7d, Open Library 30d, Gutenberg 365d), overridable per call.
- **Negative caching**: \`None\` answers (404, search returned nothing) cache too, with their own shorter TTL (24h default) — a 404 today might be a name-spelling fix tomorrow.
- **Public API**:
  \`\`\`python
  from http_cache import cached_fetch
  data = cached_fetch(\"wikipedia\", author_name, lambda: fetch_json(url), url=url)
  \`\`\`
  Caller passes \`fetch\` as a closure, so the cache module never touches urllib — trivially testable with a fake fetch.
- ETag / Last-Modified columns provisioned in the schema for a future conditional-GET layer; not wired in v1.

### Wired into the existing pipeline

- \`enrichment_base.safe_request(url)\` now routes through the cache. **Six existing subclasses get caching for free** with no behavior change. Callers can pass a logical \`cache_key=\` to get hits across URL-encoding variations.
- \`enrich-authors.py\`'s two upstream calls (\`fetch_wikipedia\`, \`fetch_open_library\`) now go through \`cached_fetch\` keyed on the author name. Combined with the additive-merge guard from #90, re-running the whole script after a 24h cooldown costs **zero API calls** for any author already cached, and **zero data loss** for any author previously enriched.

### Tests

\`scripts/test_http_cache.py\` — 12 tests covering: hit/miss, per-source isolation, expiry, negative cache, invalidation, purge, stats, on-disk persistence across reopens. Uses \`tmp_path\` for the DB and a counting fake-fetch closure (no urllib mocking — that's the whole point of the closure API).

## GitHub Pages compatibility

Cache is **build-time only**. The CI deploy workflow only runs typecheck + tests + Astro build, none of which touch \`http-cache.sqlite\`. The cache lives per-developer in their local clone, gitignored. If/when a scheduled enrichment workflow is added, \`actions/cache@v4\` keyed monotonically would persist it across CI runs — but that's a separate decision.

## Test plan
- [x] \`npm run typecheck\` — 0/0/0
- [x] \`npm test\` — 33/33
- [x] \`pytest scripts/\` — **78/78** (was 66; +12 cache tests)
- [x] \`enrich-authors.py --help\` parses cleanly with new imports
- [x] \`enrichment_base.py\` imports cleanly with cache wired in
- [x] CLAUDE.md updated with the new canonical path

Closes #91. Part of epic #96. Unblocks #93 and #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)