### PR TITLE
fix(a11y): underline inline ext-link on tag overflow message

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -83,7 +83,7 @@ const hasOverflow = totalCount > topLimit;
   {hasOverflow && (
     <div class="mt-2 text-center text-sm text-muted">
       Showing top {topLimit} of {totalCount.toLocaleString()}. To see all,
-      use the genre filter on the <a href={`${base}browse/`} class="ext-link">browse page</a>.
+      use the genre filter on the <a href={`${base}browse/`} class="ext-link" style="text-decoration: underline">browse page</a>.
     </div>
   )}
 </Layout>


### PR DESCRIPTION
## What

axe-core flagged \`link-in-text-block\` (serious) on \`/tags/[tag]/\` overflow message: \`<a class=\"ext-link\">browse page</a>\` inside paragraph text is differentiated only by color, which fails WCAG 2.1 SC 1.4.1.

One-character inline-style fix. Same pattern used in #118 for the /categories/ \"by tag\" link.

axe-core on \`/tags/sci-fi/\` now clean.