### PR TITLE
feat(authors): split joint-author book bylines into individual clickable links

### DIFF
--- a/scripts/generate-author-stubs.py
+++ b/scripts/generate-author-stubs.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
-"""
-Generate stub author pages for all authors referenced in books
-but missing from src/content/authors/.
+"""Generate stub author pages for every author referenced in books.
 
-Creates minimal JSON files with name, slug, and book_count.
-Run enrich-authors.py afterward to fetch Wikipedia data.
+For each book's `author` field we attribute the book to:
+  - The full author string (existing behavior — preserves joint-string records like
+    "Robert Jordan & Brandon Sanderson" so old URLs still work)
+  - Each individual component name when the string is a multi-author entry like
+    "Robert Jordan & Brandon Sanderson" → also stub "Robert Jordan" + "Brandon Sanderson"
+
+Component splitting matches the parseAuthors() helper in src/utils/formatting.ts:
+each part must be at least two whitespace-separated tokens (avoids splitting
+initials).
+
+Run enrich-authors.py + enrich-authors-gaps.py afterward to populate bios + photos.
 
 Usage:
   python scripts/generate-author-stubs.py
@@ -18,47 +25,66 @@ from pathlib import Path
 BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
 AUTHORS_DIR = Path(__file__).parent.parent / "src" / "content" / "authors"
 
+# Mirror src/utils/formatting.ts — keep in sync.
+STRONG_SEPARATORS = re.compile(r"\s*(?:&| and | with |/)\s*", re.IGNORECASE)
+COMMA_SEPARATOR = re.compile(r"\s*,\s*")
+
 
 def to_slug(text: str) -> str:
     """Convert text to URL-safe slug."""
-    return re.sub(r'(^-|-$)', '', re.sub(r'[^a-z0-9]+', '-', text.lower()))
+    return re.sub(r"(^-|-$)", "", re.sub(r"[^a-z0-9]+", "-", text.lower()))
+
+
+def split_authors(name: str) -> list[str]:
+    """Split a multi-author byline into component names. Returns [name] if not joint."""
+    strong = [p.strip() for p in STRONG_SEPARATORS.split(name) if p.strip()]
+    if len(strong) >= 2:
+        return strong
+    # Comma is ambiguous; only split when each part has 2+ tokens.
+    comma = [p.strip() for p in COMMA_SEPARATOR.split(name) if p.strip() and len(p.split()) >= 2]
+    if len(comma) >= 2:
+        return comma
+    return [name]
 
 
 def main() -> None:
-    # Collect all authors from books
-    author_counts: Counter[str] = Counter()
+    # Per book, attribute to BOTH the full author string AND each component name.
+    # Use a set per book so a name doesn't double-count if it appears as both
+    # full-string and component (rare but possible).
+    counts: Counter[str] = Counter()
     for bp in BOOKS_DIR.glob("*.json"):
         book = json.loads(bp.read_text())
-        author_counts[book["author"]] += 1
+        author_str = book["author"]
+        names = {author_str, *split_authors(author_str)}
+        for n in names:
+            counts[n] += 1
 
-    # Find existing author slugs
-    existing_slugs = set()
+    # Find existing author slugs.
+    existing_slugs: set[str] = set()
     for ap in AUTHORS_DIR.glob("*.json"):
         author = json.loads(ap.read_text())
         existing_slugs.add(author.get("slug", ""))
 
-    # Generate stubs for missing authors
     created = 0
     skipped_unknown = 0
-    for name, count in sorted(author_counts.items()):
+    skipped_existing = 0
+    for name, count in sorted(counts.items()):
         slug = to_slug(name)
 
-        # Skip "Unknown" — not a real author
         if name == "Unknown":
             skipped_unknown += count
             continue
 
-        # Skip authors whose names produce empty slugs (e.g., Cyrillic-only names)
         if not slug:
-            continue
+            continue  # cyrillic-only names, etc.
 
-        # Skip if page already exists
         if slug in existing_slugs:
+            skipped_existing += 1
             continue
 
-        # Check if file already exists by path
         author_path = AUTHORS_DIR / f"{slug}.json"
         if author_path.exists():
+            skipped_existing += 1
             continue
 
         author_data = {
@@ -66,13 +92,12 @@ def main() -> None:
             "slug": slug,
             "book_count": count,
         }
-
         author_path.write_text(json.dumps(author_data, indent=2, ensure_ascii=False))
         created += 1
 
-    total_authors = len(author_counts)
-    print(f"Authors in books: {total_authors}")
-    print(f"Already had pages: {len(existing_slugs)}")
+    total_authors = len(counts)
+    print(f"Distinct author identities (full strings + components): {total_authors}")
+    print(f"Existing pages: {skipped_existing}")
     print(f"Created stubs: {created}")
     if skipped_unknown:
         print(f"Skipped 'Unknown': {skipped_unknown} books")

--- a/src/content/authors/aaron-courville.json
+++ b/src/content/authors/aaron-courville.json
@@ -1,0 +1,5 @@
+{
+  "name": "Aaron Courville",
+  "slug": "aaron-courville",
+  "book_count": 1
+}

--- a/src/content/authors/abhijit-v-banerjee.json
+++ b/src/content/authors/abhijit-v-banerjee.json
@@ -1,0 +1,5 @@
+{
+  "name": "Abhijit V. Banerjee",
+  "slug": "abhijit-v-banerjee",
+  "book_count": 2
+}

--- a/src/content/authors/abraham-silberschatz.json
+++ b/src/content/authors/abraham-silberschatz.json
@@ -1,0 +1,5 @@
+{
+  "name": "Abraham Silberschatz",
+  "slug": "abraham-silberschatz",
+  "book_count": 1
+}

--- a/src/content/authors/acemoglu.json
+++ b/src/content/authors/acemoglu.json
@@ -1,0 +1,5 @@
+{
+  "name": "Acemoglu",
+  "slug": "acemoglu",
+  "book_count": 1
+}

--- a/src/content/authors/adam-horovitz.json
+++ b/src/content/authors/adam-horovitz.json
@@ -1,0 +1,5 @@
+{
+  "name": "Adam Horovitz",
+  "slug": "adam-horovitz",
+  "book_count": 1
+}

--- a/src/content/authors/aho-lam-sethi.json
+++ b/src/content/authors/aho-lam-sethi.json
@@ -1,0 +1,5 @@
+{
+  "name": "Aho, Lam, Sethi,",
+  "slug": "aho-lam-sethi",
+  "book_count": 2
+}

--- a/src/content/authors/alan-m-f-souza.json
+++ b/src/content/authors/alan-m-f-souza.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alan M. F. Souza",
+  "slug": "alan-m-f-souza",
+  "book_count": 1
+}

--- a/src/content/authors/alberto-artasanchez.json
+++ b/src/content/authors/alberto-artasanchez.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alberto Artasanchez",
+  "slug": "alberto-artasanchez",
+  "book_count": 1
+}

--- a/src/content/authors/alex-haley.json
+++ b/src/content/authors/alex-haley.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alex Haley",
+  "slug": "alex-haley",
+  "book_count": 1
+}

--- a/src/content/authors/alex-matrosov.json
+++ b/src/content/authors/alex-matrosov.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alex Matrosov",
+  "slug": "alex-matrosov",
+  "book_count": 1
+}

--- a/src/content/authors/alexander-hamilton-james-madison.json
+++ b/src/content/authors/alexander-hamilton-james-madison.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alexander Hamilton, James Madison,",
+  "slug": "alexander-hamilton-james-madison",
+  "book_count": 1
+}

--- a/src/content/authors/alexander-hamilton.json
+++ b/src/content/authors/alexander-hamilton.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alexander Hamilton",
+  "slug": "alexander-hamilton",
+  "book_count": 1
+}

--- a/src/content/authors/alexandra-boldyreva.json
+++ b/src/content/authors/alexandra-boldyreva.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alexandra Boldyreva",
+  "slug": "alexandra-boldyreva",
+  "book_count": 1
+}

--- a/src/content/authors/alexandre-gazet.json
+++ b/src/content/authors/alexandre-gazet.json
@@ -1,0 +1,5 @@
+{
+  "name": "Alexandre Gazet",
+  "slug": "alexandre-gazet",
+  "book_count": 1
+}

--- a/src/content/authors/amelia-bellamy-royds.json
+++ b/src/content/authors/amelia-bellamy-royds.json
@@ -1,0 +1,5 @@
+{
+  "name": "Amelia Bellamy-Royds",
+  "slug": "amelia-bellamy-royds",
+  "book_count": 1
+}

--- a/src/content/authors/and-john-jay.json
+++ b/src/content/authors/and-john-jay.json
@@ -1,0 +1,5 @@
+{
+  "name": "and John Jay",
+  "slug": "and-john-jay",
+  "book_count": 1
+}

--- a/src/content/authors/anderson.json
+++ b/src/content/authors/anderson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Anderson",
+  "slug": "anderson",
+  "book_count": 1
+}

--- a/src/content/authors/andrew-hunt.json
+++ b/src/content/authors/andrew-hunt.json
@@ -1,0 +1,5 @@
+{
+  "name": "Andrew Hunt",
+  "slug": "andrew-hunt",
+  "book_count": 2
+}

--- a/src/content/authors/anjanava-biswas.json
+++ b/src/content/authors/anjanava-biswas.json
@@ -1,0 +1,5 @@
+{
+  "name": "Anjanava Biswas",
+  "slug": "anjanava-biswas",
+  "book_count": 1
+}

--- a/src/content/authors/ann-aguirre.json
+++ b/src/content/authors/ann-aguirre.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ann Aguirre",
+  "slug": "ann-aguirre",
+  "book_count": 1
+}

--- a/src/content/authors/arkady.json
+++ b/src/content/authors/arkady.json
@@ -1,0 +1,5 @@
+{
+  "name": "Arkady",
+  "slug": "arkady",
+  "book_count": 3
+}

--- a/src/content/authors/august-cole.json
+++ b/src/content/authors/august-cole.json
@@ -1,0 +1,5 @@
+{
+  "name": "August Cole",
+  "slug": "august-cole",
+  "book_count": 1
+}

