### PR TITLE
feat(cache-photos): local Wikimedia photo & cover cache + CI persistence

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,8 +62,35 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Restore the photo / cover cache from the previous successful run so we
+      # don't re-download every Wikimedia thumb on every build. See #94.
+      - name: Restore photo cache
+        id: photo-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: public/cached
+          key: photo-cache-v1-${{ github.run_id }}
+          restore-keys: |
+            photo-cache-v1-
+
+      - name: Download missing photos
+        run: python3 scripts/cache-photos.py
+        # cache-photos.py is fault-tolerant — failures leave upstream URLs in
+        # place, and the runtime broken-image fallback handles any that 404.
+        continue-on-error: true
+
       - name: Build Astro site
         run: npm run build
+
+      # Save the (possibly enlarged) cache for the next run. Splitting restore
+      # and save lets us "always save" — the default cache action only saves on
+      # cache miss for the exact key.
+      - name: Save photo cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: public/cached
+          key: photo-cache-v1-${{ github.run_id }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ data/.~lock.*
 data/http-cache.sqlite
 data/http-cache.sqlite-wal
 data/http-cache.sqlite-shm
+
+# Photo / cover cache (build-time download; persisted across CI runs via actions/cache)
+public/cached/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,8 @@ Computed from existing metadata (no API calls):
 | **Title matching** | `scripts/matching.py` |
 | **Additive JSON merge** | `scripts/json_merge.py` (never overwrites non-empty fields — see #90) |
 | **HTTP response cache** | `scripts/http_cache.py` + `data/http-cache.sqlite` (gitignored — see #91) |
+| **Photo / cover cache** | `scripts/cache-photos.py` + `public/cached/` (gitignored — see #94) |
+| **HTTP response cache** | `scripts/http_cache.py` + `data/http-cache.sqlite` (gitignored — see #91) |
 | **Enrichment runner** | `scripts/run-all-enrichments.py` |
 | **Data integrity tests** | `scripts/test_data_integrity.py` |
 | **CI workflow** | `.github/workflows/deploy.yml` |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,15 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 | `enrichment_config.py` | Centralized rate limits, API URLs, timeouts |
 | `enrichment_state.py` | State tracking — resume, daily resets, completion detection |
 | `matching.py` | Shared title/author matching logic (word overlap, article stripping) |
+| `json_merge.py` | Additive JSON merge — never overwrites non-empty fields (issue #90) |
+| `http_cache.py` | SQLite-backed HTTP response cache; per-source TTLs + negative caching (issue #91) |
+
+## Maintenance
+
+| Script | Purpose |
+|---|---|
+| `validate-photo-urls.py` | HEAD-probe `photo_url` / `cover_url` and clear confirmed-dead ones (issue #93). Default is dry-run; pass `--apply` to actually clear. |
+| `cache-photos.py` | Download author photos / book covers to `public/cached/` and rewrite source JSON URLs to local paths. Originals preserved in `*_source` fields (issue #94). |
 
 ## Tests
 
@@ -58,6 +67,10 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 |---|---|
 | `test_matching.py` | 27 tests for title similarity, slug generation, author matching |
 | `test_enrichment.py` | 8 tests for state tracking, config validation |
+| `test_json_merge.py` | 18 tests for additive merge invariants |
+| `test_http_cache.py` | 12 tests for hit/miss/expire/negative-cache/persistence |
+| `test_validate_photo_urls.py` | 7 tests for HEAD-probe classification + apply mode |
+| `test_cache_photos.py` | 19 tests for content-type → ext, idempotency, JSON rewrite |
 
 ## Usage
 

--- a/scripts/cache-photos.py
+++ b/scripts/cache-photos.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Download author photos and book covers to public/cached/ for resilience.
+
+After this script:
+  - public/cached/authors/{slug}.{ext}  — local copy of each author photo
+  - public/cached/covers/{slug}.{ext}   — local copy of each book cover
+  - Source JSON's photo_url / cover_url / cover_url_large rewritten to
+    local relative paths (e.g. "/tsundoku/cached/authors/plato.jpg")
+  - Original upstream URLs preserved in photo_url_source / cover_url_source
+
+If a download fails (404, network error), the original upstream URL is
+LEFT IN PLACE — never blanked, never broken-by-this-script. Combined
+with the runtime broken-image fallback in Layout.astro, the site is
+"belt + suspenders" resilient to upstream rot.
+
+Usage:
+  python scripts/cache-photos.py                   # download all
+  python scripts/cache-photos.py --target authors  # only authors
+  python scripts/cache-photos.py --target books    # only books
+  python scripts/cache-photos.py --limit 50        # sample
+  python scripts/cache-photos.py --dry-run         # plan only, no writes
+
+CI integration: this script runs in the prebuild step between content
+sync and astro build. The public/cached/ directory is gitignored —
+actions/cache@v4 persists it across CI runs.
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen, Request
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from enrichment_config import AUTHORS_DIR, BOOKS_DIR, USER_AGENT
+from json_merge import save_json
+
+
+REPO_ROOT = Path(__file__).parent.parent
+PUBLIC_CACHED = REPO_ROOT / "public" / "cached"
+ASTRO_BASE = "/tsundoku/"  # matches astro.config.mjs base — keep in sync
+
+DOWNLOAD_TIMEOUT = 30  # seconds — covers can be a few hundred KB
+SKIP_IF_NEWER_THAN_DAYS = 90  # don't re-download files newer than this
+
+# Map of Content-Type → file extension
+CONTENT_TYPE_EXT = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "image/svg+xml": "svg",
+}
+
+
+def is_already_local(url: str) -> bool:
+    """True if the URL is already pointing into our local cache."""
+    return url.startswith(ASTRO_BASE + "cached/") or url.startswith("/cached/")
+
+
+def ext_from_response(content_type: str | None, url: str) -> str:
+    """Pick a file extension from Content-Type header, falling back to URL suffix."""
+    if content_type:
+        primary = content_type.split(";")[0].strip().lower()
+        if primary in CONTENT_TYPE_EXT:
+            return CONTENT_TYPE_EXT[primary]
+    # Fall back to last URL segment
+    last_segment = url.rsplit("/", 1)[-1]
+    if "." in last_segment:
+        suffix = last_segment.rsplit(".", 1)[-1].lower()
+        if suffix in {"jpg", "jpeg", "png", "webp", "gif", "svg"}:
+            return "jpg" if suffix == "jpeg" else suffix
+    return "jpg"  # safe default
+
+
+def download(url: str) -> tuple[bytes, str] | None:
+    """Fetch image bytes + extension, or None on failure."""
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urlopen(req, timeout=DOWNLOAD_TIMEOUT) as resp:
+            data = resp.read()
+            ext = ext_from_response(resp.headers.get("Content-Type"), url)
+            return data, ext
+    except (HTTPError, URLError, TimeoutError, OSError):
+        return None
+
+
+def cache_one(
+    *,
+    url: str,
+    out_dir: Path,
+    slug: str,
+    rate_limit_s: float,
+) -> tuple[str, str] | None:
+    """Download `url` into `out_dir/{slug}.{ext}`. Returns (local_url, ext) or None."""
+    if is_already_local(url):
+        # Idempotency: if JSON already points local, no work needed.
+        return None
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Skip if a recent local file already exists for this slug.
+    for existing in out_dir.glob(f"{slug}.*"):
+        age_days = (time.time() - existing.stat().st_mtime) / 86400
+        if age_days < SKIP_IF_NEWER_THAN_DAYS:
+            ext = existing.suffix.lstrip(".")
+            return f"{ASTRO_BASE}cached/{out_dir.name}/{slug}.{ext}", ext
+
+    result = download(url)
+    if rate_limit_s:
+        time.sleep(rate_limit_s)
+    if result is None:
+        return None
+
+    data, ext = result
+    target = out_dir / f"{slug}.{ext}"
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_bytes(data)
+    tmp.replace(target)
+    return f"{ASTRO_BASE}cached/{out_dir.name}/{slug}.{ext}", ext
+
+
+def process_authors(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
+    """Walk every author file, download photo if needed, rewrite JSON."""
+    out_dir = PUBLIC_CACHED / "authors"
+    counts = {"total": 0, "cached_already": 0, "downloaded": 0, "failed": 0, "skipped": 0}
+
+    for path in sorted(AUTHORS_DIR.glob("*.json")):
+        if limit and counts["total"] >= limit:
+            break
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        url = doc.get("photo_url")
+        if not url:
+            continue
+        counts["total"] += 1
+
+        if is_already_local(url):
+            counts["cached_already"] += 1
+            continue
+
+        slug = doc.get("slug") or path.stem
+
+        if dry_run:
+            print(f"  WOULD CACHE {slug}: {url[:80]}")
+            counts["downloaded"] += 1
+            continue
+
+        result = cache_one(url=url, out_dir=out_dir, slug=slug, rate_limit_s=rate_limit_s)
+        if result is None:
+            counts["failed"] += 1
+            print(f"  FAIL {slug}: {url[:80]}")
+            continue
+
+        local_url, _ext = result
+        # Preserve upstream attribution when first caching this record.
+        if not doc.get("photo_url_source"):
+            doc["photo_url_source"] = url
+        doc["photo_url"] = local_url
+        doc["photo_cached_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        save_json(path, doc)
+        counts["downloaded"] += 1
+        print(f"  ✓ {slug} → {local_url}")
+
+    return counts
+
+
+def process_books(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
+    """Walk every book file, download cover if needed, rewrite JSON.
+
+    cover_url and cover_url_large can both exist; cover_url_large is preferred
+    when present. We cache only one (the larger), and rewrite both fields to
+    point to the same local URL — saving disk and bandwidth.
+    """
+    out_dir = PUBLIC_CACHED / "covers"
+    counts = {"total": 0, "cached_already": 0, "downloaded": 0, "failed": 0, "skipped": 0}
+
+    for path in sorted(BOOKS_DIR.glob("*.json")):
+        if limit and counts["total"] >= limit:
+            break
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        # Prefer the largest-resolution upstream URL.
+        url = doc.get("cover_url_large") or doc.get("cover_url")
+        if not url:
+            continue
+        counts["total"] += 1
+
+        if is_already_local(url):
+            counts["cached_already"] += 1
+            continue
+
+        slug = doc.get("slug") or path.stem
+
+        if dry_run:
+            print(f"  WOULD CACHE {slug}: {url[:80]}")
+            counts["downloaded"] += 1
+            continue
+
+        result = cache_one(url=url, out_dir=out_dir, slug=slug, rate_limit_s=rate_limit_s)
+        if result is None:
+            counts["failed"] += 1
+            print(f"  FAIL {slug}: {url[:80]}")
+            continue
+
+        local_url, _ext = result
+        if doc.get("cover_url") and not doc.get("cover_url_source") and not is_already_local(doc["cover_url"]):
+            doc["cover_url_source"] = doc["cover_url"]
+        if doc.get("cover_url_large") and not doc.get("cover_url_large_source") and not is_already_local(doc["cover_url_large"]):
+            doc["cover_url_large_source"] = doc["cover_url_large"]
+        # Both small and large now point to the same local file — Astro serves it once.
+        if "cover_url" in doc:
+            doc["cover_url"] = local_url
+        if "cover_url_large" in doc:
+            doc["cover_url_large"] = local_url
+        doc["cover_cached_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        save_json(path, doc)
+        counts["downloaded"] += 1
+        print(f"  ✓ {slug} → {local_url}")
+
+    return counts
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cache photos / covers locally")
+    parser.add_argument("--target", choices=("authors", "books", "all"), default="all")
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--rate-limit",
+        type=float,
+        default=0.2,
+        help="Seconds between downloads to be a good citizen of upstream CDNs (default 0.2)",
+    )
+    args = parser.parse_args()
+
+    if not args.dry_run:
+        PUBLIC_CACHED.mkdir(parents=True, exist_ok=True)
+
+    summary = {}
+    if args.target in ("authors", "all"):
+        print("Caching author photos...")
+        summary["authors"] = process_authors(args.limit, args.dry_run, args.rate_limit)
+    if args.target in ("books", "all"):
+        print("\nCaching book covers...")
+        summary["books"] = process_books(args.limit, args.dry_run, args.rate_limit)
+
+    print("\n=== Summary ===")
+    for kind, c in summary.items():
+        print(
+            f"  {kind:8s}  total={c['total']:5d}  "
+            f"already-cached={c['cached_already']:5d}  "
+            f"downloaded={c['downloaded']:5d}  "
+            f"failed={c['failed']:4d}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_cache_photos.py
+++ b/scripts/test_cache_photos.py
@@ -1,0 +1,270 @@
+"""Tests for cache-photos.py — covers content-type → ext mapping, idempotency
+on already-local URLs, JSON rewriting on success, no-modification on failure."""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Module name has a hyphen, so import via spec.
+_spec = importlib.util.spec_from_file_location(
+    "cache_photos", Path(__file__).parent / "cache-photos.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class TestIsAlreadyLocal:
+    def test_local_paths(self):
+        assert mod.is_already_local("/tsundoku/cached/authors/plato.jpg")
+        assert mod.is_already_local("/cached/authors/plato.jpg")
+
+    def test_upstream_paths(self):
+        assert not mod.is_already_local("https://upload.wikimedia.org/wiki/foo.jpg")
+        assert not mod.is_already_local("https://covers.openlibrary.org/b/id/123-L.jpg")
+
+
+class TestExtFromResponse:
+    def test_jpeg(self):
+        assert mod.ext_from_response("image/jpeg", "https://x/y.jpg") == "jpg"
+
+    def test_jpeg_with_charset(self):
+        assert mod.ext_from_response("image/jpeg; charset=binary", "https://x/y") == "jpg"
+
+    def test_png(self):
+        assert mod.ext_from_response("image/png", "https://x/y.png") == "png"
+
+    def test_webp(self):
+        assert mod.ext_from_response("image/webp", "https://x/y") == "webp"
+
+    def test_unknown_type_falls_back_to_url_suffix(self):
+        assert mod.ext_from_response("application/octet-stream", "https://x/y.png") == "png"
+
+    def test_unknown_everything_defaults_jpg(self):
+        assert mod.ext_from_response(None, "https://x/no-suffix") == "jpg"
+
+    def test_jpeg_url_normalized_to_jpg(self):
+        assert mod.ext_from_response(None, "https://x/y.jpeg") == "jpg"
+
+
+class TestCacheOne:
+    def test_skips_when_already_local(self, tmp_path, monkeypatch):
+        out_dir = tmp_path / "authors"
+        result = mod.cache_one(
+            url="/tsundoku/cached/authors/plato.jpg",
+            out_dir=out_dir,
+            slug="plato",
+            rate_limit_s=0,
+        )
+        assert result is None  # nothing to do
+
+    def test_uses_existing_recent_file_without_redownload(self, tmp_path, monkeypatch):
+        out_dir = tmp_path / "authors"
+        out_dir.mkdir()
+        # Existing recent file (mtime = now)
+        (out_dir / "plato.png").write_bytes(b"fake png bytes")
+
+        # If download() were called, it would fail noisily — make sure it isn't.
+        def boom(url):
+            raise AssertionError(f"download() should not be called; got {url}")
+
+        monkeypatch.setattr(mod, "download", boom)
+        result = mod.cache_one(
+            url="https://example.com/plato.png",
+            out_dir=out_dir,
+            slug="plato",
+            rate_limit_s=0,
+        )
+        assert result is not None
+        local_url, ext = result
+        assert ext == "png"
+        assert local_url.endswith("/cached/authors/plato.png")
+
+    def test_redownloads_if_existing_file_is_old(self, tmp_path, monkeypatch):
+        out_dir = tmp_path / "authors"
+        out_dir.mkdir()
+        old_file = out_dir / "plato.jpg"
+        old_file.write_bytes(b"old data")
+        # Pretend it's 200 days old
+        ancient = time.time() - 200 * 86400
+        os.utime(old_file, (ancient, ancient))
+
+        monkeypatch.setattr(mod, "download", lambda u: (b"fresh data", "jpg"))
+        result = mod.cache_one(
+            url="https://example.com/plato.jpg",
+            out_dir=out_dir,
+            slug="plato",
+            rate_limit_s=0,
+        )
+        assert result is not None
+        assert old_file.read_bytes() == b"fresh data"
+
+    def test_returns_none_on_download_failure(self, tmp_path, monkeypatch):
+        out_dir = tmp_path / "authors"
+        monkeypatch.setattr(mod, "download", lambda u: None)
+        result = mod.cache_one(
+            url="https://example.com/dead.jpg",
+            out_dir=out_dir,
+            slug="dead",
+            rate_limit_s=0,
+        )
+        assert result is None
+        # No file was written
+        assert not (out_dir / "dead.jpg").exists()
+
+    def test_writes_atomically(self, tmp_path, monkeypatch):
+        """Verifies the .tmp + rename pattern: success writes the final file."""
+        out_dir = tmp_path / "authors"
+        monkeypatch.setattr(mod, "download", lambda u: (b"image bytes", "jpg"))
+        result = mod.cache_one(
+            url="https://example.com/x.jpg",
+            out_dir=out_dir,
+            slug="x",
+            rate_limit_s=0,
+        )
+        assert result is not None
+        assert (out_dir / "x.jpg").read_bytes() == b"image bytes"
+        # No leftover .tmp file
+        leftovers = list(out_dir.glob("*.tmp"))
+        assert leftovers == []
+
+
+class TestProcessAuthors:
+    def test_dead_url_does_not_modify_json(self, tmp_path, monkeypatch):
+        authors = tmp_path / "authors"
+        authors.mkdir()
+        author_file = authors / "test.json"
+        original = {
+            "name": "Test",
+            "slug": "test",
+            "book_count": 1,
+            "photo_url": "https://dead.example/x.jpg",
+        }
+        author_file.write_text(json.dumps(original))
+
+        monkeypatch.setattr(mod, "AUTHORS_DIR", authors)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        monkeypatch.setattr(mod, "download", lambda u: None)  # always fail
+
+        counts = mod.process_authors(limit=0, dry_run=False, rate_limit_s=0)
+
+        assert counts["failed"] == 1
+        # JSON unchanged
+        assert json.loads(author_file.read_text()) == original
+
+    def test_successful_download_rewrites_json(self, tmp_path, monkeypatch):
+        authors = tmp_path / "authors"
+        authors.mkdir()
+        author_file = authors / "plato.json"
+        original = {
+            "name": "Plato",
+            "slug": "plato",
+            "book_count": 21,
+            "photo_url": "https://upload.wikimedia.org/plato.jpg",
+            "bio": "philosopher",
+        }
+        author_file.write_text(json.dumps(original))
+
+        monkeypatch.setattr(mod, "AUTHORS_DIR", authors)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        monkeypatch.setattr(mod, "download", lambda u: (b"plato photo bytes", "jpg"))
+
+        counts = mod.process_authors(limit=0, dry_run=False, rate_limit_s=0)
+        assert counts["downloaded"] == 1
+        assert counts["failed"] == 0
+
+        result = json.loads(author_file.read_text())
+        # Upstream URL preserved for attribution
+        assert result["photo_url_source"] == "https://upload.wikimedia.org/plato.jpg"
+        # photo_url rewritten to local
+        assert result["photo_url"] == "/tsundoku/cached/authors/plato.jpg"
+        assert "photo_cached_at" in result
+        # Other fields untouched
+        assert result["bio"] == "philosopher"
+        assert result["book_count"] == 21
+
+    def test_dry_run_does_not_modify_files(self, tmp_path, monkeypatch):
+        authors = tmp_path / "authors"
+        authors.mkdir()
+        author_file = authors / "x.json"
+        original = '{"name":"X","slug":"x","book_count":1,"photo_url":"https://example.com/x.jpg"}'
+        author_file.write_text(original)
+
+        monkeypatch.setattr(mod, "AUTHORS_DIR", authors)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        monkeypatch.setattr(mod, "download", lambda u: (b"data", "jpg"))
+
+        mod.process_authors(limit=0, dry_run=True, rate_limit_s=0)
+        # JSON untouched
+        assert author_file.read_text() == original
+
+
+class TestProcessBooks:
+    def test_caches_largest_url_and_rewrites_both_fields(self, tmp_path, monkeypatch):
+        """When both cover_url and cover_url_large exist, we download once
+        (the large one) and rewrite both fields to point at it."""
+        books = tmp_path / "books"
+        books.mkdir()
+        book_file = books / "1984.json"
+        original = {
+            "title": "1984",
+            "author": "Orwell",
+            "category": "Literature",
+            "priority": 2,
+            "slug": "1984",
+            "cover_url": "https://covers.openlibrary.org/b/id/1-M.jpg",
+            "cover_url_large": "https://covers.openlibrary.org/b/id/1-L.jpg",
+        }
+        book_file.write_text(json.dumps(original))
+
+        downloads = []
+
+        def fake_download(url):
+            downloads.append(url)
+            return b"cover bytes", "jpg"
+
+        monkeypatch.setattr(mod, "BOOKS_DIR", books)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        monkeypatch.setattr(mod, "download", fake_download)
+
+        mod.process_books(limit=0, dry_run=False, rate_limit_s=0)
+
+        # Exactly one download — the large URL only
+        assert len(downloads) == 1
+        assert downloads[0].endswith("-L.jpg")
+
+        result = json.loads(book_file.read_text())
+        assert result["cover_url"] == "/tsundoku/cached/covers/1984.jpg"
+        assert result["cover_url_large"] == "/tsundoku/cached/covers/1984.jpg"
+        assert result["cover_url_source"].endswith("-M.jpg")
+        assert result["cover_url_large_source"].endswith("-L.jpg")
+
+    def test_idempotent_already_local(self, tmp_path, monkeypatch):
+        """Re-running on a record whose cover_url is already local does nothing."""
+        books = tmp_path / "books"
+        books.mkdir()
+        book_file = books / "x.json"
+        original = {
+            "title": "X",
+            "author": "Y",
+            "category": "Z",
+            "priority": 3,
+            "slug": "x",
+            "cover_url": "/tsundoku/cached/covers/x.jpg",
+        }
+        book_file.write_text(json.dumps(original))
+
+        monkeypatch.setattr(mod, "BOOKS_DIR", books)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        # download() should not be called
+        monkeypatch.setattr(mod, "download", lambda u: pytest.fail("unexpected download"))
+
+        counts = mod.process_books(limit=0, dry_run=False, rate_limit_s=0)
+        assert counts["cached_already"] == 1
+        assert counts["downloaded"] == 0

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -38,6 +38,12 @@ const books = defineCollection({
     copyright_status: z.enum(['public_domain', 'likely_public_domain', 'in_copyright', 'undetermined']).optional(),
     // Reading status (from data/reading-status.csv — owner's reading progress)
     reading_status: z.enum(['want', 'reading', 'read']).optional(),
+    // Local cover cache (populated by scripts/cache-photos.py — see #94)
+    // When set, cover_url / cover_url_large point to a local /cached/ path
+    // and the *_source fields preserve the original upstream URL for attribution.
+    cover_url_source: z.string().optional(),
+    cover_url_large_source: z.string().optional(),
+    cover_cached_at: z.string().optional(),
   }),
 });
 
@@ -53,6 +59,9 @@ const authors = defineCollection({
     birth_year: z.number().optional(),
     death_year: z.number().optional(),
     book_count: z.number(),
+    // Local photo cache (populated by scripts/cache-photos.py — see #94)
+    photo_url_source: z.string().optional(),
+    photo_cached_at: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
## What

The actual deliverable behind your original \"cache wikimedia photos and data\" ask. \`scripts/cache-photos.py\` downloads every \`photo_url\` / \`cover_url\` / \`cover_url_large\` to \`public/cached/\`, rewrites the source JSON URL to a local \`/tsundoku/cached/...\` path, and preserves the original upstream URL in \`*_source\` for attribution.

Once the cache is populated:
- Pages serve photos from the same origin as the rest of the site
- Wikimedia CDN rotations stop breaking author / book covers
- The build is reproducible offline (after first cache run)

## How

### \`scripts/cache-photos.py\`

CLI:
\`\`\`
python scripts/cache-photos.py                   # download all
python scripts/cache-photos.py --target authors  # only authors
python scripts/cache-photos.py --target books    # only books
python scripts/cache-photos.py --limit 50        # sample
python scripts/cache-photos.py --dry-run         # plan only, no writes
\`\`\`

**Failure-safe by design**: if a download fails (4xx, network error, timeout), the original upstream URL is **left in place** — never blanked, never broken-by-this-script. Combined with the Layout.astro runtime fallback from #89, the site is \"belt + suspenders\" resilient to upstream rot.

**Idempotent**: re-runs skip records whose URL is already local, and skip files on disk newer than 90 days.

**Cover deduplication**: Open Library serves \`cover_url\` (-M.jpg) and \`cover_url_large\` (-L.jpg) — different sizes of the same image. Downloads the larger one once and rewrites *both* fields to the same local URL. Saves ~3,000 × 50 KB ≈ 150 MB.

### CI persistence

\`\`\`yaml
- uses: actions/cache/restore@v4    # pull last successful cache
  with: { path: public/cached, key: photo-cache-v1-${{ github.run_id }}, restore-keys: photo-cache-v1- }
- run: python3 scripts/cache-photos.py
  continue-on-error: true            # Wikimedia outage doesn't break the build
- run: npm run build
- uses: actions/cache/save@v4        # always save (split pattern)
  if: always()
  with: { path: public/cached, key: photo-cache-v1-${{ github.run_id }} }
\`\`\`

The split restore/save pattern is the documented way to get \"always save\" behavior — the default action skips save on key hit.

### Schema additions

\`\`\`ts
// books
cover_url_source: z.string().optional(),
cover_url_large_source: z.string().optional(),
cover_cached_at: z.string().optional(),
// authors
photo_url_source: z.string().optional(),
photo_cached_at: z.string().optional(),
\`\`\`

### \`scripts/test_cache_photos.py\` — 19 tests

\`is_already_local\` for both URL prefixes; Content-Type → ext (jpeg/png/webp/charset variants/URL-suffix fallback); \`cache_one\` skip-if-local, reuse-recent-file, redownload-if-old, failure path, atomic .tmp + rename; \`process_authors\` dead-URL preserves JSON, success rewrites correctly, dry-run leaves files untouched; \`process_books\` largest-URL-only download with both fields rewritten.

## Test counts

| Suite | Before | After |
|---|---|---|
| pytest | 85 | **104** (+19) |
| vitest | 33 | 33 |
| typecheck | 0/0/0 | 0/0/0 |

## GitHub Pages compatibility

- \`public/cached/\` is gitignored — never committed
- Photos download at CI build time, ship in \`dist/cached/\` artifact
- ~290 MB worst case (1,300 authors × 40 KB + 3,500 covers × 70 KB), well under 1 GB Pages ceiling
- \`actions/cache@v4\` keeps the download fast across runs (~10 GB cache budget per repo)

## Closes

- Closes #94
- **Closes epic #96** — all six original child issues now shipped (#90, #91, #92, #93, #94, #95) plus the second-pass-discovered #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)