### PR TITLE
Series + awards + movements browse pages (#129 C2)

### DIFF
--- a/src/pages/awards/[slug].astro
+++ b/src/pages/awards/[slug].astro
@@ -1,0 +1,72 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug, priorityClass, priorityLabel, formatYear } from '../../utils/formatting';
+
+export async function getStaticPaths() {
+  const MIN_BOOKS = 3;
+  const books = await getCollection('books');
+  const groups = new Map<string, Array<{ book: typeof books[0]; year?: number }>>();
+
+  for (const b of books) {
+    for (const a of b.data.awards ?? []) {
+      if (!a.name) continue;
+      if (!groups.has(a.name)) groups.set(a.name, []);
+      groups.get(a.name)!.push({ book: b, year: a.year });
+    }
+  }
+
+  return [...groups.entries()]
+    .filter(([, list]) => list.length >= MIN_BOOKS)
+    .map(([name, list]) => ({
+      params: { slug: toSlug(name) },
+      props: {
+        awardName: name,
+        entries: list
+          .sort((a, b) => (a.year ?? 9999) - (b.year ?? 9999))
+          .map(({ book, year }) => ({ ...book.data, _awardYear: year })),
+      },
+    }));
+}
+
+const { awardName, entries } = Astro.props;
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title={awardName} description={`${entries.length} books in the collection that received the ${awardName}`}>
+  <nav class="breadcrumb">
+    <a href={`${base}`}>Home</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}awards/`}>Awards</a>
+    <span class="breadcrumb-sep">/</span>
+    <span class="breadcrumb-current">{awardName}</span>
+  </nav>
+
+  <h1 class="heading-xl mb-2">{awardName}</h1>
+  <p class="text-muted text-sm mb-6">{entries.length} books in the collection.</p>
+
+  <div class="grid sm-grid-2 md-grid-3 gap-3">
+    {entries.map(b => (
+      <a href={`${base}books/${b.slug}/`} class="card related-book">
+        {b.cover_url ? (
+          <img src={b.cover_url} alt={`Cover of ${b.title}`} class="related-book-cover" loading="lazy" />
+        ) : (
+          <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
+        )}
+        <div class="book-card-body">
+          <div class="flex items-center gap-2 mb-1">
+            {b._awardYear && (
+              <span class="text-xs text-mono text-dim">{b._awardYear}</span>
+            )}
+            <span class={priorityClass(b.priority)}>{priorityLabel(b.priority)}</span>
+          </div>
+          <h3 class="text-sm font-bold line-clamp-2 mb-1">{b.title}</h3>
+          <p class="text-xs text-dim line-clamp-1">{b.author}</p>
+          {b.first_published && (
+            <p class="text-xs text-dim">First published {formatYear(b.first_published, b.first_published_circa)}</p>
+          )}
+        </div>
+      </a>
+    ))}
+  </div>
+</Layout>

--- a/src/pages/awards/index.astro
+++ b/src/pages/awards/index.astro
@@ -1,0 +1,36 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug } from '../../utils/formatting';
+
+const MIN_BOOKS = 3;
+
+const books = await getCollection('books');
+const counts = new Map<string, number>();
+for (const b of books) {
+  for (const a of b.data.awards ?? []) {
+    if (!a.name) continue;
+    counts.set(a.name, (counts.get(a.name) ?? 0) + 1);
+  }
+}
+const awards = [...counts.entries()]
+  .filter(([, c]) => c >= MIN_BOOKS)
+  .sort(([a, ac], [b, bc]) => bc - ac || a.localeCompare(b))
+  .map(([name, count]) => ({ name, count, slug: toSlug(name) }));
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title="Awards" description={`${awards.length} awards represented in the collection`}>
+  <h1 class="heading-xl mb-2">Awards</h1>
+  <p class="text-muted text-sm mb-6">{awards.length} awards with {MIN_BOOKS} or more winners on the shelf.</p>
+
+  <div class="grid sm-grid-2 md-grid-3 gap-2">
+    {awards.map(a => (
+      <a href={`${base}awards/${a.slug}/`} class="list-item">
+        <span class="text-sm">{a.name}</span>
+        <span class="ml-auto text-xs text-dim text-mono">{a.count}</span>
+      </a>
+    ))}
+  </div>
+</Layout>

--- a/src/pages/movements/[slug].astro
+++ b/src/pages/movements/[slug].astro
@@ -1,0 +1,93 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug, priorityClass, priorityLabel, formatYear, authorMatches } from '../../utils/formatting';
+
+export async function getStaticPaths() {
+  const MIN_AUTHORS = 3;
+  const authors = await getCollection('authors');
+
+  const groups = new Map<string, typeof authors>();
+  for (const a of authors) {
+    for (const m of a.data.movements ?? []) {
+      if (!groups.has(m)) groups.set(m, []);
+      groups.get(m)!.push(a);
+    }
+  }
+
+  const books = await getCollection('books');
+
+  return [...groups.entries()]
+    .filter(([, list]) => list.length >= MIN_AUTHORS)
+    .map(([name, list]) => {
+      const authorNames = new Set(list.map(a => a.data.name));
+      const movementBooks = books
+        .filter(b => [...authorNames].some(an => authorMatches(b.data.author, an)))
+        .map(b => b.data)
+        .sort((a, b) => (a.first_published ?? 9999) - (b.first_published ?? 9999));
+      return {
+        params: { slug: toSlug(name) },
+        props: {
+          movementName: name,
+          authors: list.map(a => a.data).sort((a, b) => a.name.localeCompare(b.name)),
+          books: movementBooks,
+        },
+      };
+    });
+}
+
+const { movementName, authors, books } = Astro.props;
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title={movementName} description={`${authors.length} authors in the ${movementName} movement, ${books.length} books in the collection`}>
+  <nav class="breadcrumb">
+    <a href={`${base}`}>Home</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}movements/`}>Movements</a>
+    <span class="breadcrumb-sep">/</span>
+    <span class="breadcrumb-current">{movementName}</span>
+  </nav>
+
+  <h1 class="heading-xl mb-2">{movementName}</h1>
+  <p class="text-muted text-sm mb-6">
+    {authors.length} {authors.length === 1 ? 'author' : 'authors'} · {books.length} {books.length === 1 ? 'book' : 'books'} in the collection
+  </p>
+
+  <h2 class="heading-md mb-4">Authors</h2>
+  <div class="grid sm-grid-2 md-grid-3 gap-2 mb-8">
+    {authors.map(a => (
+      <a href={`${base}authors/${a.slug}/`} class="list-item">
+        <span class="text-sm">{a.name}</span>
+        {a.book_count !== undefined && (
+          <span class="ml-auto text-xs text-dim text-mono">{a.book_count}</span>
+        )}
+      </a>
+    ))}
+  </div>
+
+  {books.length > 0 && (
+    <>
+      <h2 class="heading-md mb-4">Books</h2>
+      <div class="grid sm-grid-2 md-grid-3 gap-3">
+        {books.map(b => (
+          <a href={`${base}books/${b.slug}/`} class="card related-book">
+            {b.cover_url ? (
+              <img src={b.cover_url} alt={`Cover of ${b.title}`} class="related-book-cover" loading="lazy" />
+            ) : (
+              <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
+            )}
+            <div class="book-card-body">
+              <span class={priorityClass(b.priority)}>{priorityLabel(b.priority)}</span>
+              <h3 class="text-sm font-bold line-clamp-2 mb-1">{b.title}</h3>
+              <p class="text-xs text-dim line-clamp-1">{b.author}</p>
+              {b.first_published && (
+                <p class="text-xs text-dim">{formatYear(b.first_published, b.first_published_circa)}</p>
+              )}
+            </div>
+          </a>
+        ))}
+      </div>
+    </>
+  )}
+</Layout>

