### PR TITLE
fix(photos): converge author photo cache + show avatars throughout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,12 +81,14 @@ jobs:
           restore-keys: |
             photo-cache-v1-
 
-      # Chunked approach so a build never burns more than ~5 minutes on cache
-      # population — see #109. After ~20 deploys the cache converges and the
-      # --limit becomes mostly a no-op (idempotent skip on already-cached).
+      # Chunked approach so a build never burns more than ~10 minutes on cache
+      # population — see #109. The limit counts *new downloads* (not records
+      # iterated), so a build with mostly already-cached records still pushes
+      # towards convergence rather than getting stuck on the alphabetically-
+      # early entries.
       - name: Download missing photos (chunked)
-        run: python3 scripts/cache-photos.py --limit 200
-        timeout-minutes: 5
+        run: python3 scripts/cache-photos.py --limit 1000
+        timeout-minutes: 10
         # cache-photos.py is fault-tolerant — failures leave upstream URLs in
         # place, and the runtime broken-image fallback handles any that 404.
         continue-on-error: true

--- a/scripts/cache-photos.py
+++ b/scripts/cache-photos.py
@@ -128,12 +128,17 @@ def cache_one(
 
 
 def process_authors(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
-    """Walk every author file, download photo if needed, rewrite JSON."""
+    """Walk every author file, download photo if needed, rewrite JSON.
+
+    `limit` counts *new downloads*, not records seen — so a build with only
+    the first ~200 alphabetical records cached cannot stop short before
+    reaching the missing ones at zzz.
+    """
     out_dir = PUBLIC_CACHED / "authors"
     counts = {"total": 0, "cached_already": 0, "downloaded": 0, "failed": 0, "skipped": 0}
 
     for path in sorted(AUTHORS_DIR.glob("*.json")):
-        if limit and counts["total"] >= limit:
+        if limit and counts["downloaded"] >= limit:
             break
         doc = json.loads(path.read_text(encoding="utf-8"))
         url = doc.get("photo_url")
@@ -182,7 +187,7 @@ def process_books(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
     counts = {"total": 0, "cached_already": 0, "downloaded": 0, "failed": 0, "skipped": 0}
 
     for path in sorted(BOOKS_DIR.glob("*.json")):
-        if limit and counts["total"] >= limit:
+        if limit and counts["downloaded"] >= limit:
             break
         doc = json.loads(path.read_text(encoding="utf-8"))
         # Prefer the largest-resolution upstream URL.

--- a/scripts/test_cache_photos.py
+++ b/scripts/test_cache_photos.py
@@ -189,6 +189,40 @@ class TestProcessAuthors:
         assert result["bio"] == "philosopher"
         assert result["book_count"] == 21
 
+    def test_limit_counts_downloads_not_iterations(self, tmp_path, monkeypatch):
+        """`--limit N` must cap on downloads, not records seen.
+
+        Regression: the chunked CI run was getting starved because the
+        first ~200 alphabetical author records were already cached and
+        bumped the iterator's `total` count to the limit before any
+        actual download happened. After the fix, a build with 5 missing
+        photos but limit=2 should download exactly 2 — even when 100
+        already-cached records sit between them.
+        """
+        authors = tmp_path / "authors"
+        authors.mkdir()
+        # 5 records: 2 already cached (alpha-first), 3 needing download.
+        for i, (slug, url) in enumerate([
+            ("a-already", "/tsundoku/cached/authors/a-already.jpg"),
+            ("b-already", "/tsundoku/cached/authors/b-already.jpg"),
+            ("c-need", "https://up.example/c.jpg"),
+            ("d-need", "https://up.example/d.jpg"),
+            ("e-need", "https://up.example/e.jpg"),
+        ]):
+            (authors / f"{slug}.json").write_text(
+                json.dumps({"name": slug, "slug": slug, "book_count": 1, "photo_url": url})
+            )
+
+        monkeypatch.setattr(mod, "AUTHORS_DIR", authors)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        monkeypatch.setattr(mod, "download", lambda u: (b"x", "jpg"))
+
+        counts = mod.process_authors(limit=2, dry_run=False, rate_limit_s=0)
+
+        assert counts["cached_already"] == 2
+        assert counts["downloaded"] == 2  # capped at limit, not 3
+        # The 3rd missing record was never reached because limit was hit.
+
     def test_dry_run_does_not_modify_files(self, tmp_path, monkeypatch):
         authors = tmp_path / "authors"
         authors.mkdir()

--- a/src/data/stats.json
+++ b/src/data/stats.json
@@ -642,5 +642,5 @@
     "shelf_meters": 89.8,
     "books_with_pages": 3467
   },
-  "generated_at": "2026-05-04T14:15:32.159888"
+  "generated_at": "2026-05-04T16:18:16.691520"
 }

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -42,7 +42,7 @@ const allAuthors = [...authorMap.entries()]
 
 const mostProlific = [...allAuthors]
   .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
-  .slice(0, 12);
+  .slice(0, 30);
 ---
 
 <Layout title="Authors" description={`${allAuthors.length} authors — read, unread, and somewhere in between`}>
@@ -112,6 +112,15 @@ const mostProlific = [...allAuthors]
           data-author-name={author.name.toLowerCase()}
           aria-disabled={!author.hasDetailPage}
         >
+          {author.photo_url ? (
+            <img src={author.photo_url} alt="" class="author-avatar author-avatar-sm" loading="lazy" />
+          ) : (
+            <div class="author-avatar-placeholder author-avatar-sm" aria-hidden="true">
+              <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+              </svg>
+            </div>
+          )}
           <span class="text-sm truncate">{author.name}</span>
           <span class="ml-auto text-xs text-dim text-mono">{author.count}</span>
         </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -828,6 +828,13 @@ a:hover { color: var(--pop-pink); }
   border: 2px solid var(--border);
   box-shadow: 2px 2px 0 var(--shadow-color);
 }
