### PR TITLE
fix(cache-photos): invalidate stale cached file when source URL changes

### DIFF
--- a/scripts/cache-photos.py
+++ b/scripts/cache-photos.py
@@ -99,19 +99,48 @@ def cache_one(
     slug: str,
     rate_limit_s: float,
 ) -> tuple[str, str] | None:
-    """Download `url` into `out_dir/{slug}.{ext}`. Returns (local_url, ext) or None."""
+    """Download `url` into `out_dir/{slug}.{ext}`. Returns (local_url, ext) or None.
+
+    Tracks the source URL in a `<slug>.url` sidecar so that if a record's
+    upstream URL is later edited (e.g. swapping a wrong Wikipedia
+    thumbnail for an Open Library cover), the stale cached file is
+    invalidated and re-fetched. Without this, the 90-day "skip if recent"
+    optimisation reuses the previous URL's bytes silently — see the
+    Cyberstorm regression where the 1996 video-game box art kept
+    rendering for the 2013 novel after the JSON was corrected.
+
+    Backward-compat: a cached file with no sidecar is treated as fresh
+    (the legacy fleet doesn't have sidecars yet). Once any cache run
+    overwrites a file, the sidecar lands and future URL changes are
+    detected.
+    """
     if is_already_local(url):
         # Idempotency: if JSON already points local, no work needed.
         return None
 
     out_dir.mkdir(parents=True, exist_ok=True)
+    sidecar = out_dir / f"{slug}.url"
 
-    # Skip if a recent local file already exists for this slug.
-    for existing in out_dir.glob(f"{slug}.*"):
+    # Skip if a recent local file already exists for this slug AND a
+    # sidecar confirms it came from the same upstream URL. We only reach
+    # this branch when the JSON points to an *upstream* URL — i.e., a
+    # new or manually re-pointed record. Legacy records whose JSON
+    # points to /tsundoku/cached/<slug> short-circuit at the top of
+    # cache_one (is_already_local), so they never touch this sidecar
+    # logic and are not invalidated by it.
+    for existing in sorted(out_dir.glob(f"{slug}.*")):
+        if existing.suffix == ".url":
+            continue
         age_days = (time.time() - existing.stat().st_mtime) / 86400
-        if age_days < SKIP_IF_NEWER_THAN_DAYS:
-            ext = existing.suffix.lstrip(".")
-            return f"{ASTRO_BASE}cached/{out_dir.name}/{slug}.{ext}", ext
+        if age_days >= SKIP_IF_NEWER_THAN_DAYS:
+            break
+        if not sidecar.exists() or sidecar.read_text().strip() != url:
+            # Either the cached bytes came from a different URL, or we
+            # have no record of where they came from. Treat as stale.
+            existing.unlink()
+            break
+        ext = existing.suffix.lstrip(".")
+        return f"{ASTRO_BASE}cached/{out_dir.name}/{slug}.{ext}", ext
 
     result = download(url)
     if rate_limit_s:
@@ -124,6 +153,7 @@ def cache_one(
     tmp = target.with_suffix(target.suffix + ".tmp")
     tmp.write_bytes(data)
     tmp.replace(target)
+    sidecar.write_text(url)
     return f"{ASTRO_BASE}cached/{out_dir.name}/{slug}.{ext}", ext
 
 

--- a/scripts/test_cache_photos.py
+++ b/scripts/test_cache_photos.py
@@ -64,13 +64,14 @@ class TestCacheOne:
         )
         assert result is None  # nothing to do
 
-    def test_uses_existing_recent_file_without_redownload(self, tmp_path, monkeypatch):
+    def test_uses_existing_recent_file_when_sidecar_matches(self, tmp_path, monkeypatch):
+        """A recent cached file PLUS a sidecar URL matching the request
+        is reused without re-downloading. This is the steady-state path."""
         out_dir = tmp_path / "authors"
         out_dir.mkdir()
-        # Existing recent file (mtime = now)
         (out_dir / "plato.png").write_bytes(b"fake png bytes")
+        (out_dir / "plato.url").write_text("https://example.com/plato.png")
 
-        # If download() were called, it would fail noisily — make sure it isn't.
         def boom(url):
             raise AssertionError(f"download() should not be called; got {url}")
 
@@ -85,6 +86,51 @@ class TestCacheOne:
         local_url, ext = result
         assert ext == "png"
         assert local_url.endswith("/cached/authors/plato.png")