--- a/src/content/authors/austin-warren.json
+++ b/src/content/authors/austin-warren.json
@@ -1,0 +1,5 @@
+{
+  "name": "Austin Warren",
+  "slug": "austin-warren",
+  "book_count": 1
+}

--- a/src/content/authors/barroso.json
+++ b/src/content/authors/barroso.json
@@ -1,0 +1,5 @@
+{
+  "name": "Barroso",
+  "slug": "barroso",
+  "book_count": 1
+}

--- a/src/content/authors/beau-woods.json
+++ b/src/content/authors/beau-woods.json
@@ -1,0 +1,5 @@
+{
+  "name": "Beau Woods",
+  "slug": "beau-woods",
+  "book_count": 1
+}

--- a/src/content/authors/ben-silverman.json
+++ b/src/content/authors/ben-silverman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ben Silverman",
+  "slug": "ben-silverman",
+  "book_count": 1
+}

--- a/src/content/authors/ben-straub.json
+++ b/src/content/authors/ben-straub.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ben Straub",
+  "slug": "ben-straub",
+  "book_count": 1
+}

--- a/src/content/authors/bert-bates.json
+++ b/src/content/authors/bert-bates.json
@@ -1,0 +1,5 @@
+{
+  "name": "Bert Bates",
+  "slug": "bert-bates",
+  "book_count": 1
+}

--- a/src/content/authors/bing-west.json
+++ b/src/content/authors/bing-west.json
@@ -1,0 +1,5 @@
+{
+  "name": "Bing West",
+  "slug": "bing-west",
+  "book_count": 1
+}

--- a/src/content/authors/boris-strugatsky.json
+++ b/src/content/authors/boris-strugatsky.json
@@ -1,0 +1,5 @@
+{
+  "name": "Boris Strugatsky",
+  "slug": "boris-strugatsky",
+  "book_count": 3
+}

--- a/src/content/authors/brian-w-kernighan.json
+++ b/src/content/authors/brian-w-kernighan.json
@@ -1,0 +1,5 @@
+{
+  "name": "Brian W. Kernighan",
+  "slug": "brian-w-kernighan",
+  "book_count": 3
+}

--- a/src/content/authors/bruce-dang.json
+++ b/src/content/authors/bruce-dang.json
@@ -1,0 +1,5 @@
+{
+  "name": "Bruce Dang",
+  "slug": "bruce-dang",
+  "book_count": 1
+}

--- a/src/content/authors/bryant.json
+++ b/src/content/authors/bryant.json
@@ -1,0 +1,5 @@
+{
+  "name": "Bryant",
+  "slug": "bryant",
+  "book_count": 1
+}

--- a/src/content/authors/buchanan.json
+++ b/src/content/authors/buchanan.json
@@ -1,0 +1,5 @@
+{
+  "name": "Buchanan",
+  "slug": "buchanan",
+  "book_count": 1
+}

--- a/src/content/authors/c-todd-lombardo.json
+++ b/src/content/authors/c-todd-lombardo.json
@@ -1,0 +1,5 @@
+{
+  "name": "C. Todd Lombardo",
+  "slug": "c-todd-lombardo",
+  "book_count": 1
+}

--- a/src/content/authors/caitlin-tan.json
+++ b/src/content/authors/caitlin-tan.json
@@ -1,0 +1,5 @@
+{
+  "name": "Caitlin Tan",
+  "slug": "caitlin-tan",
+  "book_count": 1
+}

--- a/src/content/authors/calm-publications-staff.json
+++ b/src/content/authors/calm-publications-staff.json
@@ -1,0 +1,5 @@
+{
+  "name": "Calm Publications Staff",
+  "slug": "calm-publications-staff",
+  "book_count": 1
+}

--- a/src/content/authors/capra.json
+++ b/src/content/authors/capra.json
@@ -1,0 +1,5 @@
+{
+  "name": "Capra",
+  "slug": "capra",
+  "book_count": 1
+}

--- a/src/content/authors/caragh-m-o-brien.json
+++ b/src/content/authors/caragh-m-o-brien.json
@@ -1,0 +1,5 @@
+{
+  "name": "Caragh M. O'Brien",
+  "slug": "caragh-m-o-brien",
+  "book_count": 1
+}

--- a/src/content/authors/carolyn-thomson.json
+++ b/src/content/authors/carolyn-thomson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Carolyn Thomson",
+  "slug": "carolyn-thomson",
+  "book_count": 1
+}

--- a/src/content/authors/cass-r-sunstein.json
+++ b/src/content/authors/cass-r-sunstein.json
@@ -1,0 +1,5 @@
+{
+  "name": "Cass R. Sunstein",
+  "slug": "cass-r-sunstein",
+  "book_count": 1
+}

--- a/src/content/authors/cathy-o-neil.json
+++ b/src/content/authors/cathy-o-neil.json
@@ -1,0 +1,5 @@
+{
+  "name": "Cathy O'Neil",
+  "slug": "cathy-o-neil",
+  "book_count": 1
+}

--- a/src/content/authors/charlie-kaufman.json
+++ b/src/content/authors/charlie-kaufman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Charlie Kaufman",
+  "slug": "charlie-kaufman",
+  "book_count": 1
+}

--- a/src/content/authors/chris-anley.json
+++ b/src/content/authors/chris-anley.json
@@ -1,0 +1,5 @@
+{
+  "name": "Chris Anley",
+  "slug": "chris-anley",
+  "book_count": 1
+}

--- a/src/content/authors/chris-patten.json
+++ b/src/content/authors/chris-patten.json
@@ -1,0 +1,5 @@
+{
+  "name": "Chris Patten",
+  "slug": "chris-patten",
+  "book_count": 1
+}

--- a/src/content/authors/christine-w-park.json
+++ b/src/content/authors/christine-w-park.json
@@ -1,0 +1,5 @@
+{
+  "name": "Christine W. Park",
+  "slug": "christine-w-park",
+  "book_count": 1
+}

--- a/src/content/authors/christopher-j-pal.json
+++ b/src/content/authors/christopher-j-pal.json
@@ -1,0 +1,5 @@
+{
+  "name": "Christopher J. Pal",
+  "slug": "christopher-j-pal",
+  "book_count": 1
+}

--- a/src/content/authors/clara-bell.json
+++ b/src/content/authors/clara-bell.json
@@ -1,0 +1,5 @@
+{
+  "name": "Clara Bell",
+  "slug": "clara-bell",
+  "book_count": 1
+}

--- a/src/content/authors/colin-bendell.json
+++ b/src/content/authors/colin-bendell.json
@@ -1,0 +1,5 @@
+{
+  "name": "Colin Bendell",
+  "slug": "colin-bendell",
+  "book_count": 1
+}

--- a/src/content/authors/commission-on-geosciences.json
+++ b/src/content/authors/commission-on-geosciences.json
@@ -1,0 +1,5 @@
+{
+  "name": "Commission on Geosciences",
+  "slug": "commission-on-geosciences",
+  "book_count": 1
+}

--- a/src/content/authors/committee-on-grand-canyon-monitoring.json
+++ b/src/content/authors/committee-on-grand-canyon-monitoring.json
@@ -1,0 +1,5 @@
+{
+  "name": "Committee on Grand Canyon Monitoring",
+  "slug": "committee-on-grand-canyon-monitoring",
+  "book_count": 1
+}

--- a/src/content/authors/courant.json
+++ b/src/content/authors/courant.json
@@ -1,0 +1,5 @@
+{
+  "name": "Courant",
+  "slug": "courant",
+  "book_count": 1
+}

--- a/src/content/authors/cynthia-savard-saucier.json
+++ b/src/content/authors/cynthia-savard-saucier.json
@@ -1,0 +1,5 @@
+{
+  "name": "Cynthia Savard Saucier",
+  "slug": "cynthia-savard-saucier",
+  "book_count": 1
+}

--- a/src/content/authors/dan-kottmann.json
+++ b/src/content/authors/dan-kottmann.json
@@ -1,0 +1,5 @@
+{
+  "name": "Dan Kottmann",
+  "slug": "dan-kottmann",
+  "book_count": 1
+}

--- a/src/content/authors/daniele-micciancio.json
+++ b/src/content/authors/daniele-micciancio.json
@@ -1,0 +1,5 @@
+{
+  "name": "Daniele Micciancio",
+  "slug": "daniele-micciancio",
+  "book_count": 1
+}

--- a/src/content/authors/daron-acemoglu.json
+++ b/src/content/authors/daron-acemoglu.json
@@ -1,0 +1,5 @@
+{
+  "name": "Daron Acemoglu",
+  "slug": "daron-acemoglu",
+  "book_count": 2
+}

--- a/src/content/authors/dave-taylor.json
+++ b/src/content/authors/dave-taylor.json
@@ -1,0 +1,5 @@
+{
+  "name": "Dave Taylor",
+  "slug": "dave-taylor",
+  "book_count": 1
+}

--- a/src/content/authors/david-kennedy.json
+++ b/src/content/authors/david-kennedy.json
@@ -1,0 +1,5 @@
+{
+  "name": "David Kennedy",
+  "slug": "david-kennedy",
+  "book_count": 1
+}

--- a/src/content/authors/david-leblanc.json
+++ b/src/content/authors/david-leblanc.json
@@ -1,0 +1,5 @@
+{
+  "name": "David LeBlanc",
+  "slug": "david-leblanc",
+  "book_count": 1
+}

--- a/src/content/authors/david-thomas.json
+++ b/src/content/authors/david-thomas.json
@@ -1,0 +1,5 @@
+{
+  "name": "David Thomas",
+  "slug": "david-thomas",
+  "book_count": 2
+}

--- a/src/content/authors/delilah-s-dawson.json
+++ b/src/content/authors/delilah-s-dawson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Delilah S. Dawson",
+  "slug": "delilah-s-dawson",
+  "book_count": 1
+}

--- a/src/content/authors/dennis-m-ritchie.json
+++ b/src/content/authors/dennis-m-ritchie.json
@@ -1,0 +1,5 @@
+{
+  "name": "Dennis M. Ritchie",
+  "slug": "dennis-m-ritchie",
+  "book_count": 1
+}

