### PR TITLE
DDC stacks + index-card search drawer + reading pocket (#129)

### DIFF
--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -238,22 +238,26 @@
   }
 
   /* --- Modal --- */
+  /* Index-card drawer styling per #129 sub-epic B. The modal reads as a
+     library catalog drawer being pulled out — bg-elevated for the card
+     stock, a thin top rim line that separates the input field from the
+     drawer interior, and a subtle bottom drawer-pull shadow. */
   .modal {
-    max-width: 32rem;
-    margin: 15vh auto 0;
-    background: var(--bg-surface);
+    max-width: 36rem;
+    margin: 12vh auto 0;
+    background: var(--bg-elevated);
     border: var(--border-width) solid var(--border);
-    box-shadow: 8px 8px 0 var(--shadow-color);
+    box-shadow: var(--shadow-3);
     overflow: hidden;
   }
 
-  /* --- Search bar inside modal --- */
   .modal-search-bar {
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0 1rem;
-    border-bottom: var(--border-width) solid var(--border);
+    padding: 0.25rem 1rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface);
   }
 
   .modal-search-icon {
@@ -315,7 +319,9 @@
     color: var(--text-dim);
   }
 
-  /* --- Individual result --- */
+  /* --- Individual result — index-card row.  Each row reads as a card
+         in a drawer: thin bottom divider, monospace type tag aligned
+         right like a library category sticker. --- */
   .result-item {
     display: flex;
     align-items: center;
@@ -324,8 +330,11 @@
     text-decoration: none;
     color: var(--text);
     border-left: 3px solid transparent;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface);
     transition: border-color 80ms ease, background 80ms ease;
   }
+  .result-item:last-child { border-bottom: none; }
 
   .result-item:hover,
   .result-item.result-active {
@@ -377,10 +386,15 @@
   }
 
   .result-type {
+    font-family: var(--font-mono);
     font-size: 0.625rem;
     color: var(--text-dim);
     text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border: 1px solid var(--border);
+    padding: 0.125rem 0.375rem;
     flex-shrink: 0;
+    align-self: center;
   }
 
   /* --- Modal footer --- */

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -294,6 +294,15 @@ if (currentLcc) {
         </div>
       )}
 
