### PR TITLE
ci: run quality gate on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -46,6 +48,9 @@ jobs:
 
   build:
     needs: quality
+    # Build + deploy only run on push to main (and manual dispatch); PRs
+    # gate at the quality job and stop there.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -103,6 +108,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,10 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  # Scope by event so a PR's quality-only run cannot cancel an in-flight
+  # main-branch deploy. The `pages` group must remain singleton for the
+  # actual Pages publish, but PRs don't reach that step.
+  group: pages-${{ github.event_name == 'pull_request' && github.ref || 'main' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds \`pull_request: branches: [main]\` to the workflow trigger so the **quality** job (typecheck + JS tests + Python tests) runs on every PR.
- **build** + **deploy** keep the existing push-to-main behavior via an \`if: github.event_name != 'pull_request'\` guard — no change to deployment.

## Motivation
The data-quality fix in #151 had no PR-level CI to gate against (local validation was the only signal). This closes that gap so future PRs surface regressions before merge.

## Self-validation
This PR itself is the first to exercise the new trigger — if the quality job runs and passes here, the change is working as intended.

## Test plan
- [ ] PR shows a "Deploy to GitHub Pages / quality" check
- [ ] The check transitions from queued → in_progress → success
- [ ] No "build" or "deploy" job is queued for the PR
- [ ] After merge, the next push to main runs the full quality → build → deploy chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)