--- a/src/content/authors/devon-kearns.json
+++ b/src/content/authors/devon-kearns.json
@@ -1,0 +1,5 @@
+{
+  "name": "Devon Kearns",
+  "slug": "devon-kearns",
+  "book_count": 1
+}

--- a/src/content/authors/dimitri-bertsekas.json
+++ b/src/content/authors/dimitri-bertsekas.json
@@ -1,0 +1,5 @@
+{
+  "name": "Dimitri Bertsekas",
+  "slug": "dimitri-bertsekas",
+  "book_count": 1
+}

--- a/src/content/authors/division-on-earth.json
+++ b/src/content/authors/division-on-earth.json
@@ -1,0 +1,5 @@
+{
+  "name": "Division on Earth",
+  "slug": "division-on-earth",
+  "book_count": 1
+}

--- a/src/content/authors/donald-knuth.json
+++ b/src/content/authors/donald-knuth.json
@@ -1,0 +1,5 @@
+{
+  "name": "Donald Knuth",
+  "slug": "donald-knuth",
+  "book_count": 1
+}

--- a/src/content/authors/dr-erdal-ozkaya.json
+++ b/src/content/authors/dr-erdal-ozkaya.json
@@ -1,0 +1,5 @@
+{
+  "name": "Dr. Erdal Ozkaya",
+  "slug": "dr-erdal-ozkaya",
+  "book_count": 1
+}

--- a/src/content/authors/dudley-storey.json
+++ b/src/content/authors/dudley-storey.json
@@ -1,0 +1,5 @@
+{
+  "name": "Dudley Storey",
+  "slug": "dudley-storey",
+  "book_count": 1
+}

--- a/src/content/authors/editorial-editorial-atlantic.json
+++ b/src/content/authors/editorial-editorial-atlantic.json
@@ -1,0 +1,5 @@
+{
+  "name": "Editorial Editorial Atlantic",
+  "slug": "editorial-editorial-atlantic",
+  "book_count": 1
+}

--- a/src/content/authors/edmond-de-goncourt.json
+++ b/src/content/authors/edmond-de-goncourt.json
@@ -1,0 +1,5 @@
+{
+  "name": "Edmond de Goncourt",
+  "slug": "edmond-de-goncourt",
+  "book_count": 1
+}

--- a/src/content/authors/eibe-frank.json
+++ b/src/content/authors/eibe-frank.json
@@ -1,0 +1,5 @@
+{
+  "name": "Eibe Frank",
+  "slug": "eibe-frank",
+  "book_count": 1
+}

--- a/src/content/authors/eleanor-burford-hibbert.json
+++ b/src/content/authors/eleanor-burford-hibbert.json
@@ -1,0 +1,5 @@
+{
+  "name": "Eleanor Burford Hibbert",
+  "slug": "eleanor-burford-hibbert",
+  "book_count": 1
+}

--- a/src/content/authors/elias-bachaalany.json
+++ b/src/content/authors/elias-bachaalany.json
@@ -1,0 +1,5 @@
+{
+  "name": "Elias Bachaalany",
+  "slug": "elias-bachaalany",
+  "book_count": 1
+}

--- a/src/content/authors/elizabeth-f-churchill.json
+++ b/src/content/authors/elizabeth-f-churchill.json
@@ -1,0 +1,5 @@
+{
+  "name": "Elizabeth F Churchill",
+  "slug": "elizabeth-f-churchill",
+  "book_count": 1
+}

--- a/src/content/authors/elizabeth-fama.json
+++ b/src/content/authors/elizabeth-fama.json
@@ -1,0 +1,5 @@
+{
+  "name": "Elizabeth Fama",
+  "slug": "elizabeth-fama",
+  "book_count": 1
+}

--- a/src/content/authors/ellen-anderson-gholson-glasgow.json
+++ b/src/content/authors/ellen-anderson-gholson-glasgow.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ellen Anderson Gholson Glasgow",
+  "slug": "ellen-anderson-gholson-glasgow",
+  "book_count": 1
+}

--- a/src/content/authors/ellen-craft.json
+++ b/src/content/authors/ellen-craft.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ellen Craft",
+  "slug": "ellen-craft",
+  "book_count": 1
+}

--- a/src/content/authors/ellen-glasgow.json
+++ b/src/content/authors/ellen-glasgow.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ellen Glasgow",
+  "slug": "ellen-glasgow",
+  "book_count": 1
+}

--- a/src/content/authors/engels.json
+++ b/src/content/authors/engels.json
@@ -1,0 +1,5 @@
+{
+  "name": "Engels",
+  "slug": "engels",
+  "book_count": 1
+}

--- a/src/content/authors/eric-meyer.json
+++ b/src/content/authors/eric-meyer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Eric Meyer",
+  "slug": "eric-meyer",
+  "book_count": 1
+}

--- a/src/content/authors/eric-van-lustbader.json
+++ b/src/content/authors/eric-van-lustbader.json
@@ -1,0 +1,5 @@
+{
+  "name": "Eric Van Lustbader",
+  "slug": "eric-van-lustbader",
+  "book_count": 1
+}

--- a/src/content/authors/estelle-weyl.json
+++ b/src/content/authors/estelle-weyl.json
@@ -1,0 +1,5 @@
+{
+  "name": "Estelle Weyl",
+  "slug": "estelle-weyl",
+  "book_count": 1
+}

--- a/src/content/authors/esther-duflo.json
+++ b/src/content/authors/esther-duflo.json
@@ -1,0 +1,5 @@
+{
+  "name": "Esther Duflo",
+  "slug": "esther-duflo",
+  "book_count": 2
+}

--- a/src/content/authors/eugene-rodionov.json
+++ b/src/content/authors/eugene-rodionov.json
@@ -1,0 +1,5 @@
+{
+  "name": "Eugene Rodionov",
+  "slug": "eugene-rodionov",
+  "book_count": 1
+}

--- a/src/content/authors/evangelos-deirmentzoglou.json
+++ b/src/content/authors/evangelos-deirmentzoglou.json
@@ -1,0 +1,5 @@
+{
+  "name": "Evangelos Deirmentzoglou",
+  "slug": "evangelos-deirmentzoglou",
+  "book_count": 1
+}

--- a/src/content/authors/fabio-m-soares.json
+++ b/src/content/authors/fabio-m-soares.json
@@ -1,0 +1,5 @@
+{
+  "name": "Fabio M. Soares",
+  "slug": "fabio-m-soares",
+  "book_count": 1
+}

--- a/src/content/authors/felix-lindner.json
+++ b/src/content/authors/felix-lindner.json
@@ -1,0 +1,5 @@
+{
+  "name": "Felix Lindner",
+  "slug": "felix-lindner",
+  "book_count": 1
+}

--- a/src/content/authors/fotios-chantzis.json
+++ b/src/content/authors/fotios-chantzis.json
@@ -1,0 +1,5 @@
+{
+  "name": "Fotios Chantzis",
+  "slug": "fotios-chantzis",
+  "book_count": 1
+}

--- a/src/content/authors/frank-hutter.json
+++ b/src/content/authors/frank-hutter.json
@@ -1,0 +1,5 @@
+{
+  "name": "Frank Hutter",
+  "slug": "frank-hutter",
+  "book_count": 1
+}

--- a/src/content/authors/friedrich-engels.json
+++ b/src/content/authors/friedrich-engels.json
@@ -1,0 +1,5 @@
+{
+  "name": "Friedrich Engels",
+  "slug": "friedrich-engels",
+  "book_count": 2
+}

--- a/src/content/authors/gennifer-albin.json
+++ b/src/content/authors/gennifer-albin.json
@@ -1,0 +1,5 @@
+{
+  "name": "Gennifer Albin",
+  "slug": "gennifer-albin",
+  "book_count": 1
+}

--- a/src/content/authors/gerald-jay-sussman.json
+++ b/src/content/authors/gerald-jay-sussman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Gerald Jay Sussman",
+  "slug": "gerald-jay-sussman",
+  "book_count": 2
+}

--- a/src/content/authors/gerardo-richarte.json
+++ b/src/content/authors/gerardo-richarte.json
@@ -1,0 +1,5 @@
+{
+  "name": "Gerardo Richarte",
+  "slug": "gerardo-richarte",
+  "book_count": 1
+}

--- a/src/content/authors/gilberto-najera-gutierrez.json
+++ b/src/content/authors/gilberto-najera-gutierrez.json
@@ -1,0 +1,5 @@
+{
+  "name": "Gilberto Najera-Gutierrez",
+  "slug": "gilberto-najera-gutierrez",
+  "book_count": 1
+}

--- a/src/content/authors/gordon-tullock.json
+++ b/src/content/authors/gordon-tullock.json
@@ -1,0 +1,5 @@
+{
+  "name": "Gordon Tullock",
+  "slug": "gordon-tullock",
+  "book_count": 1
+}

--- a/src/content/authors/greg-gagne.json
+++ b/src/content/authors/greg-gagne.json
@@ -1,0 +1,5 @@
+{
+  "name": "Greg Gagne",
+  "slug": "greg-gagne",
+  "book_count": 1
+}

--- a/src/content/authors/guy-podjarny.json
+++ b/src/content/authors/guy-podjarny.json
@@ -1,0 +1,5 @@
+{
+  "name": "Guy Podjarny",
+  "slug": "guy-podjarny",
+  "book_count": 1
+}

--- a/src/content/authors/halsted-welles.json
+++ b/src/content/authors/halsted-welles.json
@@ -1,0 +1,5 @@
+{
+  "name": "Halsted Welles",
+  "slug": "halsted-welles",
+  "book_count": 1
+}

--- a/src/content/authors/hardy.json
+++ b/src/content/authors/hardy.json
@@ -1,0 +1,5 @@
+{
+  "name": "Hardy",
+  "slug": "hardy",
+  "book_count": 1
+}

--- a/src/content/authors/harold-abelson.json
+++ b/src/content/authors/harold-abelson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Harold Abelson",
+  "slug": "harold-abelson",
+  "book_count": 1
+}

--- a/src/content/authors/henry-seymour.json
+++ b/src/content/authors/henry-seymour.json
@@ -1,0 +1,5 @@
+{
+  "name": "Henry Seymour",
+  "slug": "henry-seymour",
+  "book_count": 1
+}

