### PR TITLE
Browse-grid LCC labels + search-index keyword bag

### DIFF
--- a/scripts/generate-browse-data.py
+++ b/scripts/generate-browse-data.py
@@ -37,6 +37,13 @@ def main() -> None:
             entry["y"] = d["first_published"]
         if d.get("reading_status"):
             entry["rs"] = d["reading_status"]
+        # First LCC class only (e.g. "PR-6029.00000000.R8 Ni2") — used as
+        # a spine-label on the book card. Browse-grid renders the human-
+        # readable form via the same JS `lccDisplay` shape used on book
+        # detail pages.
+        lcc = d.get("lcc") or []
+        if lcc:
+            entry["lc"] = lcc[0]
         tags = d.get("tags") or []
         if tags:
             entry["g"] = tags

--- a/scripts/generate-search-index.py
+++ b/scripts/generate-search-index.py
@@ -17,28 +17,52 @@ OUTPUT = Path(__file__).parent.parent / "public" / "search-index.json"
 def main() -> None:
     items = []
 
-    # Books
+    # Books — `k` is a hidden keyword bag the search modal also queries,
+    # so users can find "1984" by typing "Big Brother" (translator),
+    # "Wheel of Time" (series), "Umibe no Kafuka" (original title), etc.
     for bp in sorted(BOOKS_DIR.glob("*.json")):
         d = json.loads(bp.read_text())
-        items.append({
+        keywords: list[str] = []
+        if d.get("original_title") and d["original_title"] != d["title"]:
+            keywords.append(d["original_title"])
+        series = d.get("series") or {}
+        if series.get("name"):
+            keywords.append(series["name"])
+        if d.get("translator"):
+            keywords.append(d["translator"])
+        # First subject_facet entry is often a recognizable theme tag
+        for s in (d.get("subject_facet") or [])[:3]:
+            keywords.append(s)
+        entry = {
             "t": d["title"],
             "s": f'{d.get("author", "")} — {d.get("category", "")}',
             "u": f"books/{d['slug']}/",
             "y": "book",
             "c": d.get("cover_url", ""),
-        })
+        }
+        if keywords:
+            entry["k"] = " ".join(keywords)
+        items.append(entry)
 
-    # Authors
+    # Authors — `k` includes alternate_names so users can find George Eliot
+    # by typing "Mary Ann Evans".
     if AUTHORS_DIR.exists():
         for ap in sorted(AUTHORS_DIR.glob("*.json")):
             d = json.loads(ap.read_text())
-            items.append({
+            keywords: list[str] = []
+            for n in (d.get("alternate_names") or []):
+                if n and n.lower() != d["name"].lower():
+                    keywords.append(n)
+            entry = {
                 "t": d["name"],
                 "s": f'{d.get("book_count", 0)} books',
                 "u": f"authors/{d['slug']}/",
                 "y": "author",
                 "c": d.get("photo_url", ""),
-            })
+            }
+            if keywords:
+                entry["k"] = " ".join(keywords)
+            items.append(entry)
 
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(json.dumps(items, separators=(",", ":")))

--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -12,12 +12,21 @@
     first_published?: number;
     reading_status?: 'want' | 'reading' | 'read';
     tags?: string[];
+    lcc?: string;
   }
 
   // Compact wire format from /browse-data.json — keep keys short to shrink payload.
   interface WireBook {
     t: string; a: string; s: string; p: number; cat: string;
-    co?: string; y?: number; rs?: 'want' | 'reading' | 'read'; g?: string[];
+    co?: string; y?: number; rs?: 'want' | 'reading' | 'read'; g?: string[]; lc?: string;
+  }
+
+  function lccDisplay(lcc: string): string {
+    return lcc
+      .replace(/^([A-Z]+)-+(\d)/, '$1$2')
+      .replace(/\.0+(?=\D|$)/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
   interface BrowseData { books: WireBook[]; categories: string[]; tags: string[]; }
 
@@ -51,6 +60,7 @@
         first_published: b.y,
         reading_status: b.rs,
         tags: b.g,
+        lcc: b.lc,
       }));
       categories = data.categories;
       tags = data.tags;
