### PR TITLE
fix(categories): top-60 + paginated overflow — Literature 3.5 MB → 187 KB

### DIFF
--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -3,7 +3,10 @@ import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import { priorityLabel, priorityBadgeClass, toSlug, pluralize, thumbnailUrl } from '../../utils/formatting';
 
+// Astro hoists getStaticPaths into an isolated scope — module-level consts aren't visible inside.
+// Keep the limit inside getStaticPaths and surface it via props for the template.
 export async function getStaticPaths() {
+  const TOP_LIMIT = 60;
   const books = await getCollection('books');
   const categoryMap = new Map<string, { name: string; books: typeof books }>();
 
@@ -16,20 +19,27 @@ export async function getStaticPaths() {
     categoryMap.get(slug)!.books.push(book);
   }
 
-  return [...categoryMap.entries()].map(([slug, { name, books }]) => ({
-    params: { slug },
-    props: {
-      categoryName: name,
-      books: books.sort((a, b) => a.data.priority - b.data.priority || a.data.title.localeCompare(b.data.title)),
-    },
-  }));
+  return [...categoryMap.entries()].map(([slug, { name, books }]) => {
+    const sorted = books.sort((a, b) => a.data.priority - b.data.priority || a.data.title.localeCompare(b.data.title));
+    return {
+      params: { slug },
+      props: {
+        categoryName: name,
+        topBooks: sorted.slice(0, TOP_LIMIT),
+        totalCount: sorted.length,
+        topLimit: TOP_LIMIT,
+      },
+    };
+  });
 }
 
-const { categoryName, books } = Astro.props;
+const { categoryName, topBooks, totalCount, topLimit } = Astro.props;
 const base = import.meta.env.BASE_URL;
+const slug = Astro.params.slug;
+const hasOverflow = totalCount > topLimit;
 ---
 
-<Layout title={categoryName} description={`${books.length} ${categoryName} books in the tsundoku collection`}>
+<Layout title={categoryName} description={`${totalCount} ${categoryName} books in the tsundoku collection`}>
   <nav class="breadcrumb">
     <a href={`${base}`}>Home</a>
     <span class="breadcrumb-sep">/</span>
@@ -39,10 +49,15 @@ const base = import.meta.env.BASE_URL;
   </nav>
 
   <h1 class="heading-xl mb-2">{categoryName}</h1>
-  <p class="text-muted text-sm mb-8">{books.length} {pluralize(books.length, 'book')}</p>
+  <p class="text-muted text-sm mb-8">
+    {totalCount.toLocaleString()} {pluralize(totalCount, 'book')}{hasOverflow && (
+      <> · showing top {topLimit}
+      </>
+    )}
+  </p>
 
   <div class="grid sm-grid-2 lg-grid-4 gap-3">
