### PR TITLE
Cross-references on book + author detail (#129 C3)

### DIFF
--- a/src/pages/authors/[slug].astro
+++ b/src/pages/authors/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { priorityLabel, priorityBadgeClass, pluralize, thumbnailUrl, authorMatches } from '../../utils/formatting';
+import { priorityLabel, priorityBadgeClass, pluralize, thumbnailUrl, authorMatches, toSlug } from '../../utils/formatting';
 
 // ISO 3166-1 alpha-2 → human-readable nationality. Subset matches what
 // the wikidata enricher emits.
@@ -124,7 +124,7 @@ const nationalityLine = (author.nationality ?? [])
       {author.movements && author.movements.length > 0 && (
         <div class="flex flex-wrap gap-2 mb-3">
           {author.movements.slice(0, 5).map(m => (
-            <span class="meta-tag">{m}</span>
+            <a href={`${base}movements/${toSlug(m)}/`} class="meta-tag">{m}</a>
           ))}
         </div>
       )}
@@ -132,9 +132,9 @@ const nationalityLine = (author.nationality ?? [])
       {author.awards && author.awards.length > 0 && (
         <div class="flex flex-wrap gap-2 mb-3">
           {author.awards.slice(0, 5).map(a => (
-            <span class="meta-tag" title={a.year ? `${a.name} (${a.year})` : a.name}>
+            <a href={`${base}awards/${toSlug(a.name)}/`} class="meta-tag" title={a.year ? `${a.name} (${a.year})` : a.name}>
               {a.name}{a.year ? ` (${a.year})` : ''}
-            </span>
+            </a>
           ))}
         </div>
       )}

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -62,6 +62,28 @@ function lccDisplay(lcc: string): string {
     .trim();
 }
 
+// Series neighbors — when this book is part of a series with a known
+// position, find the books at position-1 and position+1 in the same
+// series. Most useful for fiction; the architecture-expert ranked
+// "Sequential (Series)" as the highest-priority cross-reference.
+let prevInSeries: { slug: string; title: string; position?: number } | null = null;
+let nextInSeries: { slug: string; title: string; position?: number } | null = null;
+if (book.series?.name && book.series.position) {
+  const sameSeries = allBooks
+    .map(b => b.data)
+    .filter(b => b.series?.name === book.series!.name && b.slug !== book.slug && b.series?.position)
+    .sort((a, b) => (a.series!.position ?? 0) - (b.series!.position ?? 0));
+  for (const b of sameSeries) {
+    const p = b.series!.position!;
+    if (p < book.series.position && (!prevInSeries || p > (prevInSeries.position ?? 0))) {
+      prevInSeries = { slug: b.slug, title: b.title, position: p };
+    }
+    if (p > book.series.position && (!nextInSeries || p < (nextInSeries.position ?? 99999))) {
+      nextInSeries = { slug: b.slug, title: b.title, position: p };
+    }
+  }
+}
+
 const currentLcc = book.lcc?.[0] ?? null;
 let shelfNeighbors: Array<{ slug: string; title: string; author: string; cover_url?: string; lcc: string }> = [];
 if (currentLcc) {
@@ -164,9 +186,9 @@ if (currentLcc) {
             <span class="status-badge stat-badge-blue">Likely Public Domain</span>
           )}
           {book.series && (
-            <span class="status-badge stat-badge-blue">
+            <a class="status-badge stat-badge-blue" href={`${base}series/${toSlug(book.series.name)}/`}>
               {book.series.name}{book.series.position ? ` #${book.series.position}` : ''}
-            </span>
+            </a>
           )}
         </div>
 
@@ -200,9 +222,9 @@ if (currentLcc) {
         {book.awards && book.awards.length > 0 && (
           <div class="flex flex-wrap gap-2 mt-3">
             {book.awards.slice(0, 6).map(a => (
-              <span class="meta-tag" title={a.year ? `${a.name} (${a.year})` : a.name}>
+              <a href={`${base}awards/${toSlug(a.name)}/`} class="meta-tag" title={a.year ? `${a.name} (${a.year})` : a.name}>
                 {a.name}{a.year ? ` (${a.year})` : ''}
-              </span>
+              </a>
             ))}
           </div>
         )}
@@ -317,6 +339,42 @@ if (currentLcc) {
         {book.librivox_url && <a href={book.librivox_url} target="_blank" rel="noopener noreferrer" class="ext-link text-sm">LibriVox</a>}
       </div>
     </div>
+
+    <!-- Series sequential — prev/next in series. Highest-priority
+         cross-reference per the architecture-expert IA review. -->
+    {(prevInSeries || nextInSeries) && book.series && (
+      <nav class="series-nav mb-8" aria-label={`${book.series.name} — sequential navigation`}>
+        <a href={prevInSeries ? `${base}books/${prevInSeries.slug}/` : undefined}
+           class={`series-nav-link series-nav-prev ${prevInSeries ? '' : 'series-nav-disabled'}`}
+           aria-disabled={!prevInSeries}>
+          {prevInSeries ? (
+            <>
+              <span class="series-nav-label">← Previous in {book.series.name}</span>
+              <span class="series-nav-title">#{prevInSeries.position} · {prevInSeries.title}</span>
+            </>
+          ) : (
+            <span class="series-nav-label text-dim">Start of series</span>
+          )}
+        </a>
+        <a href={`${base}series/${toSlug(book.series.name)}/`}
+           class="series-nav-link series-nav-mid">
+          <span class="text-xs text-dim text-mono">SERIES</span>
+          <span class="series-nav-title">{book.series.name}</span>
+        </a>
+        <a href={nextInSeries ? `${base}books/${nextInSeries.slug}/` : undefined}
+           class={`series-nav-link series-nav-next ${nextInSeries ? '' : 'series-nav-disabled'}`}
+           aria-disabled={!nextInSeries}>
+          {nextInSeries ? (
+            <>
+              <span class="series-nav-label">Next in {book.series.name} →</span>
+              <span class="series-nav-title">#{nextInSeries.position} · {nextInSeries.title}</span>
+            </>
+          ) : (
+            <span class="series-nav-label text-dim">End of series</span>
+          )}
+        </a>
+      </nav>
+    )}
 
     <!-- On the Same Shelf — LCC-adjacent neighbors -->
     {shelfNeighbors.length > 0 && currentLcc && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -903,6 +903,43 @@ a:hover { color: var(--pop-pink); }
   border-top: var(--border-width) solid var(--border);
 }
 
+/* Series sequential navigation — appears between book detail header
+   and the LCC virtual-shelf section. Three-up: previous, series link,
+   next. Disabled state rendered for endpoints. */
+.series-nav {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+@media (min-width: 720px) {
+  .series-nav { grid-template-columns: 1fr auto 1fr; gap: 0.75rem; }
+}
+.series-nav-link {
+  display: flex; flex-direction: column; gap: 0.125rem;
+  padding: 0.625rem 0.875rem;
+  border: var(--border-width) solid var(--border);
+  background: var(--bg-surface);
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 120ms ease, color 120ms ease;
+}
+.series-nav-link:hover { border-color: var(--pop-pink); color: var(--text); }
+.series-nav-prev { text-align: left; }
+.series-nav-mid {
+  text-align: center;
+  border-color: var(--pop-blue);
+}
+.series-nav-mid:hover { border-color: var(--pop-pink); }
+.series-nav-next { text-align: right; }
+.series-nav-disabled {
+  pointer-events: none;
+  opacity: 0.55;
+  background: transparent;
+  border-style: dashed;
+}
+.series-nav-label { font-size: 0.7rem; color: var(--text-dim); letter-spacing: 0.02em; text-transform: uppercase; }
+.series-nav-title { font-size: 0.95rem; font-weight: 600; line-height: 1.2; }
+
 /* Book detail page layout */
 .book-detail-layout {
   display: flex; flex-wrap: wrap; gap: 1.5rem;


### PR DESCRIPTION
## What

Sub-epic C3 of #129. The architecture-expert called out cross-reference priority on book detail; this PR implements them all:

| Priority | Cross-reference | Where | Status |
|---|---|---|---|
| 1 | **Sequential (Series)** prev/next | book detail | NEW |
| 2 | Authorship — More by author | book detail | already there |
| 3 | Collocation — On the Same Shelf (LCC) | book detail | landed in #132 |
| 4 | Series → /series/[slug] | book detail (series badge) | NEW link |
| 5 | Awards → /awards/[slug] | book detail (awards row) | NEW links |
| 6 | Movements → /movements/[slug] | author detail | NEW links |

## Series prev/next nav

3-column grid (single column on mobile) sandwiched between the metadata card and the LCC shelf section:

```
← PREVIOUS IN DISCWORLD       SERIES        NEXT IN DISCWORLD →
#1 · The Color of Magic      Discworld     #3 · Equal Rites
```

- Computes neighbors at build time from books with the same `series.name`, picking position-1 and position+1.
- Endpoints render disabled (dashed border, opacity 0.55) so the affordance still reads at start/end of series.
- Center card has `--pop-blue` border to distinguish from prev/next siblings.

## Verified

- ✅ /books/the-light-fantastic (Discworld #2): prev=#1 Color of Magic, next=#3 Equal Rites
- ✅ /books/the-color-of-magic (Discworld #1): prev disabled, next=#2
- ✅ Awards links navigate to /awards/[slug]
- ✅ Movement links on author detail navigate to /movements/[slug]
- ✅ Both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)