@@ -213,6 +223,9 @@
                   <span class="book-year">{book.first_published}</span>
                 {/if}
               </div>
+              {#if book.lcc}
+                <span class="book-call-number" title="Library of Congress call number">{lccDisplay(book.lcc)}</span>
+              {/if}
               <h3 class="book-title">{book.title}</h3>
               <p class="book-author">{book.author}</p>
               <div class="book-footer">
@@ -552,6 +565,18 @@
   .book-author {
     color: var(--text-dim);
     font-size: 0.75rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .book-call-number {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums lining-nums;
+    margin-bottom: 0.125rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -5,6 +5,7 @@
     u: string; // url path (relative to base)
     y: string; // type: book | author
     c: string; // cover/photo url
+    k?: string; // hidden keyword bag — original_title, series, translator, subject_facet, alt names
   }
 
   let { baseUrl = '/' }: { baseUrl?: string } = $props();
@@ -41,7 +42,11 @@
     if (query.length < 2 || !loaded) return [];
     const q = query.toLowerCase();
     return items
-      .filter(item => item.t.toLowerCase().includes(q) || item.s.toLowerCase().includes(q))
+      .filter(item =>
+        item.t.toLowerCase().includes(q)
+        || item.s.toLowerCase().includes(q)
+        || (item.k !== undefined && item.k.toLowerCase().includes(q))
+      )
       .slice(0, 12);
   });
 

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -51,10 +51,12 @@ function compareLcc(a: string, b: string): number {
   return ka[2].localeCompare(kb[2]);
 }
 function lccDisplay(lcc: string): string {
-  // OL pads LCC for sorting — strip leading hyphen between class+number,
-  // collapse all-zero fractional padding, normalize internal whitespace.
+  // OL pads LCC for sorting — single-letter classes get 1-2 dashes
+  // between class and number (e.g. "E--0061..."). Strip ALL leading
+  // dashes between class and number, collapse all-zero fractional
+  // padding, normalize internal whitespace.
   return lcc
-    .replace(/^([A-Z]+)-(\d)/, '$1$2')
+    .replace(/^([A-Z]+)-+(\d)/, '$1$2')
     .replace(/\.0+(?=\D|$)/g, '')
     .replace(/\s+/g, ' ')
     .trim();


### PR DESCRIPTION
## What

Two pieces of #129 sub-epics B + C2 in one cohesive PR (theme: discoverability):

### Browse-grid LCC labels (sub-epic B)

Renders the Library of Congress call number on every card in the browse grid, just below the priority badge — a small monospace tag like a real spine sticker. Pairs with the spine-label-on-cover from #133.

Shared `lccDisplay()` helper in both `BookGrid.svelte` and `[slug].astro` strips OL's sort padding (`E--0061.00000000.M26618 2013` → `E0061.M26618 2013`). Regex tightened to handle the one-or-two-dash variant single-letter classes use.

### Search-index keyword bag (sub-epic C2)

`scripts/generate-search-index.py` now emits an optional `k` field — a hidden keyword bag the modal also queries. Books include original_title, series.name, translator, top-3 subject_facet entries. Authors include alternate_names.

Lets a user find:
- *1984* by typing "Big Brother"
- *Kafka on the Shore* by typing "Umibe no Kafuka" (original title)
- *The Eye of the World* by typing "Wheel of Time" (series)
- George Eliot by typing "Mary Ann Evans" (pen name)

Wire-size cost: search-index 1029KB → 1259KB (+22%); browse-data 826KB → 898KB (+8.7%). Acceptable for the discoverability lift.

## Verified

- ✅ /browse: LCC labels render on every card; OL padding stripped
- ✅ Both themes
- ✅ Modal still searches title+subtitle; new `k` field is additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)