### PR TITLE
Fix theme toggle persistence across view-transition navigation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,8 +36,15 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500..900&display=swap" />
     <title>{title} — Tsundoku</title>
-    {/* Pre-paint theme application: read stored choice, fall back to system preference. Runs before body to prevent FOUC. */}
-    <script is:inline>
+    {/* Pre-paint theme application — runs before body to prevent FOUC.
+        `data-astro-rerun` makes the script execute on every client-side
+        navigation; without it, the script runs once on full page load
+        but skipped on view-transition swaps, causing the new page to
+        render with the system-default theme even when the user toggled
+        an explicit choice. The astro:before-swap listener carries the
+        data-theme attribute over to the incoming document before paint
+        so there's no flash mid-transition. */}
+    <script is:inline data-astro-rerun>
       (function () {
         try {
           var stored = localStorage.getItem('theme');
@@ -48,6 +55,24 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
           // localStorage unavailable — system preference handles it via @media
         }
       })();
+    </script>
+    <script>
+      // Carry data-theme across view-transition swaps so the incoming
+      // document mirrors the user's current choice before paint.
+      document.addEventListener('astro:before-swap', (event) => {
+        try {
+          var stored = localStorage.getItem('theme');
+          var current = document.documentElement.getAttribute('data-theme');
+          var apply = stored === 'light' || stored === 'dark' ? stored : current;
+          if (apply === 'light' || apply === 'dark') {
+            event.newDocument.documentElement.setAttribute('data-theme', apply);
+          } else {
+            event.newDocument.documentElement.removeAttribute('data-theme');
+          }
+        } catch (_) {
+          // ignore — pre-paint inline script will catch it post-swap
+        }
+      });
     </script>
     <ClientRouter />
   </head>


### PR DESCRIPTION
## What

Reported: toggling light/dark on the home page didn't stay applied when clicking through to a new page.

## Root cause

`src/layouts/Layout.astro` had a `<script is:inline>` in `<head>` that read `localStorage('theme')` and applied `data-theme` to the document element pre-paint. With Astro's `<ClientRouter />`, view-transition navigation replaces the document but does NOT re-execute `is:inline` head scripts by default — so the new page rendered with no `data-theme` attribute, falling back to system preference. Visible effect: after toggling to dark, clicking BROWSE went back to system default.

## Fix

Two-line change in `Layout.astro`:

1. **`data-astro-rerun`** on the pre-paint inline script — makes it execute on every client-side navigation, not just the initial full page load.

2. **`astro:before-swap` listener** that copies the active `data-theme` value onto `event.newDocument` *before* Astro swaps it in. Eliminates any flash mid-transition.

## Verified

Dev test path:
- Home (force light) → toggle → Dark applied
- Click BROWSE → still Dark ✓
- Click /books/X → still Dark ✓
- Direct nav to /stacks/800/ → still Dark ✓
- Toggle back to Light → click Authors → still Light ✓
- Reload → reads localStorage → still Light ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)