### PR TITLE
fix(enrich): reject Wikipedia hits whose summary names a non-book medium

### DIFF
--- a/scripts/enrich-wikipedia-books.py
+++ b/scripts/enrich-wikipedia-books.py
@@ -38,20 +38,53 @@ class WikipediaBookEnricher(EnrichmentScript):
             f"{title} (play)",                        # Drama
         ]
 
+        # Wikipedia summaries with these category markers describe
+        # something other than the book — even if the rest of the extract
+        # mentions "published" or "story". Outright reject; otherwise the
+        # 1996 video game *MissionForce: CyberStorm* leaks into Matthew
+        # Mather's 2013 novel, which is exactly the kind of regression
+        # this enricher exists to avoid.
+        NON_BOOK_DESC = re.compile(
+            r"\b(video game|computer game|board game|tabletop game|"
+            r"first-person shooter|real-time strategy|turn-based strategy|"
+            r"role-playing game|MMORPG|platform(?:er)?|fighting game|"
+            r"film|movie|television series|TV series|miniseries|"
+            r"studio album|debut album|live album|EP|single|song|musical|"
+            r"comic series|graphic novel series|"
+            r"programming language|operating system|software library|"
+            r"website|web framework)\b",
+            re.I,
+        )
+
         for wiki_title in candidates:
             result = self._fetch_summary(wiki_title)
             if result:
-                # Verify it's about the right book/work (not a film, song, etc.)
                 extract = result.get("extract", "").lower()
                 desc = result.get("description", "").lower()
 
-                # Accept if description mentions book/literary terms
-                is_book = any(kw in desc + " " + extract[:200] for kw in [
-                    "novel", "book", "poem", "play", "epic", "story", "work",
-                    "collection", "memoir", "essay", "treatise", "written",
-                    "published", "author", "literary", "fiction", "tale",
-                    author.split()[-1].lower(),  # Author last name in text
-                ])
+                # Hard reject: Wikipedia's short `description` field is a
+                # tight categorization like "1996 video game" or "2013
+                # novel by Matthew Mather". If it names a non-book medium,
+                # this is the wrong page no matter what the extract says.
+                if NON_BOOK_DESC.search(desc) or NON_BOOK_DESC.search(extract[:300]):
+                    continue
+
+                # Accept only on an *explicit* book/literary marker.
+                # "published" and "story" are too weak — they appear in
+                # video-game and film extracts too.
+                BOOK_MARKERS = (
+                    "novel", "novella", "book", "poem", "epic poem",
+                    "play", "memoir", "essay", "essays", "treatise",
+                    "literary", "fiction", "non-fiction", "nonfiction",
+                    "anthology", "collection of", "short story",
+                    "biography", "autobiography",
+                )
+                last_name = author.split()[-1].lower()
+                haystack = desc + " " + extract[:300]
+                is_book = (
+                    any(kw in haystack for kw in BOOK_MARKERS)
+                    or last_name in haystack
+                )
 
                 if is_book and len(result.get("extract", "")) > 50:
                     fields: dict = {}

