### PR TITLE
feat(tags): /tags/ landing pages for genre discovery

### DIFF
--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -23,7 +23,10 @@ const base = import.meta.env.BASE_URL;
 
 <Layout title="Categories">
   <h1 class="heading-xl mb-2">Categories</h1>
-  <p class="text-muted text-sm mb-8">{categories.length} categories — everything from ancient philosophy to software security, because why limit yourself.</p>
+  <p class="text-muted text-sm mb-2">{categories.length} categories — the primary classification, mostly aligned with library Dewey/LC.</p>
+  <p class="text-dim text-sm mb-8">
+    Genre cuts across categories. To browse <a href={`${base}tags/`} class="ext-link" style="text-decoration: underline">by tag</a> instead — sci-fi, fantasy, mystery, etc.
+  </p>
 
   <div class="grid sm-grid-2 md-grid-3 lg-grid-4 gap-3">
     {categories.map(cat => (

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,89 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { priorityLabel, priorityBadgeClass, toSlug, pluralize, thumbnailUrl } from '../../utils/formatting';
+
+export async function getStaticPaths() {
+  const books = await getCollection('books');
+  // tag-name → { display: original tag string, books: [...] }
+  const tagMap = new Map<string, { name: string; books: typeof books }>();
+  for (const book of books) {
+    for (const tag of (book.data.tags ?? [])) {
+      const slug = toSlug(tag);
+      if (!tagMap.has(slug)) tagMap.set(slug, { name: tag, books: [] });
+      tagMap.get(slug)!.books.push(book);
+    }
+  }
+  const TOP = 60;
+  return [...tagMap.entries()].map(([slug, { name, books: tagged }]) => {
+    const sorted = tagged.sort(
+      (a, b) => a.data.priority - b.data.priority || a.data.title.localeCompare(b.data.title)
+    );
+    return {
+      params: { tag: slug },
+      props: {
+        tagName: name,
+        topBooks: sorted.slice(0, TOP),
+        totalCount: sorted.length,
+        topLimit: TOP,
+      },
+    };
+  });
+}
+
+const { tagName, topBooks, totalCount, topLimit } = Astro.props;
+const base = import.meta.env.BASE_URL;
+const hasOverflow = totalCount > topLimit;
+---
+
+<Layout title={`${tagName} — Tagged`} description={`${totalCount} ${tagName} books in the tsundoku collection`}>
+  <nav class="breadcrumb">
+    <a href={`${base}`}>Home</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}tags/`}>Tags</a>
+    <span class="breadcrumb-sep">/</span>
+    <span class="breadcrumb-current">{tagName}</span>
+  </nav>
+
+  <h1 class="heading-xl mb-2">#{tagName}</h1>
+  <p class="text-muted text-sm mb-8">
+    {totalCount.toLocaleString()} {pluralize(totalCount, 'book')} tagged <strong>{tagName}</strong>
+    {hasOverflow && (<> · showing top {topLimit}</>)}
+  </p>
+
+  <div class="grid sm-grid-2 lg-grid-4 gap-3">
+    {topBooks.map(book => (
+      <a href={`${base}books/${book.data.slug}/`} class="card book-cover-group book-card-compact">
+        {book.data.cover_url ? (
+          <img src={thumbnailUrl(book.data.cover_url)} alt="" width="48" height="72" class="book-cover book-thumb" loading="lazy" transition:name={`cover-${book.data.slug}`} />
+        ) : (
+          <div class="book-thumb-placeholder" aria-hidden="true">
+            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+            </svg>
+          </div>
+        )}
+        <div class="book-card-body">
+          <div class="flex items-center justify-between gap-1 mb-2">
+            <span class={priorityBadgeClass(book.data.priority)}>
+              {priorityLabel(book.data.priority)}
+            </span>
+            {book.data.first_published && (
+              <span class="text-xs text-dim">{book.data.first_published}</span>
+            )}
+          </div>
+          <h3 class="text-sm font-bold line-clamp-2 mb-1">{book.data.title}</h3>
+          <p class="text-xs text-dim truncate">{book.data.author}</p>
+          <p class="text-xs text-dim truncate mt-1">{book.data.category}</p>
+        </div>
+      </a>
+    ))}
+  </div>
+
+  {hasOverflow && (
+    <div class="mt-2 text-center text-sm text-muted">
+      Showing top {topLimit} of {totalCount.toLocaleString()}. To see all,
+      use the genre filter on the <a href={`${base}browse/`} class="ext-link">browse page</a>.
+    </div>
+  )}
+</Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,66 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug, pluralize } from '../../utils/formatting';
+
+const books = await getCollection('books');
+const base = import.meta.env.BASE_URL;
+
+// Tags that are list-source markers, not topical genres — show separately.
+const META_TAGS = new Set([
+  'google-play-library',
+  'le-monde-100',
+  'npr-top-100-sff',
+  'r-philosophy',
+]);
+
+const tagCounts = new Map<string, number>();
+for (const book of books) {
+  for (const t of (book.data.tags ?? [])) {
+    tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+  }
+}
+
+const allTags = [...tagCounts.entries()]
+  .map(([tag, count]) => ({ tag, count, slug: toSlug(tag), isMeta: META_TAGS.has(tag) }))
+  .sort((a, b) => b.count - a.count);
+
+const genreTags = allTags.filter(t => !t.isMeta);
+const listTags = allTags.filter(t => t.isMeta);
+---
+
+<Layout title="Tags" description={`Browse books by ${genreTags.length} genre tags — sci-fi, fantasy, mystery, etc.`}>
+  <h1 class="heading-xl mb-2">Tags</h1>
+  <p class="text-muted text-sm mb-6">
+    {genreTags.length} genre tags — books often live across multiple genres,
+    so this is the cross-cutting view that the categories don't capture.
+  </p>
+
+  <!-- Genre tag tiles -->
+  <nav aria-label="Browse by genre tag" class="grid sm-grid-2 md-grid-3 lg-grid-4 gap-2 mb-8">
+    {genreTags.map(({ tag, count, slug }) => (
+      <a href={`${base}tags/${slug}/`} class="cat-tile">
+        <span>{tag}</span>
+        <span class="cat-tile-count">{count} {pluralize(count, 'book')}</span>
+      </a>
+    ))}
+  </nav>
+
+  {listTags.length > 0 && (
+    <>
+      <hr class="section-divider" />
+      <h2 class="heading-md mb-4">From specific lists</h2>
+      <p class="text-muted text-sm mb-6">
+        Tags marking books that came in via a particular reading list.
+      </p>
+      <nav aria-label="Browse by list source" class="grid sm-grid-2 md-grid-3 lg-grid-4 gap-2">
+        {listTags.map(({ tag, count, slug }) => (
+          <a href={`${base}tags/${slug}/`} class="cat-tile">
+            <span>{tag}</span>
+            <span class="cat-tile-count">{count} {pluralize(count, 'book')}</span>
+          </a>
+        ))}
+      </nav>
+    </>
+  )}
+</Layout>


### PR DESCRIPTION
## What

After PR #117 consolidated genre fiction into Literature per library convention, genre browsing relied on the \`/browse/\` tag filter. This adds explicit \`/tags/\` navigation so readers can discover \"all sci-fi\" or \"all mystery\" books regardless of primary category.

## Pages

- **\`/tags/\`** — index of all 39 tags with counts. Genre tags first, list-source tags (le-monde-100, npr-top-100-sff) in a separate section.
- **\`/tags/[tag]/\`** — per-tag detail page mirroring the category detail layout. Top 60 by priority then title; overflow link to /browse/ filter.
- **\`/categories/\`** — adds a one-line link explaining the relationship: \"Genre cuts across categories. To browse by tag instead — sci-fi, fantasy, mystery, etc.\"

## Numbers

| Tag | Books |
|---|---|
| sci-fi | 345 |
| fantasy | 322 |
| philosophy | 248 |
| computing | 214 |
| mystery | 186 |
| poetry | 148 |
| horror | 82 |

## Test plan
- [x] \`npm run typecheck\` — 0/0/0
- [x] \`npm test\` — 47/47
- [x] \`pytest scripts/\` — 183/183
- [x] /chrome verification: /tags/, /tags/sci-fi/, breadcrumb, axe-core 0 violations

Part of #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)