--- a/src/content/authors/herbert-robbins.json
+++ b/src/content/authors/herbert-robbins.json
@@ -1,0 +1,5 @@
+{
+  "name": "Herbert Robbins",
+  "slug": "herbert-robbins",
+  "book_count": 1
+}

--- a/src/content/authors/hillary-sanders.json
+++ b/src/content/authors/hillary-sanders.json
@@ -1,0 +1,5 @@
+{
+  "name": "Hillary Sanders",
+  "slug": "hillary-sanders",
+  "book_count": 1
+}

--- a/src/content/authors/hoglund.json
+++ b/src/content/authors/hoglund.json
@@ -1,0 +1,5 @@
+{
+  "name": "Hoglund",
+  "slug": "hoglund",
+  "book_count": 1
+}

--- a/src/content/authors/holzle.json
+++ b/src/content/authors/holzle.json
@@ -1,0 +1,5 @@
+{
+  "name": "Holzle",
+  "slug": "holzle",
+  "book_count": 1
+}

--- a/src/content/authors/honore-de-balzac.json
+++ b/src/content/authors/honore-de-balzac.json
@@ -1,0 +1,5 @@
+{
+  "name": "Honore De Balzac",
+  "slug": "honore-de-balzac",
+  "book_count": 1
+}

--- a/src/content/authors/ian-goodfellow.json
+++ b/src/content/authors/ian-goodfellow.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ian Goodfellow",
+  "slug": "ian-goodfellow",
+  "book_count": 1
+}

--- a/src/content/authors/ian-h-witten.json
+++ b/src/content/authors/ian-h-witten.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ian H. Witten",
+  "slug": "ian-h-witten",
+  "book_count": 1
+}

--- a/src/content/authors/ilya-prigogine.json
+++ b/src/content/authors/ilya-prigogine.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ilya Prigogine",
+  "slug": "ilya-prigogine",
+  "book_count": 1
+}

--- a/src/content/authors/ioannis-stais.json
+++ b/src/content/authors/ioannis-stais.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ioannis Stais",
+  "slug": "ioannis-stais",
+  "book_count": 1
+}

--- a/src/content/authors/isabelle-stengers.json
+++ b/src/content/authors/isabelle-stengers.json
@@ -1,0 +1,5 @@
+{
+  "name": "Isabelle Stengers",
+  "slug": "isabelle-stengers",
+  "book_count": 1
+}

--- a/src/content/authors/jack-wisdom.json
+++ b/src/content/authors/jack-wisdom.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jack Wisdom",
+  "slug": "jack-wisdom",
+  "book_count": 1
+}

--- a/src/content/authors/james-a-robinson.json
+++ b/src/content/authors/james-a-robinson.json
@@ -1,0 +1,5 @@
+{
+  "name": "James A. Robinson",
+  "slug": "james-a-robinson",
+  "book_count": 2
+}

--- a/src/content/authors/james-buchanan.json
+++ b/src/content/authors/james-buchanan.json
@@ -1,0 +1,5 @@
+{
+  "name": "James Buchanan",
+  "slug": "james-buchanan",
+  "book_count": 1
+}

--- a/src/content/authors/james-foulds.json
+++ b/src/content/authors/james-foulds.json
@@ -1,0 +1,5 @@
+{
+  "name": "James Foulds",
+  "slug": "james-foulds",
+  "book_count": 1
+}

--- a/src/content/authors/james-madison.json
+++ b/src/content/authors/james-madison.json
@@ -1,0 +1,5 @@
+{
+  "name": "James Madison",
+  "slug": "james-madison",
+  "book_count": 1
+}

--- a/src/content/authors/jeffrey-ullman.json
+++ b/src/content/authors/jeffrey-ullman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jeffrey Ullman",
+  "slug": "jeffrey-ullman",
+  "book_count": 1
+}

--- a/src/content/authors/jerome-friedman.json
+++ b/src/content/authors/jerome-friedman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jerome Friedman",
+  "slug": "jerome-friedman",
+  "book_count": 1
+}

--- a/src/content/authors/jim-mattis.json
+++ b/src/content/authors/jim-mattis.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jim Mattis",
+  "slug": "jim-mattis",
+  "book_count": 1
+}

--- a/src/content/authors/jim-o-gorman.json
+++ b/src/content/authors/jim-o-gorman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jim O'Gorman",
+  "slug": "jim-o-gorman",
+  "book_count": 1
+}

--- a/src/content/authors/jiming-sun.json
+++ b/src/content/authors/jiming-sun.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jiming Sun",
+  "slug": "jiming-sun",
+  "book_count": 1
+}

--- a/src/content/authors/joaquin-vanschoren.json
+++ b/src/content/authors/joaquin-vanschoren.json
@@ -1,0 +1,5 @@
+{
+  "name": "Joaquin Vanschoren",
+  "slug": "joaquin-vanschoren",
+  "book_count": 1
+}

--- a/src/content/authors/john-alderman.json
+++ b/src/content/authors/john-alderman.json
@@ -1,0 +1,5 @@
+{
+  "name": "John Alderman",
+  "slug": "john-alderman",
+  "book_count": 1
+}

--- a/src/content/authors/john-heasman.json
+++ b/src/content/authors/john-heasman.json
@@ -1,0 +1,5 @@
+{
+  "name": "John Heasman",
+  "slug": "john-heasman",
+  "book_count": 1
+}

--- a/src/content/authors/john-hopcroft.json
+++ b/src/content/authors/john-hopcroft.json
@@ -1,0 +1,5 @@
+{
+  "name": "John Hopcroft",
+  "slug": "john-hopcroft",
+  "book_count": 1
+}

--- a/src/content/authors/john-jay.json
+++ b/src/content/authors/john-jay.json
@@ -1,0 +1,5 @@
+{
+  "name": "John Jay",
+  "slug": "john-jay",
+  "book_count": 1
+}

--- a/src/content/authors/john-tsitsiklis.json
+++ b/src/content/authors/john-tsitsiklis.json
@@ -1,0 +1,5 @@
+{
+  "name": "John Tsitsiklis",
+  "slug": "john-tsitsiklis",
+  "book_count": 1
+}

--- a/src/content/authors/jon-kleinberg.json
+++ b/src/content/authors/jon-kleinberg.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jon Kleinberg",
+  "slug": "jon-kleinberg",
+  "book_count": 1
+}

--- a/src/content/authors/jon-yeager.json
+++ b/src/content/authors/jon-yeager.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jon Yeager",
+  "slug": "jon-yeager",
+  "book_count": 1
+}

--- a/src/content/authors/jonathan-haskel.json
+++ b/src/content/authors/jonathan-haskel.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jonathan Haskel",
+  "slug": "jonathan-haskel",
+  "book_count": 1
+}

--- a/src/content/authors/jonathan-shariat.json
+++ b/src/content/authors/jonathan-shariat.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jonathan Shariat",
+  "slug": "jonathan-shariat",
+  "book_count": 1
+}

--- a/src/content/authors/jose-de-fonseca.json
+++ b/src/content/authors/jose-de-fonseca.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jose de Fonseca",
+  "slug": "jose-de-fonseca",
+  "book_count": 1
+}

--- a/src/content/authors/joseph-l-galloway.json
+++ b/src/content/authors/joseph-l-galloway.json
@@ -1,0 +1,5 @@
+{
+  "name": "Joseph L. Galloway",
+  "slug": "joseph-l-galloway",
+  "book_count": 1
+}

--- a/src/content/authors/joseph-shuldiner.json
+++ b/src/content/authors/joseph-shuldiner.json
@@ -1,0 +1,5 @@
+{
+  "name": "Joseph Shuldiner",
+  "slug": "joseph-shuldiner",
+  "book_count": 1
+}

--- a/src/content/authors/joshua-saxe.json
+++ b/src/content/authors/joshua-saxe.json
@@ -1,0 +1,5 @@
+{
+  "name": "Joshua Saxe",
+  "slug": "joshua-saxe",
+  "book_count": 1
+}

--- a/src/content/authors/joy-a-thomas.json
+++ b/src/content/authors/joy-a-thomas.json
@@ -1,0 +1,5 @@
+{
+  "name": "Joy A. Thomas",
+  "slug": "joy-a-thomas",
+  "book_count": 1
+}

--- a/src/content/authors/jules-de-goncourt.json
+++ b/src/content/authors/jules-de-goncourt.json
@@ -1,0 +1,5 @@
+{
+  "name": "Jules de Goncourt",
+  "slug": "jules-de-goncourt",
+  "book_count": 1
+}

--- a/src/content/authors/juned-ahmed-ansari.json
+++ b/src/content/authors/juned-ahmed-ansari.json
@@ -1,0 +1,5 @@
+{
+  "name": "Juned Ahmed Ansari",
+  "slug": "juned-ahmed-ansari",
+  "book_count": 1
+}

--- a/src/content/authors/justin-seitz.json
+++ b/src/content/authors/justin-seitz.json
@@ -1,0 +1,5 @@
+{
+  "name": "Justin Seitz",
+  "slug": "justin-seitz",
+  "book_count": 1
+}

--- a/src/content/authors/kara-nance.json
+++ b/src/content/authors/kara-nance.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kara Nance",
+  "slug": "kara-nance",
+  "book_count": 1
+}

--- a/src/content/authors/karen-morgan.json
+++ b/src/content/authors/karen-morgan.json
@@ -1,0 +1,5 @@
+{
+  "name": "Karen Morgan",
+  "slug": "karen-morgan",
+  "book_count": 1
+}

--- a/src/content/authors/karin-kasdin.json
+++ b/src/content/authors/karin-kasdin.json
@@ -1,0 +1,5 @@
+{
+  "name": "Karin Kasdin",
+  "slug": "karin-kasdin",
+  "book_count": 1
+}

--- a/src/content/authors/kasner.json
+++ b/src/content/authors/kasner.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kasner",
+  "slug": "kasner",
+  "book_count": 1
+}

--- a/src/content/authors/kathy-sierra.json
+++ b/src/content/authors/kathy-sierra.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kathy Sierra",
+  "slug": "kathy-sierra",
+  "book_count": 1
+}

