### PR TITLE
Faceted OPAC: decade + language + nationality filters (#129 C5)

### DIFF
--- a/scripts/generate-browse-data.py
+++ b/scripts/generate-browse-data.py
@@ -13,13 +13,27 @@ import json
 from pathlib import Path
 
 BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
+AUTHORS_DIR = Path(__file__).parent.parent / "src" / "content" / "authors"
 OUTPUT = Path(__file__).parent.parent / "public" / "browse-data.json"
 
 
 def main() -> None:
+    # Author → primary nationality lookup (Wikidata P27, first entry).
+    # Used to attach a nationality filter to each book on the wire.
+    primary_nat: dict[str, str] = {}
+    if AUTHORS_DIR.exists():
+        for ap in sorted(AUTHORS_DIR.glob("*.json")):
+            a = json.loads(ap.read_text())
+            nats = a.get("nationality") or []
+            if nats:
+                primary_nat[a["name"]] = nats[0]
+
     books = []
     categories = set()
     tag_counts: dict[str, int] = {}
+    decade_counts: dict[int, int] = {}
+    language_counts: dict[str, int] = {}
+    nat_counts: dict[str, int] = {}
 
     for bp in sorted(BOOKS_DIR.glob("*.json")):
         d = json.loads(bp.read_text())
@@ -33,14 +47,12 @@ def main() -> None:
         # Only include optional fields when set — fewer null bytes on the wire.
         if d.get("cover_url"):
             entry["co"] = d["cover_url"]
-        if d.get("first_published"):
+        if d.get("first_published") is not None:
             entry["y"] = d["first_published"]
+            decade = (d["first_published"] // 10) * 10
+            decade_counts[decade] = decade_counts.get(decade, 0) + 1
         if d.get("reading_status"):
             entry["rs"] = d["reading_status"]
-        # First LCC class only (e.g. "PR-6029.00000000.R8 Ni2") — used as
-        # a spine-label on the book card. Browse-grid renders the human-
-        # readable form via the same JS `lccDisplay` shape used on book
-        # detail pages.
         lcc = d.get("lcc") or []
         if lcc:
             entry["lc"] = lcc[0]
@@ -49,15 +61,35 @@ def main() -> None:
             entry["g"] = tags
             for t in tags:
                 tag_counts[t] = tag_counts.get(t, 0) + 1
+        # Original language (when set, indicates a non-English work)
+        if d.get("original_language"):
+            entry["ol"] = d["original_language"]
+            language_counts[d["original_language"]] = language_counts.get(d["original_language"], 0) + 1
+        # Author primary nationality (lookup table from authors dir)
+        nat = primary_nat.get(d.get("author", ""))
+        if nat:
+            entry["n"] = nat
+            nat_counts[nat] = nat_counts.get(nat, 0) + 1
         if entry["cat"]:
             categories.add(entry["cat"])
         books.append(entry)
 
+    # Decade options: every populated decade with ≥1 book, sorted ascending
+    decades = sorted(decade_counts.keys())
+
+    # Language options: top by count, alphabetized for the dropdown
+    languages = sorted(language_counts.keys())
+
+    # Nationality options: top 30 by count (long tail not useful in a dropdown)
+    nationalities = sorted(nat_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:30]
+
     payload = {
         "books": books,
         "categories": sorted(categories),
-        # Tags sorted by frequency descending (matches existing UI behavior).
         "tags": [t for t, _ in sorted(tag_counts.items(), key=lambda kv: (-kv[1], kv[0]))],
+        "decades": decades,
+        "languages": languages,
+        "nationalities": [code for code, _ in nationalities],
     }
 
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
@@ -67,7 +99,11 @@ def main() -> None:
     print(
         f"Browse data: {len(books)} books, "
         f"{len(payload['categories'])} categories, "
-        f"{len(payload['tags'])} tags ({size_kb:.0f}KB)"
+        f"{len(payload['tags'])} tags, "
+        f"{len(decades)} decades, "
+        f"{len(languages)} languages, "
+        f"{len(payload['nationalities'])} nationalities "
+        f"({size_kb:.0f}KB)"
     )
 
 

--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -13,12 +13,15 @@
     reading_status?: 'want' | 'reading' | 'read';
     tags?: string[];
     lcc?: string;
+    original_language?: string;
+    nationality?: string;
   }
 
   // Compact wire format from /browse-data.json — keep keys short to shrink payload.
   interface WireBook {
     t: string; a: string; s: string; p: number; cat: string;
     co?: string; y?: number; rs?: 'want' | 'reading' | 'read'; g?: string[]; lc?: string;
+    ol?: string; n?: string;
   }
 
   function lccDisplay(lcc: string): string {
@@ -28,13 +31,47 @@
       .replace(/\s+/g, ' ')
       .trim();
   }
-  interface BrowseData { books: WireBook[]; categories: string[]; tags: string[]; }
+  interface BrowseData {
+    books: WireBook[];
+    categories: string[];
+    tags: string[];
+    decades?: number[];
+    languages?: string[];
+    nationalities?: string[];
+  }
+
+  // Display labels for the new facet dropdowns.
+  const COUNTRY_NAMES: Record<string, string> = {
+    GB: 'British', US: 'American', CA: 'Canadian', AU: 'Australian', NZ: 'New Zealander',
+    IE: 'Irish', FR: 'French', DE: 'German', IT: 'Italian', ES: 'Spanish', PT: 'Portuguese',
+    NL: 'Dutch', BE: 'Belgian', CH: 'Swiss', AT: 'Austrian', SE: 'Swedish', NO: 'Norwegian',
+    DK: 'Danish', FI: 'Finnish', IS: 'Icelandic', RU: 'Russian', PL: 'Polish', CZ: 'Czech',
+    HU: 'Hungarian', GR: 'Greek', RO: 'Romanian', BG: 'Bulgarian', HR: 'Croatian',
+    RS: 'Serbian', UA: 'Ukrainian', TR: 'Turkish', JP: 'Japanese', CN: 'Chinese',
+    KR: 'Korean', IN: 'Indian', IL: 'Israeli', IR: 'Iranian', EG: 'Egyptian',
+    ZA: 'South African', NG: 'Nigerian', BR: 'Brazilian', AR: 'Argentine', CL: 'Chilean',
+    MX: 'Mexican', CO: 'Colombian', PE: 'Peruvian',
+  };
+  const LANG_NAMES: Record<string, string> = {
+    eng: 'English', fre: 'French', fra: 'French', ger: 'German', deu: 'German',
+    spa: 'Spanish', ita: 'Italian', por: 'Portuguese', rus: 'Russian', jpn: 'Japanese',
+    chi: 'Chinese', zho: 'Chinese', kor: 'Korean', ara: 'Arabic', heb: 'Hebrew',
+    lat: 'Latin', grc: 'Ancient Greek', gre: 'Greek', ell: 'Greek', pol: 'Polish',
+    swe: 'Swedish', nor: 'Norwegian', dan: 'Danish', fin: 'Finnish', dut: 'Dutch',
+    nld: 'Dutch', cze: 'Czech', ces: 'Czech', hun: 'Hungarian', tur: 'Turkish',
+    hin: 'Hindi', san: 'Sanskrit', per: 'Persian', fas: 'Persian',
+  };
+  function natLabel(c: string): string { return COUNTRY_NAMES[c] ?? c; }
+  function langLabel(c: string): string { return LANG_NAMES[c] ?? c.toUpperCase(); }
 
   let { baseUrl = '/' }: { baseUrl?: string } = $props();
 
   let books = $state<Book[]>([]);
   let categories = $state<string[]>([]);
   let tags = $state<string[]>([]);
+  let decades = $state<number[]>([]);
+  let languages = $state<string[]>([]);
+  let nationalities = $state<string[]>([]);
   let loaded = $state(false);
   let loadError = $state(false);
 
@@ -43,6 +80,9 @@
   let selectedPriority = $state(0);
   let selectedStatus = $state('');
   let selectedTag = $state('');
+  let selectedDecade = $state(-1); // -1 = any
+  let selectedLanguage = $state(''); // original_language
+  let selectedNationality = $state(''); // author primary nationality
   let showCount = $state(100);
 
   onMount(async () => {
@@ -61,9 +101,14 @@
         reading_status: b.rs,
         tags: b.g,
         lcc: b.lc,
+        original_language: b.ol,
+        nationality: b.n,
       }));
       categories = data.categories;
       tags = data.tags;