--- a/src/pages/movements/index.astro
+++ b/src/pages/movements/index.astro
@@ -1,0 +1,35 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug } from '../../utils/formatting';
+
+const MIN_AUTHORS = 3;
+
+const authors = await getCollection('authors');
+const counts = new Map<string, number>();
+for (const a of authors) {
+  for (const m of a.data.movements ?? []) {
+    counts.set(m, (counts.get(m) ?? 0) + 1);
+  }
+}
+const movements = [...counts.entries()]
+  .filter(([, c]) => c >= MIN_AUTHORS)
+  .sort(([a, ac], [b, bc]) => bc - ac || a.localeCompare(b))
+  .map(([name, count]) => ({ name, count, slug: toSlug(name) }));
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title="Movements" description={`${movements.length} literary movements represented in the collection`}>
+  <h1 class="heading-xl mb-2">Movements</h1>
+  <p class="text-muted text-sm mb-6">{movements.length} literary movements with {MIN_AUTHORS} or more represented authors.</p>
+
+  <div class="grid sm-grid-2 md-grid-3 gap-2">
+    {movements.map(m => (
+      <a href={`${base}movements/${m.slug}/`} class="list-item">
+        <span class="text-sm">{m.name}</span>
+        <span class="ml-auto text-xs text-dim text-mono">{m.count}</span>
+      </a>
+    ))}
+  </div>
+</Layout>

