### PR TITLE
feat(authors): hide joint-name aliases from listings

### DIFF
--- a/src/pages/authors/[letter].astro
+++ b/src/pages/authors/[letter].astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { toSlug } from '../../utils/formatting';
+import { toSlug, isJointAlias } from '../../utils/formatting';
 
 const base = import.meta.env.BASE_URL;
 
@@ -22,16 +22,24 @@ export async function getStaticPaths() {
     authorMap.set(book.data.author, (authorMap.get(book.data.author) ?? 0) + 1);
   }
 
-  const allAuthors = [...authorMap.entries()].map(([name, count]) => {
-    const enriched = enrichedMap.get(name);
-    return {
-      name,
-      count,
-      slug: enriched?.slug ?? toSlug(name),
-      photo_url: enriched?.photo_url,
-      hasDetailPage: enrichedMap.has(name),
-    };
-  });
+  // Set of all author records by name — used to detect joint-name aliases
+  // ("Robert Jordan & Brandon Sanderson") whose components have their own
+  // records. We hide aliases from the listing to reduce noise; the URLs
+  // still work for back-compat with anyone holding a bookmark.
+  const knownAuthorNames = new Set(enrichedAuthors.map(a => a.data.name));
+
+  const allAuthors = [...authorMap.entries()]
+    .filter(([name]) => !isJointAlias(name, knownAuthorNames))
+    .map(([name, count]) => {
+      const enriched = enrichedMap.get(name);
+      return {
+        name,
+        count,
+        slug: enriched?.slug ?? toSlug(name),
+        photo_url: enriched?.photo_url,
+        hasDetailPage: enrichedMap.has(name),
+      };
+    });
 
   const groups = new Map<string, typeof allAuthors>();
   for (const a of allAuthors) {

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { toSlug } from '../../utils/formatting';
+import { toSlug, isJointAlias } from '../../utils/formatting';
 
 const books = await getCollection('books');
 const enrichedAuthors = await getCollection('authors');
@@ -21,16 +21,23 @@ for (const book of books) {
   authorMap.set(author, (authorMap.get(author) ?? 0) + 1);
 }
 
-const allAuthors = [...authorMap.entries()].map(([name, count]) => {
-  const enriched = enrichedMap.get(name);
-  return {
-    name,
-    count,
-    slug: enriched?.slug ?? toSlug(name),
-    photo_url: enriched?.photo_url,
-    hasDetailPage: enrichedMap.has(name),
-  };
-});
+// Hide joint-name aliases (e.g. "Robert Jordan & Brandon Sanderson") from
+// listings — each component has its own record per the splitting in #108.
+// URLs still work for back-compat.
+const knownAuthorNames = new Set(enrichedAuthors.map(a => a.data.name));
+
+const allAuthors = [...authorMap.entries()]
+  .filter(([name]) => !isJointAlias(name, knownAuthorNames))
+  .map(([name, count]) => {
+    const enriched = enrichedMap.get(name);
+    return {
+      name,
+      count,
+      slug: enriched?.slug ?? toSlug(name),
+      photo_url: enriched?.photo_url,
+      hasDetailPage: enrichedMap.has(name),
+    };
+  });
 
 function letterKey(c: string): string {
   const lc = c.toLowerCase();

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -11,6 +11,7 @@ import {
   thumbnailUrl,
   parseAuthors,
   authorMatches,
+  isJointAlias,
 } from './formatting.js';
 
 describe('toSlug', () => {
@@ -268,5 +269,34 @@ describe('authorMatches', () => {
   it('does not match a substring (e.g. last name)', () => {
     // We want exact part match, not substring.
     expect(authorMatches('Robert Jordan & Brandon Sanderson', 'Jordan')).toBe(false);
+  });
+});
+
+describe('isJointAlias', () => {
+  it('false for plain author names', () => {
+    expect(isJointAlias('Plato', new Set(['Plato']))).toBe(false);
+  });
+
+  it('true for joint name with both components in known set', () => {
+    const known = new Set(['Robert Jordan', 'Brandon Sanderson']);
+    expect(isJointAlias('Robert Jordan & Brandon Sanderson', known)).toBe(true);
+  });
+
+  it('false for joint name with missing component', () => {
+    // If one component is missing from the catalog, the joint record carries
+    // useful info — don't hide it.
+    const known = new Set(['Robert Jordan']);
+    expect(isJointAlias('Robert Jordan & Brandon Sanderson', known)).toBe(false);
+  });
+
+  it('handles three-author joints joined by comma (multi-word names)', () => {
+    const known = new Set(['Niccolò Machiavelli', 'Stephen Brennan', 'Some Other']);
+    expect(
+      isJointAlias('Niccolò Machiavelli, Stephen Brennan', known),
+    ).toBe(true);
+  });
+
+  it('false when not a joint name', () => {
+    expect(isJointAlias('A.A. Milne', new Set(['A.A. Milne']))).toBe(false);
   });
 });

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -127,3 +127,17 @@ export function authorMatches(bookAuthor: string, authorName: string): boolean {
   if (bookAuthor === authorName) return true;
   return parseAuthors(bookAuthor).parts.includes(authorName);
 }
+
+/**
+ * True when this author record is a joint-name alias (e.g. "Robert Jordan &
+ * Brandon Sanderson") AND each component author has its own record. Such
+ * aliases are effectively duplicates of their component records — useful for
+ * URL back-compat but noise in author listings.
+ *
+ * Pass `knownAuthorNames` as a Set for O(1) lookup.
+ */
+export function isJointAlias(name: string, knownAuthorNames: Set<string>): boolean {
+  const { isJoint, parts } = parseAuthors(name);
+  if (!isJoint) return false;
+  return parts.every((p) => knownAuthorNames.has(p));
+}


### PR DESCRIPTION
## What

After #108 split joint-author book bylines into individual records, joint-string author records like \`Robert Jordan & Brandon Sanderson\` became aliases — both components have their own pages. They still appeared in /authors/[letter]/ listings and the Most Prolific section as noise.

This filters them out of listings when **all** component authors have their own records.

## Audit

\`\`\`
Joint-name records: 105
With all components having own records: 105   ← 100%
\`\`\`

100% safe to hide. URLs continue to resolve for back-compat (book detail pages still link via canonical \`/authors/{slug}/\` paths if any external bookmarks exist).

## Code

**\`isJointAlias(name, knownAuthorNames)\`** — new helper in \`formatting.ts\`. True if name is joint AND every component is in the known set.

Used in:
- \`src/pages/authors/[letter].astro\` getStaticPaths
- \`src/pages/authors/index.astro\` Most Prolific source

5 new tests for the helper.

## Test plan
- [x] vitest 52/52 (was 47)
- [x] pytest 183/183
- [x] typecheck 0/0/0
- [x] Joint URLs still resolve (filter is on listings, not paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)