--- a/scripts/test_enrich_wikipedia_books.py
+++ b/scripts/test_enrich_wikipedia_books.py
@@ -1,0 +1,112 @@
+"""Tests for enrich-wikipedia-books `is_book` filtering.
+
+Regression: the original heuristic accepted any extract that contained
+"published" — which let the Wikipedia article for *MissionForce: CyberStorm*
+(1996 video game) leak into Matthew Mather's 2013 novel of the same name.
+The fix rejects on Wikipedia's `description` (or extract head) naming a
+non-book medium, and requires an explicit literary marker.
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# enrich-wikipedia-books.py uses a hyphen, so import via spec.
+SCRIPT = Path(__file__).parent / "enrich-wikipedia-books.py"
+_spec = importlib.util.spec_from_file_location("enrich_wikipedia_books", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+@pytest.fixture
+def enricher(monkeypatch):
+    """A WikipediaBookEnricher with `safe_request` stubbed to a fake."""
+    from enrichment_base import EnrichmentScript  # noqa
+    enricher = mod.WikipediaBookEnricher.__new__(mod.WikipediaBookEnricher)
+    enricher._fake_response = None
+    monkeypatch.setattr(enricher, "safe_request",
+                        lambda url, **kw: enricher._fake_response)
+    return enricher
+
+
+def test_rejects_video_game_summary(enricher):
+    """Wikipedia returns the 1996 game when we ask for "CyberStorm"."""
+    enricher._fake_response = {
+        "type": "standard",
+        "title": "MissionForce: CyberStorm",
+        "description": "1996 video game",
+        "extract": (
+            "MissionForce: CyberStorm is a turn-based strategy game "
+            "developed by Dynamix and published in 1996 by Sierra On-Line. "
+            "The game is set in the Metaltech universe..."
+        ),
+    }
+    book = {"title": "CyberStorm", "author": "Matthew Mather"}
+    assert enricher.search(book) is None
+
+
+def test_rejects_film_summary(enricher):
+    enricher._fake_response = {
+        "type": "standard",
+        "title": "The Shining (film)",
+        "description": "1980 horror film",
+        "extract": "The Shining is a 1980 psychological horror film "
+                   "directed by Stanley Kubrick...",
+    }
+    book = {"title": "The Shining", "author": "Stephen King"}
+    assert enricher.search(book) is None
+
+
+def test_accepts_real_novel_summary(enricher):
+    enricher._fake_response = {
+        "type": "standard",
+        "title": "Dune (novel)",
+        "description": "1965 science fiction novel by Frank Herbert",
+        "extract": "Dune is a 1965 epic science fiction novel by American "
+                   "author Frank Herbert. It is the first installment of "
+                   "the six-book Dune saga and is one of the best-selling "
+                   "science fiction novels of all time.",
+        "thumbnail": {"source": "https://upload.wikimedia.org/dune.jpg"},
+    }
+    book = {"title": "Dune", "author": "Frank Herbert"}
+    out = enricher.search(book)
+    assert out is not None
+    assert "Frank Herbert" in out["description"] or "novel" in out["description"]
+
+
+def test_accepts_via_author_last_name(enricher):
+    """Even without the word 'novel', an extract that names the author
+    by last name should pass."""
+    enricher._fake_response = {
+        "type": "standard",
+        "title": "Cryptonomicon",
+        "description": "1999 work by Neal Stephenson",
+        "extract": "Cryptonomicon is the 1999 magnum opus from Stephenson, "
+                   "weaving WW2 cryptography with present-day data havens. "
+                   "Critics called it Stephenson's most ambitious effort.",
+    }
+    book = {"title": "Cryptonomicon", "author": "Neal Stephenson"}
+    out = enricher.search(book)
+    assert out is not None
+
+
+def test_disambiguation_skipped(enricher):
+    enricher._fake_response = {"type": "disambiguation",
+                               "extract": "Foo may refer to:"}
+    book = {"title": "Foo", "author": "Anonymous"}
+    assert enricher.search(book) is None
+
+
+def test_album_rejected(enricher):
+    enricher._fake_response = {
+        "type": "standard",
+        "title": "Cryptonomicon (album)",
+        "description": "studio album",
+        "extract": "Cryptonomicon is a studio album by ...",
+    }
+    book = {"title": "Cryptonomicon", "author": "Neal Stephenson"}
+    assert enricher.search(book) is None

--- a/src/content/books/cyberstorm.json
+++ b/src/content/books/cyberstorm.json
@@ -8,8 +8,9 @@
   "language": "eng",
   "reading_status": "read",
   "copyright_status": "in_copyright",
-  "description": "MissionForce: CyberStorm is a turn-based strategy game developed by Dynamix and published in 1996 by Sierra On-Line. The game is set in the Metaltech universe created by Dynamix, and the player control units of HERCULANs : bipedal warmachines of varying size and construct, more commonly known as HERCs. Although CyberStorm was a limited commercial success, it sold well enough to spawn a 1998 sequel called CyberStorm 2: Corporate Wars.",
-  "cover_url": "/tsundoku/cached/covers/cyberstorm.jpg",
+  "description": "Mike Mitchell, an average New Yorker already struggling to keep his family together, suddenly finds himself fighting just to keep them alive when an increasingly bizarre string of disasters starts appearing on the world's news networks. As both the real world and the cyberworld come crashing down, bending perception and reality, a monster snowstorm cuts New York off from the world, turning it into a wintry tomb where nothing is what it seems.",
+  "cover_url": "https://covers.openlibrary.org/b/id/8541860-L.jpg",
+  "cover_url_large": "https://covers.openlibrary.org/b/id/8541860-L.jpg",
   "isbn": "9780991677191",
   "lcc": [
     "PS-3613.00000000.A82844 C93 2013",
@@ -41,8 +42,6 @@
   "wikidata_qid": "Q25217421",
   "original_title": "Cyberstorm",
   "original_language": "eng",
-  "cover_url_source": "https://upload.wikimedia.org/wikipedia/en/thumb/b/b6/Cyberstorm_Cover.jpg/250px-Cyberstorm_Cover.jpg",
-  "cover_cached_at": "2026-05-03T01:07:17+00:00",
   "ddc": [
     "800"
   ]


### PR DESCRIPTION
## Summary
You reported [/books/cyberstorm/](https://williamzujkowski.github.io/tsundoku/books/cyberstorm/) showed the wrong description. Confirmed via Wikipedia API — Matthew Mather's 2013 novel got the article body of *MissionForce: CyberStorm* (1996 video game, Dynamix/Sierra On-Line) because the novel has no Wikipedia page and the disambiguation redirects to the game.

## Root cause
\`scripts/enrich-wikipedia-books.py\`'s \`is_book\` heuristic accepted any extract containing **"published"**. The game extract — *"…published in 1996 by Sierra On-Line"* — passed. Same trap would catch films ("released"), albums, software, etc.

## Fix
1. **Hard-reject on Wikipedia's \`description\` field** when it names a non-book medium. That short field is Wikipedia's own canonical categorization ("1996 video game", "2013 novel by Matthew Mather"). If it names a film / video game / album / programming language / etc., no amount of extract-keyword matching can save us.
2. **Tighten the positive \`is_book\` markers** — drop "published", "story", "work", "released" (too weak — non-book extracts use them too) and require an explicit literary marker (novel, novella, poem, play, memoir, treatise, anthology, biography, …) **or** the author's last name verbatim in the first 300 chars of the extract.

## Cyberstorm record itself
- **Description**: replaced with the OL work description for the novel ("Mike Mitchell, an average New Yorker…")
- **Cover**: replaced with the OL cover (\`covers/id/8541860\`) — the snowstorm cover, not the game's box art (which the old \`Cyberstorm_Cover.jpg\` Wikimedia URL was)
- Old cached \`public/cached/covers/cyberstorm.jpg\` removed so the next photo-cache run repulls

## Audit for similar contamination
Ran a tightened scan ("[Title] is a [non-book medium]" in first sentence + studio names like Sierra/Dynamix/Nintendo/HBO/Disney) across all 3,584 records. **Cyberstorm was the only confirmed contamination**. False positives in the broader scan (e.g. *Game of Thrones* describing the HBO adaptation, *Discipline of Programming* mentioning programming languages) were legitimate descriptions.

## Tests
6 new tests in \`scripts/test_enrich_wikipedia_books.py\`:
- video-game, film, and album summaries → rejected
- legitimate novel summary → accepted
- author-last-name fallback ("…by Stephenson…" with no "novel" word) → accepted
- disambiguation page → rejected (existing behavior)

## QA
- \`pytest -q\` → 392 / 392 pass (was 386)
- \`npm run typecheck\` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)