+/* Compact variant used in the long alphabetical "All Authors" list. */
+.author-avatar.author-avatar-sm,
+.author-avatar-placeholder.author-avatar-sm {
+  width: 1.75rem; height: 1.75rem;
+  border-width: 1px;
+  box-shadow: 1px 1px 0 var(--shadow-color);
+}
 .author-header {
   display: flex; gap: 1.5rem; flex-wrap: wrap;
   margin-bottom: 2rem;


### PR DESCRIPTION
## Summary
You reported that the most prolific authors on /authors/ are missing a lot of their images. Investigation surfaced three distinct issues:

1. **Cache convergence bug** — \`cache-photos.py --limit 200\` was counting *records iterated* not *new downloads*. With ~1500 already-cached author records sitting alphabetically before the missing ones, the loop exhausted its limit on records already done and broke before reaching any of the gaps. The CI cache plateaued at ~40% coverage and could never catch up. **My live HTTP probe confirmed 80% (160/200 sampled) of author photo paths were 404'ing on the deployed site, despite their JSON pointing at \`/tsundoku/cached/authors/\` correctly.**
2. **Template only showed photos for the top 12 prolific authors** — the alphabetical "All Authors" list was text-only by design. Even when the cache *was* converged, those 1,500+ entries had no avatar.
3. **Top 12 was a small slice of "prolific"** — the user's mental model was broader.

## Changes
- **\`scripts/cache-photos.py\`**: limit now caps on \`counts["downloaded"]\`, not \`counts["total"]\`. The loop continues iterating already-cached records (which are cheap — no network) and stops only after \`limit\` *new* downloads. New regression test in \`test_cache_photos.py\` locks this in.
- **\`.github/workflows/deploy.yml\`**: bumped \`--limit\` 200 → 1000 and \`timeout-minutes\` 5 → 10 so the next 1–2 deploys converge the cache fully.
- **\`src/pages/authors/index.astro\`**: bumped Most Prolific 12 → 30 entries; added small (1.75rem) avatars to every entry in the alphabetical "All Authors" list. Authors without a \`photo_url\` get the same SVG silhouette placeholder used in the prolific section.
- **\`src/styles/global.css\`**: \`.author-avatar-sm\` modifier — same rectangle treatment, just smaller and with thinner border.

## Data note
Ran \`enrich-authors-gaps.py\` against the 369 authors missing bio/photo. Returned **0 fills** — every remaining gap is a name that resolves to nothing on Wikipedia / Open Library / Wikidata (corporate authors, niche tech writers, joint-author strings like "Yuri Diogenes, Dr. Erdal Ozkaya"). The long tail here is a data-source limitation, not a script bug.

## Verification
- \`npm run typecheck\` → 0 errors
- \`cd scripts && python -m pytest -q\` → 383 pass (including the new limit-semantics test)
- Local \`npm run build\`: \`dist/authors/index.html\` now contains 1,565 \`<img>\` avatars + 158 placeholder silhouettes (was 12 + 0)
- HTML spot-check: \`a-a-milne\`, \`a-j-ayer\`, \`a-j-p-taylor\` etc. all render with proper \`author-avatar author-avatar-sm\` images

## Test plan
- [x] PR runs the quality gate (added by #152)
- [ ] After merge, the next deploy will populate up to 1000 missing photos
- [ ] After 1–2 deploys the live cache should fully converge
- [ ] Visual smoke test on /authors/ — alphabetical list shows avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)