### PR TITLE
fix(layout): rightmost grid column clipped on category pages

### DIFF
--- a/src/components/BookGrid.svelte
+++ b/src/components/BookGrid.svelte
@@ -525,19 +525,21 @@
 
   @media (min-width: 640px) {
     .book-cards-grid {
-      grid-template-columns: repeat(2, 1fr);
+      /* See note in src/styles/global.css — minmax(0, 1fr) prevents long
+       * unbreakable titles/authors from blowing out a column. */
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
   @media (min-width: 1024px) {
     .book-cards-grid {
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 
   @media (min-width: 1280px) {
     .book-cards-grid {
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -425,20 +425,25 @@ a:hover { color: var(--pop-pink); }
 
 /* ===== Grid System ===== */
 .grid { display: grid; gap: 1rem; }
-.grid-2 { grid-template-columns: repeat(2, 1fr); }
-.grid-3 { grid-template-columns: repeat(3, 1fr); }
-.grid-4 { grid-template-columns: repeat(4, 1fr); }
+/* `minmax(0, 1fr)` instead of `1fr` so a grid item's intrinsic min-content
+ * (long unbreakable titles, author lists, etc.) cannot blow out a column
+ * past its fractional share. Without this the rightmost cell extends past
+ * the page's `.site-main` and gets silently clipped by `overflow-x: hidden`
+ * — see the regression on /categories/computer-science/. */
+.grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 @media (min-width: 640px) {
-  .sm-grid-2 { grid-template-columns: repeat(2, 1fr); }
-  .sm-grid-4 { grid-template-columns: repeat(4, 1fr); }
+  .sm-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .sm-grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
 @media (min-width: 768px) {
-  .md-grid-3 { grid-template-columns: repeat(3, 1fr); }
+  .md-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 @media (min-width: 1024px) {
-  .lg-grid-4 { grid-template-columns: repeat(4, 1fr); }
-  .lg-grid-6 { grid-template-columns: repeat(6, 1fr); }
-  .lg-grid-8 { grid-template-columns: repeat(8, 1fr); }
+  .lg-grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .lg-grid-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  .lg-grid-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
 }
 
 /* ===== Utility ===== */


### PR DESCRIPTION
## Summary
You reported [/categories/computer-science/](https://williamzujkowski.github.io/tsundoku/categories/computer-science/) was clipping the rightmost column. Reproduced via Chrome DevTools.

**Cause:** every grid utility in \`global.css\` and \`BookGrid.svelte\` used \`grid-template-columns: repeat(N, 1fr)\`. CSS treats \`1fr\` as \`minmax(auto, 1fr)\` — \`auto\` is the cell's intrinsic min-content. On the CS page, the longest card had a 76-character author byline (Colin Bendell + 5 co-authors) and the line-clamp on the title leaks a long min-content up. That forced col 3 to ~496 px while the other three sat at ~295 px, pushing the grid scrollWidth to 1607 px while \`.site-main\` was only 1280 px wide. \`.site-main { overflow-x: hidden }\` then clipped the overflow silently.

**Fix:** change every grid utility to \`repeat(N, minmax(0, 1fr))\`. Min-content can no longer push columns past their fractional share. This is the canonical CSS-grid pattern for the problem.

## Live-verified before / after
\`\`\`
before: gridStyle = "275.075px 395.35px 496.475px 404.163px"
        gridScroll = 1607 px, last card right = 1894 (clipped past 1535)
after:  gridStyle = "295px 295px 295px 295px"
        gridScroll = 1216 px, last card right = 1503 (within main 1535)
\`\`\`

Verified by injecting the new \`grid-template-columns\` value into the live page via DevTools — column widths immediately equalised, no more clipping.

## Files
- \`src/styles/global.css\` — \`.grid-N\`, \`.sm-grid-N\`, \`.md-grid-N\`, \`.lg-grid-N\` (10 declarations)
- \`src/components/BookGrid.svelte\` — three responsive media queries (browse page hand-rolls its own grid)

## QA
- \`npm run typecheck\` → 0 errors
- \`pytest -q\` → 386 / 386 pass
- No template changes, just CSS — no risk of layout regressions on pages without long min-content

## Test plan
- [x] Live DevTools repro of the bug on /categories/computer-science/
- [x] Live DevTools verification of the fix on the same page
- [ ] PR-level CI quality gate
- [ ] After merge, /categories/computer-science/ renders the rightmost column fully visible
- [ ] Spot-check /categories/literature/, /categories/mathematics/ and /browse/ — no regression on shorter-title categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)