+
+    def test_invalidates_stale_cache_when_sidecar_url_differs(self, tmp_path, monkeypatch):
+        """Regression for the Cyberstorm bug: JSON's cover_url was
+        re-pointed at a new upstream (OL cover) but the cached bytes were
+        the old game-cover wikimedia file. The 90-day skip silently
+        reused the old bytes. Sidecar mismatch must now trigger a
+        re-download instead."""
+        out_dir = tmp_path / "covers"
+        out_dir.mkdir()
+        (out_dir / "cyberstorm.jpg").write_bytes(b"old game cover bytes")
+        (out_dir / "cyberstorm.url").write_text("https://wikimedia/old.jpg")
+
+        monkeypatch.setattr(mod, "download", lambda u: (b"new novel cover", "jpg"))
+        result = mod.cache_one(
+            url="https://covers.openlibrary.org/b/id/8541860-L.jpg",
+            out_dir=out_dir,
+            slug="cyberstorm",
+            rate_limit_s=0,
+        )
+        assert result is not None
+        # File overwritten with fresh bytes
+        assert (out_dir / "cyberstorm.jpg").read_bytes() == b"new novel cover"
+        # Sidecar updated to the new URL
+        assert (out_dir / "cyberstorm.url").read_text() == \
+            "https://covers.openlibrary.org/b/id/8541860-L.jpg"
+
+    def test_invalidates_stale_cache_when_no_sidecar(self, tmp_path, monkeypatch):
+        """Same shape as Cyberstorm before the sidecar feature shipped:
+        a cached file exists with no sidecar. We have no record of which
+        URL it came from, so it must be re-fetched, not silently reused."""
+        out_dir = tmp_path / "covers"
+        out_dir.mkdir()
+        (out_dir / "cyberstorm.jpg").write_bytes(b"unknown-source bytes")
+        # NO sidecar
+
+        monkeypatch.setattr(mod, "download", lambda u: (b"fresh bytes", "jpg"))
+        result = mod.cache_one(
+            url="https://covers.openlibrary.org/b/id/8541860-L.jpg",
+            out_dir=out_dir,
+            slug="cyberstorm",
+            rate_limit_s=0,
+        )
+        assert result is not None
+        assert (out_dir / "cyberstorm.jpg").read_bytes() == b"fresh bytes"
+        assert (out_dir / "cyberstorm.url").exists()
 
     def test_redownloads_if_existing_file_is_old(self, tmp_path, monkeypatch):
         out_dir = tmp_path / "authors"


### PR DESCRIPTION
## Summary
Follow-up to #158. After PR #158 landed, the Cyberstorm description was correct but the page still rendered the wrong cover (the 1996 video-game box art, 250×287 — not the novel's portrait OL cover). I edited cyberstorm.json to point \`cover_url\` at \`covers.openlibrary.org/b/id/8541860-L.jpg\` and deleted my local cached jpg, but the CI runner restored the old jpg from the cache and \`cache_one\` returned that stale file without re-checking the URL.

## Root cause
\`cache_one\` had a 90-day "skip if recent" optimisation that returned an existing cached file regardless of whether the upstream URL had changed. So a manually-corrected \`cover_url\` would be silently rewritten back to the old bytes on the next deploy.

## Fix
\`cache_one\` now writes a \`<slug>.url\` sidecar alongside each cached image recording the upstream URL it came from. Subsequent calls:

| Existing on disk | Sidecar | Match? | Action |
|---|---|---|---|
| Yes | matches request URL | ✓ | reuse (steady-state fast path) |
| Yes | differs from request URL | ✗ | invalidate, re-fetch |
| Yes | no sidecar (legacy / manually re-pointed) | ✗ | invalidate, re-fetch |
| No | – | – | fetch (existing logic) |

\`cache_one\` is only called for records whose JSON points to an *upstream* URL — \`is_already_local\` short-circuits the local-URL case at the top. Records in the steady state (JSON points to \`/tsundoku/cached/...\`) never reach the sidecar logic and are not re-fetched.

## Tests
3 new / updated in \`test_cache_photos.py\`:
- \`test_uses_existing_recent_file_when_sidecar_matches\` — fast path
- \`test_invalidates_stale_cache_when_sidecar_url_differs\` — Cyberstorm regression
- \`test_invalidates_stale_cache_when_no_sidecar\` — legacy entries

## QA
- 394 / 394 pytest pass
- 0 typecheck errors

## Expected impact post-merge
After this deploys:
- Cyberstorm's cached jpg has no sidecar → invalidate, fetch from OL → correct novel cover
- Any other manually-edited \`cover_url\` records get the same correction on next visit
- Steady-state records with local URLs are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)