--- a/src/content/authors/keith-melton.json
+++ b/src/content/authors/keith-melton.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keith Melton",
+  "slug": "keith-melton",
+  "book_count": 1
+}

--- a/src/content/authors/kevin-crane.json
+++ b/src/content/authors/kevin-crane.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kevin Crane",
+  "slug": "kevin-crane",
+  "book_count": 1
+}

--- a/src/content/authors/kevin-d-mitnick.json
+++ b/src/content/authors/kevin-d-mitnick.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kevin D. Mitnick",
+  "slug": "kevin-d-mitnick",
+  "book_count": 2
+}

--- a/src/content/authors/kevin-hearne.json
+++ b/src/content/authors/kevin-hearne.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kevin Hearne",
+  "slug": "kevin-hearne",
+  "book_count": 1
+}

--- a/src/content/authors/kevin-wayne.json
+++ b/src/content/authors/kevin-wayne.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kevin Wayne",
+  "slug": "kevin-wayne",
+  "book_count": 1
+}

--- a/src/content/authors/khaled-hosseini.json
+++ b/src/content/authors/khaled-hosseini.json
@@ -1,0 +1,5 @@
+{
+  "name": "Khaled Hosseini",
+  "slug": "khaled-hosseini",
+  "book_count": 1
+}

--- a/src/content/authors/kuen-chang.json
+++ b/src/content/authors/kuen-chang.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kuen Chang",
+  "slug": "kuen-chang",
+  "book_count": 1
+}

--- a/src/content/authors/kurt-cagle.json
+++ b/src/content/authors/kurt-cagle.json
@@ -1,0 +1,5 @@
+{
+  "name": "Kurt Cagle",
+  "slug": "kurt-cagle",
+  "book_count": 1
+}

--- a/src/content/authors/lars-kotthoff.json
+++ b/src/content/authors/lars-kotthoff.json
@@ -1,0 +1,5 @@
+{
+  "name": "Lars Kotthoff",
+  "slug": "lars-kotthoff",
+  "book_count": 1
+}

--- a/src/content/authors/laura-szabo-cohen.json
+++ b/src/content/authors/laura-szabo-cohen.json
@@ -1,0 +1,5 @@
+{
+  "name": "Laura Szabo-Cohen",
+  "slug": "laura-szabo-cohen",
+  "book_count": 1
+}

--- a/src/content/authors/life-studies-commission-on-geosciences-environment.json
+++ b/src/content/authors/life-studies-commission-on-geosciences-environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Life Studies, Commission on Geosciences, Environment",
+  "slug": "life-studies-commission-on-geosciences-environment",
+  "book_count": 1
+}

--- a/src/content/authors/life-studies.json
+++ b/src/content/authors/life-studies.json
@@ -1,0 +1,5 @@
+{
+  "name": "Life Studies",
+  "slug": "life-studies",
+  "book_count": 1
+}

--- a/src/content/authors/lindsay-yeager.json
+++ b/src/content/authors/lindsay-yeager.json
@@ -1,0 +1,5 @@
+{
+  "name": "Lindsay Yeager",
+  "slug": "lindsay-yeager",
+  "book_count": 1
+}

--- a/src/content/authors/lish-mcbride.json
+++ b/src/content/authors/lish-mcbride.json
@@ -1,0 +1,5 @@
+{
+  "name": "Lish McBride",
+  "slug": "lish-mcbride",
+  "book_count": 1
+}

--- a/src/content/authors/liston.json
+++ b/src/content/authors/liston.json
@@ -1,0 +1,5 @@
+{
+  "name": "Liston",
+  "slug": "liston",
+  "book_count": 1
+}

--- a/src/content/authors/lt-gen-harold-g-moore.json
+++ b/src/content/authors/lt-gen-harold-g-moore.json
@@ -1,0 +1,5 @@
+{
+  "name": "Lt. Gen. Harold G. Moore",
+  "slug": "lt-gen-harold-g-moore",
+  "book_count": 1
+}

--- a/src/content/authors/luisi.json
+++ b/src/content/authors/luisi.json
@@ -1,0 +1,5 @@
+{
+  "name": "Luisi",
+  "slug": "luisi",
+  "book_count": 1
+}

--- a/src/content/authors/lynn-abbey.json
+++ b/src/content/authors/lynn-abbey.json
@@ -1,0 +1,5 @@
+{
+  "name": "Lynn Abbey",
+  "slug": "lynn-abbey",
+  "book_count": 2
+}

--- a/src/content/authors/lysander-spooner.json
+++ b/src/content/authors/lysander-spooner.json
@@ -1,0 +1,5 @@
+{
+  "name": "Lysander Spooner",
+  "slug": "lysander-spooner",
+  "book_count": 1
+}

--- a/src/content/authors/maj-sj-wall.json
+++ b/src/content/authors/maj-sj-wall.json
@@ -1,0 +1,5 @@
+{
+  "name": "Maj Sjöwall",
+  "slug": "maj-sj-wall",
+  "book_count": 2
+}

--- a/src/content/authors/malcolm-x.json
+++ b/src/content/authors/malcolm-x.json
@@ -1,0 +1,5 @@
+{
+  "name": "Malcolm X",
+  "slug": "malcolm-x",
+  "book_count": 1
+}

--- a/src/content/authors/marc-jones.json
+++ b/src/content/authors/marc-jones.json
@@ -1,0 +1,5 @@
+{
+  "name": "Marc Jones",
+  "slug": "marc-jones",
+  "book_count": 1
+}

--- a/src/content/authors/marie-rutkoski.json
+++ b/src/content/authors/marie-rutkoski.json
@@ -1,0 +1,5 @@
+{
+  "name": "Marie Rutkoski",
+  "slug": "marie-rutkoski",
+  "book_count": 1
+}

--- a/src/content/authors/mark-a-hall.json
+++ b/src/content/authors/mark-a-hall.json
@@ -1,0 +1,5 @@
+{
+  "name": "Mark A. Hall",
+  "slug": "mark-a-hall",
+  "book_count": 1
+}

--- a/src/content/authors/martin-eriksson.json
+++ b/src/content/authors/martin-eriksson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Martin Eriksson",
+  "slug": "martin-eriksson",
+  "book_count": 1
+}

--- a/src/content/authors/marx.json
+++ b/src/content/authors/marx.json
@@ -1,0 +1,5 @@
+{
+  "name": "Marx",
+  "slug": "marx",
+  "book_count": 1
+}

--- a/src/content/authors/mati-aharoni.json
+++ b/src/content/authors/mati-aharoni.json
@@ -1,0 +1,5 @@
+{
+  "name": "Mati Aharoni",
+  "slug": "mati-aharoni",
+  "book_count": 1
+}

--- a/src/content/authors/maurice-herlihy.json
+++ b/src/content/authors/maurice-herlihy.json
@@ -1,0 +1,5 @@
+{
+  "name": "Maurice Herlihy",
+  "slug": "maurice-herlihy",
+  "book_count": 1
+}

--- a/src/content/authors/mckenrick.json
+++ b/src/content/authors/mckenrick.json
@@ -1,0 +1,5 @@
+{
+  "name": "McKenrick",
+  "slug": "mckenrick",
+  "book_count": 1
+}

--- a/src/content/authors/michael-diamond.json
+++ b/src/content/authors/michael-diamond.json
@@ -1,0 +1,5 @@
+{
+  "name": "Michael Diamond",
+  "slug": "michael-diamond",
+  "book_count": 1
+}

--- a/src/content/authors/michael-howard.json
+++ b/src/content/authors/michael-howard.json
@@ -1,0 +1,5 @@
+{
+  "name": "Michael Howard",
+  "slug": "michael-howard",
+  "book_count": 1
+}

--- a/src/content/authors/michael-solberg.json
+++ b/src/content/authors/michael-solberg.json
@@ -1,0 +1,5 @@
+{
+  "name": "Michael Solberg",
+  "slug": "michael-solberg",
+  "book_count": 1
+}

--- a/src/content/authors/mike-mccall.json
+++ b/src/content/authors/mike-mccall.json
@@ -1,0 +1,5 @@
+{
+  "name": "Mike McCall",
+  "slug": "mike-mccall",
+  "book_count": 1
+}

--- a/src/content/authors/mike-speciner.json
+++ b/src/content/authors/mike-speciner.json
@@ -1,0 +1,5 @@
+{
+  "name": "Mike Speciner",
+  "slug": "mike-speciner",
+  "book_count": 1
+}

--- a/src/content/authors/moore.json
+++ b/src/content/authors/moore.json
@@ -1,0 +1,5 @@
+{
+  "name": "Moore",
+  "slug": "moore",
+  "book_count": 1
+}

--- a/src/content/authors/nagel.json
+++ b/src/content/authors/nagel.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nagel",
+  "slug": "nagel",
+  "book_count": 1
+}

--- a/src/content/authors/nate-walkingshaw.json
+++ b/src/content/authors/nate-walkingshaw.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nate Walkingshaw",
+  "slug": "nate-walkingshaw",
+  "book_count": 1
+}

--- a/src/content/authors/national-research-council-division-on-earth.json
+++ b/src/content/authors/national-research-council-division-on-earth.json
@@ -1,0 +1,5 @@
+{
+  "name": "National Research Council, Division on Earth",
+  "slug": "national-research-council-division-on-earth",
+  "book_count": 1
+}

--- a/src/content/authors/national-research-council.json
+++ b/src/content/authors/national-research-council.json
@@ -1,0 +1,5 @@
+{
+  "name": "National Research Council",
+  "slug": "national-research-council",
+  "book_count": 1
+}

--- a/src/content/authors/newman.json
+++ b/src/content/authors/newman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Newman",
+  "slug": "newman",
+  "book_count": 2
+}

--- a/src/content/authors/nick-doyle.json
+++ b/src/content/authors/nick-doyle.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nick Doyle",
+  "slug": "nick-doyle",
+  "book_count": 1
+}

--- a/src/content/authors/niels-ferguson.json
+++ b/src/content/authors/niels-ferguson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Niels Ferguson",
+  "slug": "niels-ferguson",
+  "book_count": 2
+}