+      {book.reading_status && (
+        <div class="library-pocket" aria-label="Reading status — library card pocket">
+          <span class="library-pocket-label">FROM THE STACKS</span>
+          <span class="library-pocket-status">
+            {book.reading_status === 'read' ? 'Returned · Read' : book.reading_status === 'reading' ? 'Currently checked out' : 'On hold · waiting'}
+          </span>
+        </div>
+      )}
+
 
       {(book.gutenberg_url || book.hathitrust_url || book.librivox_url) && (
         <div class="detail-section flex flex-wrap gap-2">

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -40,7 +40,11 @@ const base = import.meta.env.BASE_URL;
 
   <hr class="section-divider" />
   <h2 class="heading-md mb-4">Other ways to browse</h2>
-  <div class="grid sm-grid-2 md-grid-4 gap-3">
+  <div class="grid sm-grid-2 md-grid-3 gap-3">
+    <a href={`${base}stacks/`} class="card card-padded">
+      <h3 class="font-bold mb-1">The Stacks (DDC)</h3>
+      <p class="text-sm text-dim">Browse by Dewey Decimal main class — 000 to 900. Library-style.</p>
+    </a>
     <a href={`${base}series/`} class="card card-padded">
       <h3 class="font-bold mb-1">Series</h3>
       <p class="text-sm text-dim">Discworld, Wheel of Time, Hercule Poirot, and other multi-book runs.</p>

--- a/src/pages/stacks/[class].astro
+++ b/src/pages/stacks/[class].astro
@@ -1,0 +1,157 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import { priorityClass, priorityLabel, formatYear } from '../../utils/formatting';
+
+const DDC_LABELS: Record<string, string> = {
+  '000': 'General works', '100': 'Philosophy & psychology', '200': 'Religion',
+  '300': 'Social sciences', '400': 'Language', '500': 'Pure science',
+  '600': 'Technology & applied sciences', '700': 'Arts & recreation',
+  '800': 'Literature', '900': 'History & geography',
+};
+
+// Second-tier (division) labels — drilled down where useful. Not all
+// numbers populated for every catalog; we only render dividers when
+// there are books behind them.
+const DDC_DIVISION_LABELS: Record<string, string> = {
+  '000': 'General works', '010': 'Bibliography', '020': 'Library science', '030': 'Encyclopedias',
+  '040': 'Magazines & journals', '050': 'General periodicals', '060': 'Associations & museums',
+  '070': 'News media & journalism', '080': 'Quotations', '090': 'Manuscripts & rare books',
+  '100': 'Philosophy', '110': 'Metaphysics', '120': 'Epistemology & causation',
+  '130': 'Parapsychology & occultism', '140': 'Specific philosophical schools',
+  '150': 'Psychology', '160': 'Logic', '170': 'Ethics', '180': 'Ancient philosophy',
+  '190': 'Modern Western philosophy',
+  '200': 'Religion', '210': 'Philosophy of religion', '220': 'Bible',
+  '230': 'Christianity', '240': 'Christian practical theology', '250': 'Christian orders',
+  '260': 'Social & ecclesiastical theology', '270': 'History of Christianity',
+  '280': 'Christian denominations', '290': 'Other religions',
+  '300': 'Social sciences', '310': 'Statistics', '320': 'Political science',
+  '330': 'Economics', '340': 'Law', '350': 'Public administration',
+  '360': 'Social problems & services', '370': 'Education', '380': 'Commerce',
+  '390': 'Customs & folklore',
+  '400': 'Language', '410': 'Linguistics', '420': 'English & Old English',
+  '430': 'German & related', '440': 'French & related', '450': 'Italian & related',
+  '460': 'Spanish & Portuguese', '470': 'Latin', '480': 'Greek', '490': 'Other languages',
+  '500': 'Science', '510': 'Mathematics', '520': 'Astronomy', '530': 'Physics',
+  '540': 'Chemistry', '550': 'Earth sciences', '560': 'Paleontology',
+  '570': 'Biology', '580': 'Plants', '590': 'Zoology',
+  '600': 'Technology', '610': 'Medicine', '620': 'Engineering', '630': 'Agriculture',
+  '640': 'Home economics', '650': 'Management', '660': 'Chemical engineering',
+  '670': 'Manufacturing', '680': 'Specific manufactures', '690': 'Buildings',
+  '700': 'Arts', '710': 'Civic & landscape art', '720': 'Architecture',
+  '730': 'Sculpture', '740': 'Drawing & decorative arts', '750': 'Painting',
+  '760': 'Printmaking', '770': 'Photography', '780': 'Music', '790': 'Sports & games',
+  '800': 'Literature', '810': 'American literature', '820': 'English literature',
+  '830': 'German literature', '840': 'French literature', '850': 'Italian literature',
+  '860': 'Spanish & Portuguese literature', '870': 'Latin literature',
+  '880': 'Greek literature', '890': 'Other literatures',
+  '900': 'History & geography', '910': 'Geography & travel', '920': 'Biography',
+  '930': 'Ancient world', '940': 'Europe', '950': 'Asia', '960': 'Africa',
+  '970': 'North America', '980': 'South America', '990': 'Other parts of the world',
+};
+
+function ddcClassOf(ddcs: string[] | undefined): string | null {
+  if (!ddcs || ddcs.length === 0) return null;
+  const first = ddcs[0];
+  for (const ch of first) {
+    if (ch >= '0' && ch <= '9') return ch + '00';
+  }
+  return null;
+}
+
+function ddcDivisionOf(ddc: string): string {
+  // Pull two leading digits (e.g. "813" → "810", "823.912" → "820").
+  const m = ddc.match(/^(\d)(\d)/);
+  if (!m) return '000';
+  return `${m[1]}${m[2]}0`;
+}
+
+export async function getStaticPaths() {
+  const allBooks = await getCollection('books');
+  const groups = new Map<string, typeof allBooks>();
+  for (const b of allBooks) {
+    const ddcs = b.data.ddc;
+    if (!ddcs || ddcs.length === 0) continue;
+    const first = ddcs[0];
+    let cls: string | null = null;
+    for (const ch of first) {
+      if (ch >= '0' && ch <= '9') { cls = ch + '00'; break; }
+    }
+    if (!cls) continue;
+    if (!groups.has(cls)) groups.set(cls, []);
+    groups.get(cls)!.push(b);
+  }
+  return [...groups.entries()].map(([cls, list]) => ({
+    params: { class: cls },
+    props: { books: list.map(b => b.data) },
+  }));
+}
+
+const { class: ddcClass } = Astro.params;
+const { books } = Astro.props;
+const className = DDC_LABELS[ddcClass!] ?? ddcClass!;
+
+// Group books within this class by DDC division (tens digit).
+const divisionGroups = new Map<string, typeof books>();
+for (const b of books) {
+  const div = ddcDivisionOf(b.ddc![0]);
+  if (!divisionGroups.has(div)) divisionGroups.set(div, []);
+  divisionGroups.get(div)!.push(b);
+}
+const divisions = [...divisionGroups.entries()]
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([code, list]) => ({
+    code,
+    name: DDC_DIVISION_LABELS[code] ?? code,
+    books: list.sort((a, b) => (a.author || '').localeCompare(b.author || '') || a.title.localeCompare(b.title)),
+  }));
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title={`${className} — ${ddcClass}`} description={`${books.length} books in DDC class ${ddcClass} (${className})`}>
+  <nav class="breadcrumb">
+    <a href={`${base}`}>Home</a>
+    <span class="breadcrumb-sep">/</span>
+    <a href={`${base}stacks/`}>The Stacks</a>
+    <span class="breadcrumb-sep">/</span>
+    <span class="breadcrumb-current">{ddcClass} · {className}</span>
+  </nav>
+
+  <h1 class="heading-xl mb-2"><span class="text-mono text-muted">{ddcClass}</span> {className}</h1>
+  <p class="text-muted text-sm mb-8">{books.length} {books.length === 1 ? 'book' : 'books'} in this stack, divided by Dewey ten-class.</p>
+
+  {divisions.map(div => (
+    <section class="mb-8">
+      <h2 class="heading-md mb-2">
+        <span class="text-mono text-dim">{div.code}</span> {div.name}
+        <span class="text-dim text-sm ml-2">· {div.books.length}</span>
+      </h2>
+      <div class="grid sm-grid-2 md-grid-3 gap-3">
+        {div.books.slice(0, 30).map(b => (
+          <a href={`${base}books/${b.slug}/`} class="card related-book">
+            {b.cover_url ? (
+              <img src={b.cover_url} alt={`Cover of ${b.title}`} class="related-book-cover" loading="lazy" />
+            ) : (
+              <div class="book-thumb-placeholder" aria-hidden="true">📖</div>
+            )}
+            <div class="book-card-body">
+              {b.ddc && b.ddc[0] && (
+                <span class="text-xs text-dim text-mono">{b.ddc[0]}</span>
+              )}
+              <h3 class="text-sm font-bold line-clamp-2 mb-1">{b.title}</h3>
+              <p class="text-xs text-dim line-clamp-1">{b.author}</p>
+              {b.first_published && (
+                <p class="text-xs text-dim">{formatYear(b.first_published, b.first_published_circa)}</p>
+              )}
+              <span class={priorityClass(b.priority)}>{priorityLabel(b.priority)}</span>
+            </div>
+          </a>
+        ))}
+      </div>
+      {div.books.length > 30 && (
+        <p class="text-dim text-sm mt-2">+ {div.books.length - 30} more in {div.name}.</p>
+      )}
+    </section>
+  ))}
+</Layout>

--- a/src/pages/stacks/index.astro
+++ b/src/pages/stacks/index.astro
@@ -1,0 +1,69 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const DDC_MAIN_CLASSES: Array<{ code: string; name: string; description: string }> = [
+  { code: '000', name: 'General works', description: 'Computer science, information, libraries, journalism' },
+  { code: '100', name: 'Philosophy & psychology', description: 'Logic, ethics, metaphysics, the mind' },
+  { code: '200', name: 'Religion', description: 'Christianity, comparative religion, mythology' },
+  { code: '300', name: 'Social sciences', description: 'Sociology, politics, economics, law, education' },
+  { code: '400', name: 'Language', description: 'Linguistics, languages of the world' },
+  { code: '500', name: 'Pure science', description: 'Mathematics, physics, biology, earth sciences' },
+  { code: '600', name: 'Technology & applied sciences', description: 'Medicine, engineering, agriculture' },
+  { code: '700', name: 'Arts & recreation', description: 'Fine arts, music, sports, performing arts' },
+  { code: '800', name: 'Literature', description: 'Fiction, poetry, drama, essays — by language' },
+  { code: '900', name: 'History & geography', description: 'World history, biography, travel' },
+];
+
+const books = await getCollection('books');
+
+// Bucket each book by the first digit of its first DDC entry. Books
+// without DDC don't appear here — they're still reachable via /browse/
+// and /categories/.
+function ddcClassOf(ddcs: string[] | undefined): string | null {
+  if (!ddcs || ddcs.length === 0) return null;
+  const first = ddcs[0];
+  for (const ch of first) {
+    if (ch >= '0' && ch <= '9') return ch + '00';
+  }
+  return null;
+}
+
+const counts = new Map<string, number>();
+for (const b of books) {
+  const cls = ddcClassOf(b.data.ddc);
+  if (cls) counts.set(cls, (counts.get(cls) ?? 0) + 1);
+}
+
+const totalWithDdc = [...counts.values()].reduce((a, b) => a + b, 0);
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Layout title="The Stacks" description="Browse the catalog by Dewey Decimal main class — 000 to 900.">
+  <h1 class="heading-xl mb-2">The Stacks</h1>
+  <p class="text-muted text-sm mb-2">
+    Browse by Library of Congress / Dewey Decimal main class. {totalWithDdc.toLocaleString()} of {books.length.toLocaleString()} books are classified.
+  </p>
+  <p class="text-dim text-sm mb-8">
+    Looking for a topical bucket instead? <a href={`${base}categories/`} class="ext-link" style="text-decoration: underline">Browse by category →</a>
+  </p>
+
+  <div class="grid sm-grid-2 gap-3">
+    {DDC_MAIN_CLASSES.map(c => {
+      const count = counts.get(c.code) ?? 0;
+      return (
+        <a href={count > 0 ? `${base}stacks/${c.code}/` : undefined}
+           class={count > 0 ? 'card card-padded ddc-stack' : 'card card-padded ddc-stack ddc-stack-empty'}
+           aria-disabled={count === 0}>
+          <div class="flex items-center justify-between mb-1">
+            <span class="text-mono text-sm text-dim">{c.code}</span>
+            <span class="text-xs text-mono text-dim">{count}</span>
+          </div>
+          <h3 class="font-bold mb-1">{c.name}</h3>
+          <p class="text-sm text-dim">{c.description}</p>
+        </a>
+      );
+    })}
+  </div>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -942,6 +942,31 @@ a:hover { color: var(--pop-pink); }
   border-style: dashed;
 }
 
