### PR TITLE
fix(ci): cap cache-photos step to 5 min + 200 photos per deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,8 +73,12 @@ jobs:
           restore-keys: |
             photo-cache-v1-
 
-      - name: Download missing photos
-        run: python3 scripts/cache-photos.py
+      # Chunked approach so a build never burns more than ~5 minutes on cache
+      # population — see #109. After ~20 deploys the cache converges and the
+      # --limit becomes mostly a no-op (idempotent skip on already-cached).
+      - name: Download missing photos (chunked)
+        run: python3 scripts/cache-photos.py --limit 200
+        timeout-minutes: 5
         # cache-photos.py is fault-tolerant — failures leave upstream URLs in
         # place, and the runtime broken-image fallback handles any that 404.
         continue-on-error: true


### PR DESCRIPTION
## What

Closes #109. The first run of \`cache-photos.py\` in CI tried to fetch all ~4,300 photos at the rate limit and ran for **48 minutes** before being cancelled. Subsequent deploys would have been fast (cache restored) but the bootstrap is too slow for an inline build step.

## Mitigation

Chunked + timed:

\`\`\`yaml
- name: Download missing photos (chunked)
  run: python3 scripts/cache-photos.py --limit 200
  timeout-minutes: 5
  continue-on-error: true
\`\`\`

- \`--limit 200\` — cap per deploy; ~20 deploys to converge
- \`timeout-minutes: 5\` — hard cap so the queue can't back up again
- \`continue-on-error: true\` — already there; keeps build alive on timeout

The idempotent skip on already-cached files means once the cache converges, the \`--limit\` becomes a no-op and the step finishes in seconds.

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)