--- a/src/content/authors/nikolai-tillmann.json
+++ b/src/content/authors/nikolai-tillmann.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nikolai Tillmann",
+  "slug": "nikolai-tillmann",
+  "book_count": 1
+}

--- a/src/content/authors/nir-shavit.json
+++ b/src/content/authors/nir-shavit.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nir Shavit",
+  "slug": "nir-shavit",
+  "book_count": 1
+}

--- a/src/content/authors/norman-s-matloff.json
+++ b/src/content/authors/norman-s-matloff.json
@@ -1,0 +1,5 @@
+{
+  "name": "Norman S. Matloff",
+  "slug": "norman-s-matloff",
+  "book_count": 1
+}

--- a/src/content/authors/o-hallaron.json
+++ b/src/content/authors/o-hallaron.json
@@ -1,0 +1,5 @@
+{
+  "name": "O'Hallaron",
+  "slug": "o-hallaron",
+  "book_count": 1
+}

--- a/src/content/authors/oren-patashnik.json
+++ b/src/content/authors/oren-patashnik.json
@@ -1,0 +1,5 @@
+{
+  "name": "Oren Patashnik",
+  "slug": "oren-patashnik",
+  "book_count": 1
+}

--- a/src/content/authors/p-w-singer.json
+++ b/src/content/authors/p-w-singer.json
@@ -1,0 +1,5 @@
+{
+  "name": "P.W. Singer",
+  "slug": "p-w-singer",
+  "book_count": 1
+}

--- a/src/content/authors/paulino-calderon.json
+++ b/src/content/authors/paulino-calderon.json
@@ -1,0 +1,5 @@
+{
+  "name": "Paulino Calderon",
+  "slug": "paulino-calderon",
+  "book_count": 1
+}

--- a/src/content/authors/pedro-carolino.json
+++ b/src/content/authors/pedro-carolino.json
@@ -1,0 +1,5 @@
+{
+  "name": "Pedro Carolino",
+  "slug": "pedro-carolino",
+  "book_count": 1
+}

--- a/src/content/authors/per-wahl.json
+++ b/src/content/authors/per-wahl.json
@@ -1,0 +1,5 @@
+{
+  "name": "Per Wahlöö",
+  "slug": "per-wahl",
+  "book_count": 2
+}

--- a/src/content/authors/persian.json
+++ b/src/content/authors/persian.json
@@ -1,0 +1,5 @@
+{
+  "name": "Persian)",
+  "slug": "persian",
+  "book_count": 1
+}

--- a/src/content/authors/peter-dans.json
+++ b/src/content/authors/peter-dans.json
@@ -1,0 +1,5 @@
+{
+  "name": "Peter Dans",
+  "slug": "peter-dans",
+  "book_count": 1
+}

--- a/src/content/authors/peter-galvin.json
+++ b/src/content/authors/peter-galvin.json
@@ -1,0 +1,5 @@
+{
+  "name": "Peter Galvin",
+  "slug": "peter-galvin",
+  "book_count": 1
+}

--- a/src/content/authors/peter-jay-salzman.json
+++ b/src/content/authors/peter-jay-salzman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Peter Jay Salzman",
+  "slug": "peter-jay-salzman",
+  "book_count": 1
+}

--- a/src/content/authors/peter-norvig.json
+++ b/src/content/authors/peter-norvig.json
@@ -1,0 +1,5 @@
+{
+  "name": "Peter Norvig",
+  "slug": "peter-norvig",
+  "book_count": 1
+}

--- a/src/content/authors/prateek-joshi.json
+++ b/src/content/authors/prateek-joshi.json
@@ -1,0 +1,5 @@
+{
+  "name": "Prateek Joshi",
+  "slug": "prateek-joshi",
+  "book_count": 1
+}

--- a/src/content/authors/r-nigel-horspool.json
+++ b/src/content/authors/r-nigel-horspool.json
@@ -1,0 +1,5 @@
+{
+  "name": "R. Nigel Horspool",
+  "slug": "r-nigel-horspool",
+  "book_count": 1
+}

--- a/src/content/authors/rachel-schutt.json
+++ b/src/content/authors/rachel-schutt.json
@@ -1,0 +1,5 @@
+{
+  "name": "Rachel Schutt",
+  "slug": "rachel-schutt",
+  "book_count": 1
+}

--- a/src/content/authors/radia-perlman.json
+++ b/src/content/authors/radia-perlman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Radia Perlman",
+  "slug": "radia-perlman",
+  "book_count": 1
+}

--- a/src/content/authors/rajeev-motwani.json
+++ b/src/content/authors/rajeev-motwani.json
@@ -1,0 +1,5 @@
+{
+  "name": "Rajeev Motwani",
+  "slug": "rajeev-motwani",
+  "book_count": 1
+}

--- a/src/content/authors/ren-wellek.json
+++ b/src/content/authors/ren-wellek.json
@@ -1,0 +1,5 @@
+{
+  "name": "René Wellek",
+  "slug": "ren-wellek",
+  "book_count": 1
+}

--- a/src/content/authors/research.json
+++ b/src/content/authors/research.json
@@ -1,0 +1,5 @@
+{
+  "name": "Research",
+  "slug": "research",
+  "book_count": 1
+}

--- a/src/content/authors/resources-committee-on-grand-canyon-monitoring.json
+++ b/src/content/authors/resources-committee-on-grand-canyon-monitoring.json
@@ -1,0 +1,5 @@
+{
+  "name": "Resources, Committee on Grand Canyon Monitoring",
+  "slug": "resources-committee-on-grand-canyon-monitoring",
+  "book_count": 1
+}

--- a/src/content/authors/richard-a-clarke.json
+++ b/src/content/authors/richard-a-clarke.json
@@ -1,0 +1,5 @@
+{
+  "name": "Richard A. Clarke",
+  "slug": "richard-a-clarke",
+  "book_count": 2
+}

--- a/src/content/authors/richard-banfield.json
+++ b/src/content/authors/richard-banfield.json
@@ -1,0 +1,5 @@
+{
+  "name": "Richard Banfield",
+  "slug": "richard-banfield",
+  "book_count": 2
+}

--- a/src/content/authors/richard-courant.json
+++ b/src/content/authors/richard-courant.json
@@ -1,0 +1,5 @@
+{
+  "name": "Richard Courant",
+  "slug": "richard-courant",
+  "book_count": 1
+}

--- a/src/content/authors/richard-h-thaler.json
+++ b/src/content/authors/richard-h-thaler.json
@@ -1,0 +1,5 @@
+{
+  "name": "Richard H. Thaler",
+  "slug": "richard-h-thaler",
+  "book_count": 1
+}

--- a/src/content/authors/robbins.json
+++ b/src/content/authors/robbins.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robbins",
+  "slug": "robbins",
+  "book_count": 1
+}

--- a/src/content/authors/robert-k-knake.json
+++ b/src/content/authors/robert-k-knake.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robert K. Knake",
+  "slug": "robert-k-knake",
+  "book_count": 2
+}

--- a/src/content/authors/robert-lynn-asprin.json
+++ b/src/content/authors/robert-lynn-asprin.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robert Lynn Asprin",
+  "slug": "robert-lynn-asprin",
+  "book_count": 2
+}

--- a/src/content/authors/robert-sedgewick.json
+++ b/src/content/authors/robert-sedgewick.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robert Sedgewick",
+  "slug": "robert-sedgewick",
+  "book_count": 1
+}

--- a/src/content/authors/robert-tibshirani.json
+++ b/src/content/authors/robert-tibshirani.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robert Tibshirani",
+  "slug": "robert-tibshirani",
+  "book_count": 1
+}

--- a/src/content/authors/robert-wallace.json
+++ b/src/content/authors/robert-wallace.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robert Wallace",
+  "slug": "robert-wallace",
+  "book_count": 1
+}

--- a/src/content/authors/robin-asbell-susie-middleton-karen-morgan-joseph-shuldiner-melissa-s.json
+++ b/src/content/authors/robin-asbell-susie-middleton-karen-morgan-joseph-shuldiner-melissa-s.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robin Asbell, Susie Middleton, Karen Morgan, Joseph Shuldiner, Melissa's",
+  "slug": "robin-asbell-susie-middleton-karen-morgan-joseph-shuldiner-melissa-s",
+  "book_count": 1
+}

--- a/src/content/authors/robin-asbell.json
+++ b/src/content/authors/robin-asbell.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robin Asbell",
+  "slug": "robin-asbell",
+  "book_count": 1
+}

--- a/src/content/authors/robinson.json
+++ b/src/content/authors/robinson.json
@@ -1,0 +1,5 @@
+{
+  "name": "Robinson",
+  "slug": "robinson",
+  "book_count": 1
+}

--- a/src/content/authors/rochelle-king.json
+++ b/src/content/authors/rochelle-king.json
@@ -1,0 +1,5 @@
+{
+  "name": "Rochelle King",
+  "slug": "rochelle-king",
+  "book_count": 1
+}

--- a/src/content/authors/ronald-graham.json
+++ b/src/content/authors/ronald-graham.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ronald Graham",
+  "slug": "ronald-graham",
+  "book_count": 1
+}

--- a/src/content/authors/ross05.json
+++ b/src/content/authors/ross05.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ross05",
+  "slug": "ross05",
+  "book_count": 1
+}

--- a/src/content/authors/russell.json
+++ b/src/content/authors/russell.json
@@ -1,0 +1,5 @@
+{
+  "name": "Russell",
+  "slug": "russell",
+  "book_count": 1
+}

--- a/src/content/authors/saltzer.json
+++ b/src/content/authors/saltzer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Saltzer",
+  "slug": "saltzer",
+  "book_count": 1
+}

--- a/src/content/authors/samuel-augustus-binion.json
+++ b/src/content/authors/samuel-augustus-binion.json
@@ -1,0 +1,5 @@
+{
+  "name": "Samuel Augustus Binion",
+  "slug": "samuel-augustus-binion",
+  "book_count": 1
+}

--- a/src/content/authors/schroeder.json
+++ b/src/content/authors/schroeder.json
@@ -1,0 +1,5 @@
+{
+  "name": "Schroeder",
+  "slug": "schroeder",
+  "book_count": 1
+}