+/* Library card pocket — reading-status affordance on book detail.
+   Sits inside the metadata card. Dashed bottom edge mimics the corner
+   of a library card pocket; monospace label reads as a date stamp. */
+.library-pocket {
+  margin-top: 1rem;
+  padding: 0.625rem 0.875rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-bottom: 1px dashed var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  max-width: 18rem;
+}
+.library-pocket-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+}
+.library-pocket-status {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
 /* Series sequential navigation — appears between book detail header
    and the LCC virtual-shelf section. Three-up: previous, series link,
    next. Disabled state rendered for endpoints. */


### PR DESCRIPTION
## What

Three approved items from #129, shipped together as the final library-feel pass.

### 1. /stacks/ — DDC main-class browse

The architecture-expert called out replacing the bespoke 30-category taxonomy with the 10 Dewey Decimal main classes. Done as an addition (not a retirement) — `/categories/` continues to work; `/stacks/` is the new library-style entry point, called out as such on the categories index.

| Class | Name | Books |
|---|---|---|
| 000 | General works | 106 |
| 100 | Philosophy & psychology | 151 |
| 200 | Religion | 48 |
| 300 | Social sciences | 210 |
| 400 | Language | 32 |
| 500 | Pure science | 79 |
| 600 | Technology & applied sciences | 16 |
| 700 | Arts & recreation | 25 |
| **800** | **Literature** | **1,819** |
| 900 | History & geography | 126 |

`/stacks/[class]/` (e.g. `/stacks/800/`) groups books by Dewey division (810, 820, 830, …) with up to 30 books per division and a `+N more` overflow note.

### 2. SearchModal as index-card drawer

- Drawer interior on `--bg-elevated`, input row on `--bg-surface`
- Each result row a 1px-rule index card; monospace bordered category tag right-aligned (book / author)
- Slightly roomier: max-width 32rem → 36rem, top margin 15vh → 12vh

### 3. Reading-status as library card pocket

Inside the metadata card on book detail:

```
┌─────────────────────────┐
│ FROM THE STACKS         │
│ Returned · Read         │
└┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┘
```

Monospace label, dashed bottom border (the pocket affordance). Three states: "Returned · Read", "Currently checked out", "On hold · waiting".

## Verified

- ✅ /stacks/, /stacks/800/, /stacks/100/ render correctly
- ✅ Library pocket card visible on /books/nineteen-eighty-four/
- ✅ Search modal opens with the new drawer styling
- ✅ Both themes
- ✅ /categories/ now links to /stacks/ as the first "Other ways to browse" tile

## #129 status: complete

All sub-epics from epic #129 are now landed:
- A: Library typography + brutalism toning ✅
- B: Spine labels + reading-pocket + index-card search ✅
- C1: Virtual shelf via LCC adjacency ✅
- C2: Series + awards + movements pages ✅
- C3: Cross-references on book + author detail ✅
- C4: Drop letter index → searchable list ✅
- C5: Faceted OPAC + DDC stacks ✅
- D: World-map antimeridian fix ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)