### PR TITLE
fix(validate): treat 429/5xx as transient — never clear rate-limited URLs

### DIFF
--- a/scripts/test_validate_photo_urls.py
+++ b/scripts/test_validate_photo_urls.py
@@ -60,6 +60,37 @@ class TestHeadProbeClassification:
         result = validator.head_probe("https://example.com/slow.jpg")
         assert result is None
 
+    def test_handles_429_rate_limit_returns_none(self, monkeypatch):
+        """429 is rate-limit, not 'URL is dead'. Must not get cleared."""
+        from urllib.error import HTTPError
+
+        def fake_urlopen(*args, **kwargs):
+            raise HTTPError("u", 429, "Too Many Requests", {}, None)
+
+        monkeypatch.setattr(validator, "urlopen", fake_urlopen)
+        assert validator.head_probe("https://example.com/x.jpg") is None
+
+    def test_handles_503_server_error_returns_none(self, monkeypatch):
+        """5xx is transient, not definitive."""
+        from urllib.error import HTTPError
+
+        def fake_urlopen(*args, **kwargs):
+            raise HTTPError("u", 503, "Service Unavailable", {}, None)
+
+        monkeypatch.setattr(validator, "urlopen", fake_urlopen)
+        assert validator.head_probe("https://example.com/x.jpg") is None
+
+    def test_410_gone_is_definitive_dead(self, monkeypatch):
+        """410 is the same as 404 for our purposes — definitively dead."""
+        from urllib.error import HTTPError
+
+        def fake_urlopen(*args, **kwargs):
+            raise HTTPError("u", 410, "Gone", {}, None)
+
+        monkeypatch.setattr(validator, "urlopen", fake_urlopen)
+        result = validator.head_probe("https://example.com/x.jpg")
+        assert result == {"status": 410, "ok": False}
+
 
 class TestProbeCacheBehavior:
     """The cache layer should make repeat probes cheap."""

--- a/scripts/validate-photo-urls.py
+++ b/scripts/validate-photo-urls.py
@@ -33,22 +33,37 @@ HEAD_TIMEOUT = 10  # seconds — should be plenty for a HEAD
 
 def head_probe(url: str) -> dict | None:
     """Single HEAD request. Returns:
-      {'status': int, 'ok': bool}  for any HTTP response (200, 404, etc.)
-      None                          for network errors / timeouts
+      {'status': int, 'ok': bool}  for definitive HTTP responses
+      None                          for transient errors (429 rate limit,
+                                    5xx, network blip, timeout) — caller
+                                    treats as unknown and retries later
+
+    Definitive 4xx (404, 410, 401, 403) → ok=False (clear the URL).
+    Transient (429, 5xx) → None (don't draw any conclusion).
     """
     req = Request(url, method="HEAD", headers={"User-Agent": USER_AGENT})
     try:
         with urlopen(req, timeout=HEAD_TIMEOUT) as resp:
             return {"status": resp.status, "ok": resp.status < 400}
     except HTTPError as e:
-        # 4xx is a real answer — cache it as a (cached) negative
+        # 429 = rate limited; 5xx = server hiccup. Both are NOT proof the URL
+        # is dead — treat as unknown so we don't wrongly clear good URLs when
+        # the upstream is just having a moment.
+        if e.code == 429 or 500 <= e.code < 600:
+            return None
+        # Genuine 4xx (404, 410, 401, 403) — cache as confirmed dead.
         return {"status": e.code, "ok": False}
     except (URLError, TimeoutError, OSError):
         return None  # Network blip — don't cache; retry next run
 
 
-def probe(url: str, source: str = "photo-validator") -> dict | None:
-    """Cache-aware HEAD probe. Cache key is the URL itself."""
+def probe(url: str, source: str = "photo-validator-v2") -> dict | None:
+    """Cache-aware HEAD probe. Cache key is the URL itself.
+
+    Source name bumped to v2 when we changed head_probe to return None for
+    429/5xx — old cache entries had ok=False for 429, which would still
+    misclassify rate-limited URLs as dead.
+    """
     return cached_fetch(source, url, lambda: head_probe(url), url=url)
 
 


### PR DESCRIPTION
## What

\`validate-photo-urls.py\` incorrectly classified rate-limit (429) responses as \"URL is dead.\" If \`--apply\` had been run during this session, **65% of author photo_urls would have been wrongly cleared** — Wikimedia was rate-limiting us hard, and 65/100 sample probes hit 429.

## Fix

\`head_probe\` now returns:
- \`{status, ok: True}\` for 200-399
- \`{status: 4xx, ok: False}\` for **definitive** 4xx (404, 410, 401, 403) → caller clears the URL
- \`None\` for **transient** errors (429, 5xx, network blip, timeout) → caller leaves URL alone, retry next run

Cache namespace bumped to \`photo-validator-v2\` so the old 429-cached entries (which had \`ok=False\`) don't keep biasing classification on subsequent runs.

## Tests — 10/10 (was 7)

3 new cases:
- \`test_handles_429_rate_limit_returns_none\`
- \`test_handles_503_server_error_returns_none\`
- \`test_410_gone_is_definitive_dead\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)