--- a/src/content/authors/scott-chacon.json
+++ b/src/content/authors/scott-chacon.json
@@ -1,0 +1,5 @@
+{
+  "name": "Scott Chacon",
+  "slug": "scott-chacon",
+  "book_count": 1
+}

--- a/src/content/authors/sergey-bratus.json
+++ b/src/content/authors/sergey-bratus.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sergey Bratus",
+  "slug": "sergey-bratus",
+  "book_count": 1
+}

--- a/src/content/authors/sheba-blake.json
+++ b/src/content/authors/sheba-blake.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sheba Blake",
+  "slug": "sheba-blake",
+  "book_count": 3
+}

--- a/src/content/authors/simon-king.json
+++ b/src/content/authors/simon-king.json
@@ -1,0 +1,5 @@
+{
+  "name": "Simon King",
+  "slug": "simon-king",
+  "book_count": 1
+}

--- a/src/content/authors/skoudis.json
+++ b/src/content/authors/skoudis.json
@@ -1,0 +1,5 @@
+{
+  "name": "Skoudis",
+  "slug": "skoudis",
+  "book_count": 1
+}

--- a/src/content/authors/stefan-reinauer.json
+++ b/src/content/authors/stefan-reinauer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Stefan Reinauer",
+  "slug": "stefan-reinauer",
+  "book_count": 1
+}

--- a/src/content/authors/stephen-brennan.json
+++ b/src/content/authors/stephen-brennan.json
@@ -1,0 +1,5 @@
+{
+  "name": "Stephen Brennan",
+  "slug": "stephen-brennan",
+  "book_count": 1
+}

--- a/src/content/authors/stian-westlake.json
+++ b/src/content/authors/stian-westlake.json
@@ -1,0 +1,5 @@
+{
+  "name": "Stian Westlake",
+  "slug": "stian-westlake",
+  "book_count": 1
+}

--- a/src/content/authors/stuart-russell.json
+++ b/src/content/authors/stuart-russell.json
@@ -1,0 +1,5 @@
+{
+  "name": "Stuart Russell",
+  "slug": "stuart-russell",
+  "book_count": 1
+}

--- a/src/content/authors/sunstein.json
+++ b/src/content/authors/sunstein.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sunstein",
+  "slug": "sunstein",
+  "book_count": 1
+}

--- a/src/content/authors/susan-landau.json
+++ b/src/content/authors/susan-landau.json
@@ -1,0 +1,5 @@
+{
+  "name": "Susan Landau",
+  "slug": "susan-landau",
+  "book_count": 1
+}

--- a/src/content/authors/susie-middleton.json
+++ b/src/content/authors/susie-middleton.json
@@ -1,0 +1,5 @@
+{
+  "name": "Susie Middleton",
+  "slug": "susie-middleton",
+  "book_count": 1
+}

--- a/src/content/authors/tadayoshi-kohno.json
+++ b/src/content/authors/tadayoshi-kohno.json
@@ -1,0 +1,5 @@
+{
+  "name": "Tadayoshi Kohno",
+  "slug": "tadayoshi-kohno",
+  "book_count": 1
+}

--- a/src/content/authors/thaler.json
+++ b/src/content/authors/thaler.json
@@ -1,0 +1,5 @@
+{
+  "name": "Thaler",
+  "slug": "thaler",
+  "book_count": 1
+}

--- a/src/content/authors/thomas-m-cover.json
+++ b/src/content/authors/thomas-m-cover.json
@@ -1,0 +1,5 @@
+{
+  "name": "Thomas M. Cover",
+  "slug": "thomas-m-cover",
+  "book_count": 1
+}

--- a/src/content/authors/tim-arnold.json
+++ b/src/content/authors/tim-arnold.json
@@ -1,0 +1,5 @@
+{
+  "name": "Tim Arnold",
+  "slug": "tim-arnold",
+  "book_count": 1
+}

--- a/src/content/authors/tim-kadlec.json
+++ b/src/content/authors/tim-kadlec.json
@@ -1,0 +1,5 @@
+{
+  "name": "Tim Kadlec",
+  "slug": "tim-kadlec",
+  "book_count": 1
+}

--- a/src/content/authors/tom-steele.json
+++ b/src/content/authors/tom-steele.json
@@ -1,0 +1,5 @@
+{
+  "name": "Tom Steele",
+  "slug": "tom-steele",
+  "book_count": 1
+}

--- a/src/content/authors/trace-wax.json
+++ b/src/content/authors/trace-wax.json
@@ -1,0 +1,5 @@
+{
+  "name": "Trace Wax",
+  "slug": "trace-wax",
+  "book_count": 1
+}

--- a/src/content/authors/trevor-hastie.json
+++ b/src/content/authors/trevor-hastie.json
@@ -1,0 +1,5 @@
+{
+  "name": "Trevor Hastie",
+  "slug": "trevor-hastie",
+  "book_count": 1
+}

--- a/src/content/authors/tullock.json
+++ b/src/content/authors/tullock.json
@@ -1,0 +1,5 @@
+{
+  "name": "Tullock",
+  "slug": "tullock",
+  "book_count": 1
+}

--- a/src/content/authors/ullman.json
+++ b/src/content/authors/ullman.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ullman",
+  "slug": "ullman",
+  "book_count": 2
+}

--- a/src/content/authors/va-tardos.json
+++ b/src/content/authors/va-tardos.json
@@ -1,0 +1,5 @@
+{
+  "name": "Éva Tardos",
+  "slug": "va-tardos",
+  "book_count": 1
+}

--- a/src/content/authors/various-arabic.json
+++ b/src/content/authors/various-arabic.json
@@ -1,0 +1,5 @@
+{
+  "name": "Various (Arabic",
+  "slug": "various-arabic",
+  "book_count": 1
+}

--- a/src/content/authors/victoria-holt.json
+++ b/src/content/authors/victoria-holt.json
@@ -1,0 +1,5 @@
+{
+  "name": "Victoria Holt",
+  "slug": "victoria-holt",
+  "book_count": 1
+}

--- a/src/content/authors/vincent-zimmer.json
+++ b/src/content/authors/vincent-zimmer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Vincent Zimmer",
+  "slug": "vincent-zimmer",
+  "book_count": 1
+}

--- a/src/content/authors/whitehead.json
+++ b/src/content/authors/whitehead.json
@@ -1,0 +1,5 @@
+{
+  "name": "Whitehead",
+  "slug": "whitehead",
+  "book_count": 1
+}

--- a/src/content/authors/whitfield-diffie.json
+++ b/src/content/authors/whitfield-diffie.json
@@ -1,0 +1,5 @@
+{
+  "name": "Whitfield Diffie",
+  "slug": "whitfield-diffie",
+  "book_count": 1
+}

--- a/src/content/authors/william-craft.json
+++ b/src/content/authors/william-craft.json
@@ -1,0 +1,5 @@
+{
+  "name": "William Craft",
+  "slug": "william-craft",
+  "book_count": 1
+}

--- a/src/content/authors/william-l-simon.json
+++ b/src/content/authors/william-l-simon.json
@@ -1,0 +1,5 @@
+{
+  "name": "William L. Simon",
+  "slug": "william-l-simon",
+  "book_count": 2
+}

--- a/src/content/authors/world-variety-produce-inc.json
+++ b/src/content/authors/world-variety-produce-inc.json
@@ -1,0 +1,5 @@
+{
+  "name": "World Variety Produce, Inc.",
+  "slug": "world-variety-produce-inc",
+  "book_count": 1
+}

--- a/src/content/authors/world-variety-produce.json
+++ b/src/content/authors/world-variety-produce.json
@@ -1,0 +1,5 @@
+{
+  "name": "World Variety Produce",
+  "slug": "world-variety-produce",
+  "book_count": 1
+}

--- a/src/content/authors/wrick-talukdar.json
+++ b/src/content/authors/wrick-talukdar.json
@@ -1,0 +1,5 @@
+{
+  "name": "Wrick Talukdar",
+  "slug": "wrick-talukdar",
+  "book_count": 1
+}

--- a/src/content/authors/wright.json
+++ b/src/content/authors/wright.json
@@ -1,0 +1,5 @@
+{
+  "name": "Wright",
+  "slug": "wright",
+  "book_count": 1
+}

--- a/src/content/authors/yoav-weiss.json
+++ b/src/content/authors/yoav-weiss.json
@@ -1,0 +1,5 @@
+{
+  "name": "Yoav Weiss",
+  "slug": "yoav-weiss",
+  "book_count": 1
+}

--- a/src/content/authors/yoshua-bengio.json
+++ b/src/content/authors/yoshua-bengio.json
@@ -1,0 +1,5 @@
+{
+  "name": "Yoshua Bengio",
+  "slug": "yoshua-bengio",
+  "book_count": 1
+}

--- a/src/content/authors/yuri-diogenes.json
+++ b/src/content/authors/yuri-diogenes.json
@@ -1,0 +1,5 @@
+{
+  "name": "Yuri Diogenes",
+  "slug": "yuri-diogenes",
+  "book_count": 1
+}

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -250,5 +250,5 @@
     "shelf_meters": 91.1,
     "books_with_pages": 3267
   },
-  "generated_at": "2026-05-01T11:57:00.656015"
+  "generated_at": "2026-05-01T14:03:20.823695"
 }

