### PR TITLE
fix(photos): verify cached file exists on disk before declaring already-cached

### DIFF
--- a/scripts/cache-photos.py
+++ b/scripts/cache-photos.py
@@ -127,12 +127,25 @@ def cache_one(
     return f"{ASTRO_BASE}cached/{out_dir.name}/{slug}.{ext}", ext
 
 
+def _resolve_local_path(local_url: str, out_dir: Path) -> Path | None:
+    """Map a /tsundoku/cached/<dir>/<slug>.<ext> URL to its local Path."""
+    if not local_url:
+        return None
+    name = local_url.rsplit("/", 1)[-1]
+    return out_dir / name
+
+
 def process_authors(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
     """Walk every author file, download photo if needed, rewrite JSON.
 
-    `limit` counts *new downloads*, not records seen — so a build with only
-    the first ~200 alphabetical records cached cannot stop short before
-    reaching the missing ones at zzz.
+    `limit` counts *new downloads*, not records seen.
+
+    "Already cached" requires both (a) photo_url points at /cached/ AND
+    (b) the file actually exists on disk. The CI cache restore can be
+    incomplete (the saved cache plateaued at ~40% of files), so the
+    URL-only heuristic was reporting "cached" while leaving 404s for
+    Pages to serve. When the file is missing, we fall back to the
+    upstream `photo_url_source` for re-download.
     """
     out_dir = PUBLIC_CACHED / "authors"
     counts = {"total": 0, "cached_already": 0, "downloaded": 0, "failed": 0, "skipped": 0}
@@ -147,8 +160,17 @@ def process_authors(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
         counts["total"] += 1
 
         if is_already_local(url):
-            counts["cached_already"] += 1
-            continue
+            local_path = _resolve_local_path(url, out_dir)
+            if local_path and local_path.exists():
+                counts["cached_already"] += 1
+                continue
+            # Cache miss: file is gone but JSON insists it's local.
+            # Recover via the upstream attribution URL.
+            recovery_url = doc.get("photo_url_source")
+            if not recovery_url:
+                counts["skipped"] += 1
+                continue
+            url = recovery_url
 
         slug = doc.get("slug") or path.stem
 
@@ -197,8 +219,17 @@ def process_books(limit: int, dry_run: bool, rate_limit_s: float) -> dict:
         counts["total"] += 1
 
         if is_already_local(url):
-            counts["cached_already"] += 1
-            continue
+            local_path = _resolve_local_path(url, out_dir)
+            if local_path and local_path.exists():
+                counts["cached_already"] += 1
+                continue
+            # Cache restore was incomplete; fall back to upstream source
+            # captured the first time we cached. See process_authors().
+            recovery_url = doc.get("cover_url_large_source") or doc.get("cover_url_source")
+            if not recovery_url:
+                counts["skipped"] += 1
+                continue
+            url = recovery_url
 
         slug = doc.get("slug") or path.stem
 

--- a/scripts/test_cache_photos.py
+++ b/scripts/test_cache_photos.py
@@ -201,6 +201,11 @@ class TestProcessAuthors:
         """
         authors = tmp_path / "authors"
         authors.mkdir()
+        cached_dir = tmp_path / "public" / "cached" / "authors"
+        cached_dir.mkdir(parents=True)
+        # Materialise the cached jpgs so the disk-existence check passes.
+        for slug in ("a-already", "b-already"):
+            (cached_dir / f"{slug}.jpg").write_bytes(b"x")
         # 5 records: 2 already cached (alpha-first), 3 needing download.
         for i, (slug, url) in enumerate([
             ("a-already", "/tsundoku/cached/authors/a-already.jpg"),
@@ -222,6 +227,60 @@ class TestProcessAuthors:
         assert counts["cached_already"] == 2
         assert counts["downloaded"] == 2  # capped at limit, not 3
         # The 3rd missing record was never reached because limit was hit.
+
+    def test_recovers_from_missing_cached_file(self, tmp_path, monkeypatch):
+        """When JSON says cached but the file is gone (incomplete restore
+        from actions/cache), we MUST refetch from photo_url_source rather
+        than declaring "cached_already" and serving a 404."""
+        authors = tmp_path / "authors"
+        authors.mkdir()
+        # JSON says cached but no file on disk. Has photo_url_source.
+        author_file = authors / "missing.json"
+        author_file.write_text(json.dumps({
+            "name": "Missing",
+            "slug": "missing",
+            "book_count": 1,
+            "photo_url": "/tsundoku/cached/authors/missing.jpg",
+            "photo_url_source": "https://upstream.example/missing.jpg",
+        }))
+
+        monkeypatch.setattr(mod, "AUTHORS_DIR", authors)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        # download() must be called with the recovery URL
+        seen = []
+        def fake_download(url):
+            seen.append(url)
+            return b"recovered bytes", "jpg"
+        monkeypatch.setattr(mod, "download", fake_download)
+
+        counts = mod.process_authors(limit=0, dry_run=False, rate_limit_s=0)
+
+        assert counts["cached_already"] == 0
+        assert counts["downloaded"] == 1
+        assert seen == ["https://upstream.example/missing.jpg"]
+        # File is now on disk
+        assert (tmp_path / "public" / "cached" / "authors" / "missing.jpg").exists()
+
+    def test_skips_when_cache_miss_has_no_recovery_url(self, tmp_path, monkeypatch):
+        """If the file is missing AND no photo_url_source is recorded
+        (legacy records), skip rather than error — the runtime broken-image
+        fallback handles the visual."""
+        authors = tmp_path / "authors"
+        authors.mkdir()
+        (authors / "stranded.json").write_text(json.dumps({
+            "name": "Stranded",
+            "slug": "stranded",
+            "book_count": 1,
+            "photo_url": "/tsundoku/cached/authors/stranded.jpg",
+            # no photo_url_source
+        }))
+        monkeypatch.setattr(mod, "AUTHORS_DIR", authors)
+        monkeypatch.setattr(mod, "PUBLIC_CACHED", tmp_path / "public" / "cached")
+        monkeypatch.setattr(mod, "download", lambda u: pytest.fail("unexpected download"))
+
+        counts = mod.process_authors(limit=0, dry_run=False, rate_limit_s=0)
+        assert counts["downloaded"] == 0
+        assert counts["skipped"] == 1
 
     def test_dry_run_does_not_modify_files(self, tmp_path, monkeypatch):
         authors = tmp_path / "authors"
@@ -283,6 +342,10 @@ class TestProcessBooks:
         """Re-running on a record whose cover_url is already local does nothing."""
         books = tmp_path / "books"
         books.mkdir()
+        cached_dir = tmp_path / "public" / "cached" / "covers"
+        cached_dir.mkdir(parents=True)
+        (cached_dir / "x.jpg").write_bytes(b"x")  # the disk file the JSON points at
+
         book_file = books / "x.json"
         original = {
             "title": "X",


### PR DESCRIPTION
## Summary
Follow-up to #153. PR #153's CI deploy log:

\`\`\`
authors   total= 1574  already-cached= 1570  downloaded=    0  failed=   4
books     total= 3581  already-cached= 3580  downloaded=    1  failed=   0
\`\`\`

…but a live HTTP probe of 200 random author photo URLs **still found 80% returning 404**. The runner's actions/cache restore is incomplete (the saved cache has plateaued at ~101 MB while the full local set is ~241 MB), so the runner's \`public/cached/\` is missing many files. \`cache-photos.py\` was declaring records "already-cached" purely because their \`photo_url\` *pointed at* /cached/ — without checking the file actually exists on disk after the cache restore.

## Fix
Both \`process_authors\` and \`process_books\` now verify the file exists on disk after the URL pattern matches. On a miss, fall back to \`photo_url_source\` / \`cover_url_large_source\` / \`cover_url_source\` (the upstream URL we recorded the first time we cached, kept precisely for this kind of recovery) and re-download.

Verified all 1,570 author records and 3,580 book records carry a recovery source URL — none are stranded.

## Tests
- \`test_recovers_from_missing_cached_file\` — JSON says cached, file gone, source present → re-download from source
- \`test_skips_when_cache_miss_has_no_recovery_url\` — same but no source → skip, don't error
- Existing \`test_idempotent_already_local\` and \`test_limit_counts_downloads_not_iterations\` updated to materialise the cached file (was implicitly testing only the URL-pattern path).

## Expected impact after merge
On the next deploy, \`cache-photos.py --limit 1000\` (the limit set in #153) will redownload up to 1,000 photos that were missing on the runner — moving live cache hit-rate from ~20% toward full coverage in 1–2 deploys.

## Test plan
- [x] 22 cache-photos tests pass locally
- [x] All 1,570 cached author photo URLs have \`photo_url_source\` populated (recovery is possible)
- [ ] PR CI quality gate green
- [ ] After merge, deploy log shows downloaded= ≫ 0 for authors
- [ ] Live HTTP sample after deploy shows hit-rate climbing past 50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)