--- a/src/pages/series/[slug].astro
+++ b/src/pages/series/[slug].astro
@@ -1,0 +1,78 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug, priorityClass, priorityLabel, formatYear } from '../../utils/formatting';
+
+export async function getStaticPaths() {
+  // Astro runs getStaticPaths in an isolated scope — module-level
+  // constants are not visible. Inline the minimum.
+  const MIN_BOOKS = 3;
+  const books = await getCollection('books');
+
+  const groups = new Map<string, typeof books>();
+  for (const b of books) {
+    const series = b.data.series;
+    if (!series?.name) continue;
+    if (!groups.has(series.name)) groups.set(series.name, []);
+    groups.get(series.name)!.push(b);
+  }
+
+  const eligible = [...groups.entries()].filter(([, list]) => list.length >= MIN_BOOKS);
+
+  return eligible.map(([name, list]) => ({
+    params: { slug: toSlug(name) },
+    props: {
+      seriesName: name,
+      books: list
+        .map(b => b.data)
+        .sort((a, b) => {
+          const ap = a.series?.position ?? 9999;
+          const bp = b.series?.position ?? 9999;
+          if (ap !== bp) return ap - bp;
+          return (a.first_published ?? 9999) - (b.first_published ?? 9999);
+        }),
+    },
+  }));
+}
+
+const { seriesName, books } = Astro.props;
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title={seriesName} description={`${books.length} books in the ${seriesName} series`}>
+  <nav class="breadcrumb">
+    <a href={`${base}`}>Home</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}series/`}>Series</a>
+    <span class="breadcrumb-sep">/</span>
+    <span class="breadcrumb-current">{seriesName}</span>
+  </nav>
+
+  <h1 class="heading-xl mb-2">{seriesName}</h1>
+  <p class="text-muted text-sm mb-6">{books.length} books in this series</p>
+
+  <div class="grid sm-grid-2 md-grid-3 gap-3">
+    {books.map(b => (
+      <a href={`${base}books/${b.slug}/`} class="card related-book">
+        {b.cover_url ? (
+          <img src={b.cover_url} alt={`Cover of ${b.title}`} class="related-book-cover" loading="lazy" />
+        ) : (
+          <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
+        )}
+        <div class="book-card-body">
+          <div class="flex items-center gap-2 mb-1">
+            {b.series?.position && (
+              <span class="text-xs text-mono text-dim">#{b.series.position}</span>
+            )}
+            <span class={priorityClass(b.priority)}>{priorityLabel(b.priority)}</span>
+          </div>
+          <h3 class="text-sm font-bold line-clamp-2 mb-1">{b.title}</h3>
+          <p class="text-xs text-dim line-clamp-1">{b.author}</p>
+          {b.first_published && (
+            <p class="text-xs text-dim">{formatYear(b.first_published, b.first_published_circa)}</p>
+          )}
+        </div>
+      </a>
+    ))}
+  </div>
+</Layout>

--- a/src/pages/series/index.astro
+++ b/src/pages/series/index.astro
@@ -1,0 +1,35 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { toSlug } from '../../utils/formatting';
+
+const MIN_BOOKS = 3;
+
+const books = await getCollection('books');
+const groups = new Map<string, number>();
+for (const b of books) {
+  const series = b.data.series;
+  if (!series?.name) continue;
+  groups.set(series.name, (groups.get(series.name) ?? 0) + 1);
+}
+const series = [...groups.entries()]
+  .filter(([, c]) => c >= MIN_BOOKS)
+  .sort(([a, ac], [b, bc]) => bc - ac || a.localeCompare(b))
+  .map(([name, count]) => ({ name, count, slug: toSlug(name) }));
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title="Series" description={`${series.length} series with at least ${MIN_BOOKS} books in the collection`}>
+  <h1 class="heading-xl mb-2">Series</h1>
+  <p class="text-muted text-sm mb-6">{series.length} series with {MIN_BOOKS} or more books on the shelf.</p>
+
+  <div class="grid sm-grid-2 md-grid-3 gap-2">
+    {series.map(s => (
+      <a href={`${base}series/${s.slug}/`} class="list-item">
+        <span class="text-sm">{s.name}</span>
+        <span class="ml-auto text-xs text-dim text-mono">{s.count}</span>
+      </a>
+    ))}
+  </div>
+</Layout>


### PR DESCRIPTION
## What

Three new dynamic-route page sets — the architecture-expert called series/awards as **must-haves** and movements as a **nice-to-have**. Now all three ship.

| Route | Pages | Source |
|---|---|---|
| `/series/` + `/series/[slug]/` | 45 series | `book.series.name` (≥3 books cap) |
| `/awards/` + `/awards/[slug]/` | 34 awards | `book.awards[].name` (≥3 books cap) |
| `/movements/` + `/movements/[slug]/` | 28 movements | `author.movements[]` (≥3 authors cap) |

## Top entries

**Series**: Discworld (11), Platonic dialogue (9), Wheel of Time (8), Hercule Poirot (7), Culture (7)
**Awards**: NPR Top 100 SF&F (58), Hugo Best Novel (49), 20th Century 100 (39), Le Monde 100 (36), Nebula (31)
**Movements**: literary realism (12), Romanticism (10), continental philosophy (9), atheism (8), surrealism (7)

## Implementation notes

- Astro `getStaticPaths` runs in an isolated scope so `MIN_BOOKS` / `MIN_AUTHORS` constants are inlined inside each function body. Module-level constants would be a silent ReferenceError.
- Movements aggregate at the author level (Wikidata P135 is per-author) but the page also rolls up books from those authors so the user lands on a literary-period summary, not just a name list.
- Series ordering: `series.position` first, then `first_published` as tiebreak. Awards: by P585 year ascending. Movement books: chronological.
- 107 new static pages total. Build still under 12 min.

## Verified

- ✅ /series/, /series/discworld/, /awards/, /movements/, /movements/literary-realism/ — all render in both themes
- ✅ Title doubling fixed (Layout already appends "— Tsundoku")

## Follow-up

Cross-references from book detail (next-in-series link, awards row clickable to award page, movement chips on author detail) — sub-epic C3, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)