-    {books.map(book => (
+    {topBooks.map(book => (
       <a href={`${base}books/${book.data.slug}/`} class="card book-cover-group book-card-compact">
         {book.data.cover_url ? (
           <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" transition:name={`cover-${book.data.slug}`} />
@@ -68,4 +83,12 @@ const base = import.meta.env.BASE_URL;
       </a>
     ))}
   </div>
+
+  {hasOverflow && (
+    <div class="mt-2 text-center">
+      <a href={`${base}categories/${slug}/all/`} class="btn btn-outline">
+        View all {totalCount.toLocaleString()} {pluralize(totalCount, 'book')} →
+      </a>
+    </div>
+  )}
 </Layout>

--- a/src/pages/categories/[slug]/all/[...page].astro
+++ b/src/pages/categories/[slug]/all/[...page].astro
@@ -1,0 +1,134 @@
+---
+import Layout from '../../../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { priorityLabel, priorityBadgeClass, toSlug, thumbnailUrl } from '../../../../utils/formatting';
+import type { GetStaticPathsOptions } from 'astro';
+
+const PAGE_SIZE = 100;
+
+export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
+  // Mirror the limit in [slug].astro — only categories above this threshold get paginated /all/ pages.
+  const TOP_LIMIT = 60;
+  const PAGE_SIZE_LOCAL = 100;
+  const books = await getCollection('books');
+  const categoryMap = new Map<string, { name: string; books: typeof books }>();
+
+  for (const book of books) {
+    const cat = book.data.category;
+    const slug = toSlug(cat);
+    if (!categoryMap.has(slug)) {
+      categoryMap.set(slug, { name: cat, books: [] });
+    }
+    categoryMap.get(slug)!.books.push(book);
+  }
+
+  // Only generate /all/ pages for categories with overflow.
+  return [...categoryMap.entries()]
+    .filter(([_slug, { books }]) => books.length > TOP_LIMIT)
+    .flatMap(([slug, { name, books }]) => {
+      const sorted = books.sort(
+        (a, b) => a.data.priority - b.data.priority || a.data.title.localeCompare(b.data.title)
+      );
+      return paginate(sorted, {
+        params: { slug },
+        props: { categoryName: name },
+        pageSize: PAGE_SIZE_LOCAL,
+      });
+    });
+}
+
+const { page } = Astro.props;
+const { categoryName } = Astro.props as { categoryName: string };
+const base = import.meta.env.BASE_URL;
+const slug = Astro.params.slug;
+
+const startIdx = (page.currentPage - 1) * PAGE_SIZE + 1;
+const endIdx = Math.min(page.currentPage * PAGE_SIZE, page.total);
+---
+
+<Layout
+  title={`${categoryName} — All books, page ${page.currentPage} of ${page.lastPage}`}
+  description={`All ${page.total} ${categoryName} books, page ${page.currentPage} of ${page.lastPage}`}
+>
+  <nav class="breadcrumb">
+    <a href={`${base}`}>Home</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}categories/`}>Categories</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}categories/${slug}/`}>{categoryName}</a>
+    <span class="breadcrumb-sep">/</span>
+    <span class="breadcrumb-current">All books · page {page.currentPage}</span>
+  </nav>
+
+  <h1 class="heading-xl mb-2">All {categoryName} Books</h1>
+  <p class="text-muted text-sm mb-8">
+    Books {startIdx.toLocaleString()}–{endIdx.toLocaleString()} of {page.total.toLocaleString()} · page {page.currentPage} of {page.lastPage}
+  </p>
+
+  {page.lastPage > 1 && (
+    <nav aria-label="Pagination" class="pagination-nav mb-6">
+      {page.url.prev ? (
+        <a href={page.url.prev} class="btn btn-outline" rel="prev">← Prev</a>
+      ) : (
+        <span class="btn btn-outline pagination-disabled" aria-disabled="true">← Prev</span>
+      )}
+      <span class="pagination-pages">
+        Page {page.currentPage} of {page.lastPage}
+      </span>
+      {page.url.next ? (
+        <a href={page.url.next} class="btn btn-outline" rel="next">Next →</a>
+      ) : (
+        <span class="btn btn-outline pagination-disabled" aria-disabled="true">Next →</span>
+      )}
+    </nav>
+  )}
+
+  <div class="grid sm-grid-2 lg-grid-4 gap-3">
+    {page.data.map(book => (
+      <a href={`${base}books/${book.data.slug}/`} class="card book-cover-group book-card-compact">
+        {book.data.cover_url ? (
+          <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" transition:name={`cover-${book.data.slug}`} />
+        ) : (
+          <div class="book-thumb-placeholder" aria-hidden="true">
+            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+            </svg>
+          </div>
+        )}
+        <div class="book-card-body">
+          <div class="flex items-center justify-between gap-1 mb-2">
+            <span class={priorityBadgeClass(book.data.priority)}>
+              {priorityLabel(book.data.priority)}
+            </span>
+            {book.data.first_published && (
+              <span class="text-xs text-dim">{book.data.first_published}</span>
+            )}
+          </div>
+          <h3 class="text-sm font-bold line-clamp-2 mb-1">{book.data.title}</h3>
+          <p class="text-xs text-dim truncate">{book.data.author}</p>
+        </div>
+      </a>
+    ))}
+  </div>
+
+  {page.lastPage > 1 && (
+    <nav aria-label="Pagination" class="pagination-nav mt-6">
+      {page.url.prev ? (
+        <a href={page.url.prev} class="btn btn-outline" rel="prev">← Prev</a>
+      ) : (
+        <span class="btn btn-outline pagination-disabled" aria-disabled="true">← Prev</span>
+      )}
+      <span class="pagination-pages">
+        Page {page.currentPage} of {page.lastPage}
+      </span>
+      {page.url.next ? (
+        <a href={page.url.next} class="btn btn-outline" rel="next">Next →</a>
+      ) : (
+        <span class="btn btn-outline pagination-disabled" aria-disabled="true">Next →</span>
+      )}
+    </nav>
+  )}
+
+  <hr class="section-divider" />
+  <a href={`${base}categories/${slug}/`} class="ext-link text-sm">← Back to {categoryName}</a>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -634,6 +634,25 @@ a:hover { color: var(--pop-pink); }
   background: var(--bg-elevated);
 }
 
+/* ===== Pagination Nav (category overflow pages) ===== */
+.pagination-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.pagination-pages {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.pagination-disabled {
+  opacity: 0.4;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 /* ===== Letter Tiles (authors index landing) ===== */
 .letter-tile-grid {
   display: grid;


### PR DESCRIPTION
## What

Category detail pages rendered every book in a single static page — fine for the 25 categories under 60 books, but cripplingly heavy for the long tail. **Literature alone shipped 3.5 MB / 1,140 cards / 1,117 \`<img>\` tags.**

Per the recommendation in #100, this slices each detail page to top-60 (must-reads first, then alphabetical), and routes the rest through a new paginated overflow tree.

## How

### \`src/pages/categories/[slug].astro\`

Now renders only the top 60. Sort key: \`priority\` ascending (must-reads first), then title alphabetical. Categories with > 60 books get a \"View all *N* books →\" button. Smaller categories don't see a link — pure no-op for them.

### \`src/pages/categories/[slug]/all/[...page].astro\` (new)

Uses Astro's \`paginate()\` helper. Astro's \`[...page]\` convention puts page 1 at the bare \`/all/\` URL (no number), then \`/all/2/\`, \`/all/3/\`, etc. \`pageSize: 100\`. Pagination strip (\`← Prev\` / \`Page N of M\` / \`Next →\`) at top *and* bottom, with a disabled visual state at endpoints (\`aria-disabled=\"true\"\`).

Generated only for categories above the threshold — the 11 oversized categories (Literature, Fantasy, Mystery, History, Computer Science, Drama, Classics, Horror, Economics, Mathematics, Non-Western Literature) get \`/all/\` pages; the 19 smaller ones don't add any new routes.

### Astro gotcha

\`getStaticPaths\` runs in an *isolated scope* — module-level \`const\`s are not visible inside. Worth a comment in the file. \`TOP_LIMIT\` had to live inside the function and be surfaced to the template via props.

## Numbers (verified live in local preview)

| Page | Before | After |
|---|---|---|
| /categories/literature/ | 3,498,548 bytes | **186,672 bytes (95% smaller)** |
| /categories/literature/all/ | — | 304,288 bytes (page 1 of 12; books 1–100) |
| /categories/biography-memoir/ | 61,325 bytes (15 books) | unchanged — no overflow link rendered |
| Pages built | 5,379 | 5,417 (+38 paginated pages across 11 categories) |

## Test plan
- [x] \`npm run typecheck\` — 0/0/0
- [x] \`npm test\` — 33/33
- [x] \`pytest scripts/\` — 78/78
- [x] /chrome verification:
  - /categories/literature/ shows 60 cards, \"1,140 books · showing top 60\", view-all link present
  - /categories/literature/all/ shows 100 cards, \"Books 1–100 of 1,140 · page 1 of 12\", PREV disabled, NEXT enabled
  - /categories/literature/all/3/ shows 100 cards, both PREV and NEXT enabled, breadcrumb \"All books · page 3\"
  - /categories/biography-memoir/ shows 15 cards, no view-all link (smaller than threshold)
  - axe-core (WCAG 2.1 AA) on /all/: 0 violations

Closes #100. Part of epic #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)