--- a/src/pages/authors/[slug].astro
+++ b/src/pages/authors/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { priorityLabel, priorityBadgeClass, pluralize, thumbnailUrl } from '../../utils/formatting';
+import { priorityLabel, priorityBadgeClass, pluralize, thumbnailUrl, authorMatches } from '../../utils/formatting';
 
 export async function getStaticPaths() {
   const allAuthors = await getCollection('authors');
@@ -9,7 +9,7 @@ export async function getStaticPaths() {
 
   return allAuthors.map(author => {
     const authorBooks = allBooks
-      .filter(b => b.data.author === author.data.name)
+      .filter(b => authorMatches(b.data.author, author.data.name))
       .sort((a, b) => a.data.priority - b.data.priority || a.data.title.localeCompare(b.data.title));
 
     return {

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { priorityLabel, priorityClass, toSlug, statusLabel, statusClass } from '../../utils/formatting';
+import { priorityLabel, priorityClass, toSlug, statusLabel, statusClass, parseAuthors } from '../../utils/formatting';
 import ShareButton from '../../components/ShareButton.svelte';
 
 export async function getStaticPaths() {
@@ -76,9 +76,18 @@ const categorySlug = toSlug(book.category);
         <h1 class="heading-xl mb-2">{book.title}</h1>
         <p class="text-muted mb-4">by {book.author === 'Unknown' ? (
           <span class="text-dim">{book.author}</span>
-        ) : (
-          <a href={`${base}authors/${toSlug(book.author)}/`} class="ext-link">{book.author}</a>
-        )}</p>
+        ) : (() => {
+          const parsed = parseAuthors(book.author);
+          if (!parsed.isJoint) {
+            return <a href={`${base}authors/${toSlug(book.author)}/`} class="ext-link">{book.author}</a>;
+          }
+          return parsed.parts.map((part, i) => (
+            <>
+              {i > 0 && <span class="text-dim"> · </span>}
+              <a href={`${base}authors/${toSlug(part)}/`} class="ext-link">{part}</a>
+            </>
+          ));
+        })()}</p>
 
         <div class="flex flex-wrap items-center gap-2 mb-4">
           {book.reading_status && (

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -9,6 +9,8 @@ import {
   pluralize,
   seededShuffle,
   thumbnailUrl,
+  parseAuthors,
+  authorMatches,
 } from './formatting.js';
 
 describe('toSlug', () => {
@@ -175,5 +177,96 @@ describe('seededShuffle', () => {
 
   it('handles single-element array', () => {
     expect(seededShuffle([1], 42)).toEqual([1]);
+  });
+});
+
+describe('parseAuthors', () => {
+  it('returns single part for plain name', () => {
+    const r = parseAuthors('Plato');
+    expect(r.isJoint).toBe(false);
+    expect(r.parts).toEqual(['Plato']);
+  });
+
+  it('splits on ampersand', () => {
+    const r = parseAuthors('Robert Jordan & Brandon Sanderson');
+    expect(r.isJoint).toBe(true);
+    expect(r.parts).toEqual(['Robert Jordan', 'Brandon Sanderson']);
+  });
+
+  it('splits on " and "', () => {
+    const r = parseAuthors('Brian W. Kernighan and Rob Pike');
+    expect(r.isJoint).toBe(true);
+    expect(r.parts).toEqual(['Brian W. Kernighan', 'Rob Pike']);
+  });
+
+  it('splits on comma when each part is multi-word', () => {
+    const r = parseAuthors('Niccolò Machiavelli, Stephen Brennan');
+    expect(r.isJoint).toBe(true);
+    expect(r.parts).toEqual(['Niccolò Machiavelli', 'Stephen Brennan']);
+  });
+
+  it('does NOT split when parts would be single-word', () => {
+    // Initials with commas like "L., M." should NOT split
+    const r = parseAuthors('A.A. Milne');
+    expect(r.isJoint).toBe(false);
+    expect(r.parts).toEqual(['A.A. Milne']);
+  });
+
+  it('preserves the original string', () => {
+    expect(parseAuthors('Karl Marx and Friedrich Engels').original).toBe(
+      'Karl Marx and Friedrich Engels',
+    );
+  });
+
+  it('handles three-author entries', () => {
+    const r = parseAuthors('Abraham Silberschatz, Peter Galvin, Greg Gagne');
+    expect(r.parts.length).toBe(3);
+  });
+
+  it('splits single-word last names joined by ampersand', () => {
+    const r = parseAuthors('Marx & Engels');
+    expect(r.isJoint).toBe(true);
+    expect(r.parts).toEqual(['Marx', 'Engels']);
+  });
+
+  it('does not split "Last, First" notation', () => {
+    // "Smith, John" is library-catalog notation, not two authors.
+    const r = parseAuthors('Smith, John');
+    expect(r.isJoint).toBe(false);
+    expect(r.parts).toEqual(['Smith, John']);
+  });
+});
+
+describe('authorMatches', () => {
+  it('matches exact full string', () => {
+    expect(authorMatches('Plato', 'Plato')).toBe(true);
+  });
+
+  it('matches the joint string against its own page', () => {
+    // The joint-string author detail page (which exists historically) still works.
+    expect(
+      authorMatches(
+        'Robert Jordan & Brandon Sanderson',
+        'Robert Jordan & Brandon Sanderson',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches a component name', () => {
+    expect(
+      authorMatches('Robert Jordan & Brandon Sanderson', 'Robert Jordan'),
+    ).toBe(true);
+    expect(
+      authorMatches('Robert Jordan & Brandon Sanderson', 'Brandon Sanderson'),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated names', () => {
+    expect(authorMatches('Plato', 'Aristotle')).toBe(false);
+  });
+
+  it('does not match a substring (e.g. last name)', () => {
+    // We want exact part match, not substring.
+    expect(authorMatches('Robert Jordan & Brandon Sanderson', 'Jordan')).toBe(false);
   });
 });

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -78,3 +78,52 @@ function dayOfYear(): number {
   const start = new Date(now.getFullYear(), 0, 0);
   return Math.floor((now.getTime() - start.getTime()) / 86400000);
 }
+
+/**
+ * Split a multi-author byline ("Robert Jordan & Brandon Sanderson") into
+ * its component author names. Handles `&`, ` and `, ` with `, `, `, `/`.
+ *
+ * Each part must be at least two whitespace-separated tokens — this avoids
+ * splitting initials like "L., M.", or single-name pen names with commas.
+ *
+ * Returns `parts: [originalString]` and `isJoint: false` when no split applies,
+ * so callers can iterate `parts` uniformly.
+ */
+export interface AuthorParts {
+  original: string;
+  parts: string[];
+  isJoint: boolean;
+}
+
+// Strong separators always indicate joint authorship — split unconditionally.
+const STRONG_SEPARATORS = /\s*(?:&| and | with |\/)\s*/i;
+// Comma is ambiguous: "Smith, John" is "Last, First" notation, not joint authors.
+// Only treat comma as a separator when each part has 2+ whitespace-separated tokens.
+const COMMA_SEPARATOR = /\s*,\s*/;
+
+export function parseAuthors(name: string): AuthorParts {
+  const strong = name.split(STRONG_SEPARATORS).map((p) => p.trim()).filter((p) => p.length > 0);
+  if (strong.length >= 2) {
+    return { original: name, parts: strong, isJoint: true };
+  }
+  const commaSplit = name
+    .split(COMMA_SEPARATOR)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0 && p.split(/\s+/).length >= 2);
+  if (commaSplit.length >= 2) {
+    return { original: name, parts: commaSplit, isJoint: true };
+  }
+  return { original: name, parts: [name], isJoint: false };
+}
+
+/**
+ * True when an author detail page (for `authorName`) should claim the given
+ * book. Matches both an exact match against the book's full author string
+ * (which includes the existing joint-string records like
+ * "Robert Jordan & Brandon Sanderson") and component-name matches (so the
+ * "Robert Jordan" page also picks up the same book).
+ */
+export function authorMatches(bookAuthor: string, authorName: string): boolean {
+  if (bookAuthor === authorName) return true;
+  return parseAuthors(bookAuthor).parts.includes(authorName);
+}


### PR DESCRIPTION
## What

Books with joint-author bylines like \`\"Robert Jordan & Brandon Sanderson\"\` previously linked to a single joint-string author page (often a stub with no bio). The richer per-author bios were accessible only by typing the URL.

Now the book detail byline renders **each author as a separate link**:

| Book | Before | After |
|---|---|---|
| Communist Manifesto | by Marx & Engels (1 link → joint stub) | by **Marx · Engels** (2 links → individual pages) |
| Good Omens | by Terry Pratchett & Neil Gaiman (1 joint link) | by **Terry Pratchett · Neil Gaiman** |
| A Memory of Light | by Robert Jordan & Brandon Sanderson | each linked separately |

Closes #106 with the click-through pattern you preferred over the bio-fallback option.

## How

### \`src/utils/formatting.ts\` — new helpers

- **\`parseAuthors(name)\`** splits on \`&\`, \` and \`, \` with \`, \`/\` *unconditionally*; on comma only when each side has 2+ tokens (avoids splitting library-catalog \"Last, First\" notation).
- **\`authorMatches(bookAuthor, authorName)\`** returns true when an author detail page should claim the book — matches both exact full-string and component-name. Existing joint-string author pages still find their books AND the new component-author pages find theirs.

### \`src/pages/books/[slug].astro\`

Byline renders one link per author when \`isJoint\`, separated by \" · \". Single-author books unchanged.

### \`src/pages/authors/[slug].astro\`

\`getStaticPaths\` filter switches from strict equality to \`authorMatches()\`, so e.g. \`/authors/marx/\` finds all books where Marx appears as a component.

### \`scripts/generate-author-stubs.py\`

For each book, attribute to both the full author string AND each component name. Joint-string records preserved for backward-compat with existing URLs; new component records auto-generated as part of prebuild.

\`\`\`
Distinct author identities (full strings + components): 1923 (was 1671)
Created stubs:                                          265 new component pages
\`\`\`

## Tests — 47/47 vitest

14 new tests in \`src/utils/formatting.test.ts\`:
- 9 \`parseAuthors\`: ampersand, \" and \", comma-with-multi-word, single-word ampersand (Marx & Engels), \"Last, First\" notation correctly NOT split, three-author entries, originals preserved
- 5 \`authorMatches\`: exact, joint-string-self, component match (both directions), unrelated, not-substring (\"Jordan\" should NOT match the joint string)

| Suite | Before | After |
|---|---|---|
| vitest | 33 | **47** (+14) |
| pytest | 124 | 124 |
| typecheck | 0/0/0 | 0/0/0 |

## Verified live in /chrome

- \`/books/communist-manifesto/\` — byline shows \"by Marx · Engels\" with two separate links
- \`/books/good-omens/\` — byline shows \"by Terry Pratchett · Neil Gaiman\" with two links
- \`/authors/karl-marx/\` — finds 8 books (was 0 before; now picks up component matches)

Closes #106. Part of epic #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)