+      decades = data.decades ?? [];
+      languages = data.languages ?? [];
+      nationalities = data.nationalities ?? [];
       loaded = true;
     } catch {
       loadError = true;
@@ -80,7 +125,12 @@
       const matchesPriority = selectedPriority === 0 || b.priority === selectedPriority;
       const matchesStatus = selectedStatus === '' || b.reading_status === selectedStatus;
       const matchesTag = selectedTag === '' || (b.tags && b.tags.includes(selectedTag));
-      return matchesSearch && matchesCategory && matchesPriority && matchesStatus && matchesTag;
+      const matchesDecade = selectedDecade === -1
+        || (b.first_published !== undefined && Math.floor(b.first_published / 10) * 10 === selectedDecade);
+      const matchesLanguage = selectedLanguage === '' || b.original_language === selectedLanguage;
+      const matchesNationality = selectedNationality === '' || b.nationality === selectedNationality;
+      return matchesSearch && matchesCategory && matchesPriority && matchesStatus
+        && matchesTag && matchesDecade && matchesLanguage && matchesNationality;
     })
   );
 
@@ -104,6 +154,9 @@
     selectedPriority = 0;
     selectedStatus = '';
     selectedTag = '';
+    selectedDecade = -1;
+    selectedLanguage = '';
+    selectedNationality = '';
   }
 
   function loadMore() {
@@ -161,6 +214,36 @@
           {/each}
         </select>
       {/if}
+      {#if decades.length > 0}
+        <select bind:value={selectedDecade}
+          aria-label="Filter by decade"
+          class="filter-select">
+          <option value={-1}>All Decades</option>
+          {#each decades as d}
+            <option value={d}>{d < 0 ? `${Math.abs(d)}s BCE` : `${d}s`}</option>
+          {/each}
+        </select>
+      {/if}
+      {#if nationalities.length > 0}
+        <select bind:value={selectedNationality}
+          aria-label="Filter by author nationality"
+          class="filter-select">
+          <option value="">All Nationalities</option>
+          {#each nationalities as code}
+            <option value={code}>{natLabel(code)}</option>
+          {/each}
+        </select>
+      {/if}
+      {#if languages.length > 0}
+        <select bind:value={selectedLanguage}
+          aria-label="Filter by original language"
+          class="filter-select">
+          <option value="">All Languages</option>
+          {#each languages as code}
+            <option value={code}>{langLabel(code)}</option>
+          {/each}
+        </select>
+      {/if}
     </div>
   </div>
 
@@ -175,7 +258,7 @@
         {sortedBooks.length.toLocaleString()} of {books.length.toLocaleString()} books
       {/if}
     </p>
-    {#if search !== '' || selectedCategory !== '' || selectedPriority !== 0 || selectedStatus !== '' || selectedTag !== ''}
+    {#if search !== '' || selectedCategory !== '' || selectedPriority !== 0 || selectedStatus !== '' || selectedTag !== '' || selectedDecade !== -1 || selectedLanguage !== '' || selectedNationality !== ''}
       <button onclick={clearFilters} class="clear-filters-link">
         Clear filters
       </button>
@@ -273,17 +356,10 @@
     gap: 0.5rem;
   }
 
-  @media (min-width: 640px) {
-    .filters-bar {
-      flex-direction: row;
-      gap: 0.75rem;
-    }
-  }
-
-  .search-wrapper {
-    position: relative;
-    flex: 1;
-  }
+  /* search-wrapper is now always full-width above the wrapping filters
+     row — it's the most-used input and deserves to be the first thing.
+     The dropdowns wrap below into as many rows as needed. */
+  .search-wrapper { position: relative; }
 
   .search-input {
     width: 100%;
@@ -321,27 +397,29 @@
 
   .filter-selects {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
   }
 
   .filter-select {
-    flex: 1;
+    flex: 1 1 8rem;
+    min-width: 8rem;
     background: var(--bg-surface);
-    border: 3px solid var(--border);
+    border: 2px solid var(--border);
     color: var(--text);
-    padding: 0.625rem 0.75rem;
+    padding: 0.5rem 0.625rem;
     font-size: 0.875rem;
     font-family: var(--font-body);
     font-weight: 600;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    box-shadow: var(--shadow-sm);
+    box-shadow: var(--shadow-1);
   }
 
   @media (min-width: 640px) {
     .filter-select {
-      flex: none;
+      flex: 0 1 9rem;
     }
   }
 


### PR DESCRIPTION
## What

Per the architecture-expert: *"convert /browse/ into a faceted OPAC utilizing subject_facet, original_language, and Wikidata metrics."*

Three new simultaneous filters on the existing five-filter Browse page:

| Filter | Source | Cardinality |
|---|---|---|
| **Decade** | `book.first_published` bucketed to 10-year windows | 63 populated decades, -400s → 2020s |
| **Original Language** | `book.original_language` (ISO 639-3, set only for non-English originals) | 29 languages |
| **Author Nationality** | author's primary nationality (Wikidata P27) | top 30 by frequency |

Layout reorganized: search-wrapper now full width above the dropdown row, dropdowns wrap with `flex: 0 1 9rem` so all 7 fit cleanly on any viewport.

Wire-size delta: browse-data.json 898KB → 928KB (+3.3%).

Country and language codes shown as labels (`"GB"` → `"British"`, `"jpn"` → `"Japanese"`).

## Verified

- ✅ /browse renders all 7 dropdowns wrapping to two rows
- ✅ Combined filters work (e.g. Russian / 1860s / Must-Read = Crime and Punishment)
- ✅ Clear filters resets the new state
- ✅ Both themes

## Remaining in #129

- DDC stacks retirement (000–900 → /stacks) — flagged for explicit user approval before autonomous shift
- SearchModal index-card-drawer styling (cosmetic)
- Reading-status as library-pocket card (cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)