### PR TITLE
fix(authors): recompute book_count on every build (#179)

### DIFF
--- a/scripts/generate-author-stubs.py
+++ b/scripts/generate-author-stubs.py
@@ -59,15 +59,36 @@ def main() -> None:
         for n in names:
             counts[n] += 1
 
-    # Find existing author slugs.
-    existing_slugs: set[str] = set()
+    # Map existing author slug → file path. Most records live at
+    # `<slug>.json`, but a record's `slug` field can differ from its filename
+    # (e.g. -2 suffixes), so resolve via the record's own slug.
+    existing_paths: dict[str, Path] = {}
     for ap in AUTHORS_DIR.glob("*.json"):
         author = json.loads(ap.read_text())
-        existing_slugs.add(author.get("slug", ""))
+        existing_paths[author.get("slug", "")] = ap
 
+    # Refresh book_count on EVERY existing record. `book_count` is a derived
+    # field, so authoritatively overwrite it with the freshly computed
+    # attributable count — keyed off each record's own `name` so orphaned
+    # records (whose name no longer appears in any book) correctly drop to 0
+    # rather than going stale (issue #179). All other fields (bio, photo_url,
+    # wikipedia_url, …) are preserved exactly.
+    updated = 0
+    skipped_existing = 0
+    for slug, existing_path in existing_paths.items():
+        skipped_existing += 1
+        author_data = json.loads(existing_path.read_text())
+        count = counts.get(author_data.get("name", ""), 0)
+        if author_data.get("book_count") != count:
+            author_data["book_count"] = count
+            existing_path.write_text(
+                json.dumps(author_data, indent=2, ensure_ascii=False) + "\n"
+            )
+            updated += 1
+
+    # Create stubs for any author identity that has no record yet.
     created = 0
     skipped_unknown = 0
-    skipped_existing = 0
     for name, count in sorted(counts.items()):
         slug = to_slug(name)
 
@@ -78,27 +99,23 @@ def main() -> None:
         if not slug:
             continue  # cyrillic-only names, etc.
 
-        if slug in existing_slugs:
-            skipped_existing += 1
+        if slug in existing_paths or (AUTHORS_DIR / f"{slug}.json").exists():
             continue
 
         author_path = AUTHORS_DIR / f"{slug}.json"
-        if author_path.exists():
-            skipped_existing += 1
-            continue
-
         author_data = {
             "name": name,
             "slug": slug,
             "book_count": count,
         }
-        author_path.write_text(json.dumps(author_data, indent=2, ensure_ascii=False))
+        author_path.write_text(json.dumps(author_data, indent=2, ensure_ascii=False) + "\n")
         created += 1
 
     total_authors = len(counts)
     print(f"Distinct author identities (full strings + components): {total_authors}")
     print(f"Existing pages: {skipped_existing}")
     print(f"Created stubs: {created}")
+    print(f"Updated book_count on existing records: {updated}")
     if skipped_unknown:
         print(f"Skipped 'Unknown': {skipped_unknown} books")
 

--- a/scripts/test_data_integrity.py
+++ b/scripts/test_data_integrity.py
@@ -9,6 +9,7 @@ import json
 import csv
 import glob
 import re
+import importlib.util
 from pathlib import Path
 from collections import Counter
 
@@ -17,6 +18,15 @@ import pytest
 BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
 AUTHORS_DIR = Path(__file__).parent.parent / "src" / "content" / "authors"
 CSV_PATH = Path(__file__).parent.parent / "data" / "reading-status.csv"
+
+# Reuse the pipeline's author-splitting logic rather than duplicating it, so the
+# book_count invariant tracks generate-author-stubs.py exactly. Module name has
+# a hyphen, so import via spec.
+_stub_spec = importlib.util.spec_from_file_location(
+    "generate_author_stubs", Path(__file__).parent / "generate-author-stubs.py"
+)
+_author_stubs = importlib.util.module_from_spec(_stub_spec)
+_stub_spec.loader.exec_module(_author_stubs)
 
 REQUIRED_BOOK_FIELDS = ["title", "author", "category", "priority", "slug", "language"]
 
@@ -241,6 +251,36 @@ class TestAuthorIntegrity:
             assert a.get("name"), f"{Path(f).name}: missing name"
             assert a.get("slug"), f"{Path(f).name}: missing slug"
             assert "book_count" in a, f"{Path(f).name}: missing book_count"
+
+    def test_book_count_matches_attribution(self):
+        """Every author's book_count equals its attributable book count.
+
+        Regression guard for issue #179: generate-author-stubs.py only created
+        missing stubs and never refreshed book_count on existing records, so
+        counts went stale as books were added/removed. The generator now
+        authoritatively rewrites book_count on every run; this invariant keeps
+        the content files honest. Attribution mirrors the generator: each book
+        counts toward its full author string AND each split component name.
+        """
+        # Freshly compute attributable counts, exactly as the generator does.
+        counts = Counter()
+        for _, b in load_all_books():
+            author_str = b["author"]
+            names = {author_str, *_author_stubs.split_authors(author_str)}
+            for n in names:
+                counts[n] += 1
+
+        mismatches = []
+        for f, a in load_all_authors():
+            expected = counts.get(a["name"], 0)
+            if a.get("book_count") != expected:
+                mismatches.append(
+                    f"{Path(f).name}: book_count={a.get('book_count')} != {expected}"
+                )
+        assert not mismatches, (
+            "Stale author book_count(s) — re-run generate-author-stubs.py:\n"
+            + "\n".join(mismatches[:15])
+        )
 
 
 class TestCSVIntegrity:

--- a/src/content/authors/a-a-milne.json
+++ b/src/content/authors/a-a-milne.json
@@ -1,7 +1,7 @@
 {
   "name": "A. A. Milne",
   "slug": "a-a-milne",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Alan Alexander Milne was an English writer best known for his books about the teddy bear Winnie-the-Pooh, as well as children's poetry. Milne was primarily a playwright before the huge success of Winnie-the-Pooh overshadowed his previous work. He served as a lieutenant in the Royal Warwickshire Regiment in the First World War and as a captain in the Home Guard in the Second World War.",
   "photo_url": "/tsundoku/cached/authors/a-a-milne.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/A._A._Milne",

--- a/src/content/authors/acemoglu-robinson.json
+++ b/src/content/authors/acemoglu-robinson.json
@@ -1,7 +1,7 @@
 {
   "name": "Acemoglu & Robinson",
   "slug": "acemoglu-robinson",
-  "book_count": 1,
+  "book_count": 0,
   "photo_url": "/tsundoku/cached/authors/acemoglu-robinson.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL13496718A",
   "bio": "family name",

--- a/src/content/authors/acemoglu.json
+++ b/src/content/authors/acemoglu.json
@@ -1,7 +1,7 @@
 {
   "name": "Acemoglu",
   "slug": "acemoglu",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL4464437A",
   "bio": "family name",
   "photo_url": "/tsundoku/cached/authors/acemoglu.png",

--- a/src/content/authors/agatha-christie.json
+++ b/src/content/authors/agatha-christie.json
@@ -1,7 +1,7 @@
 {
   "name": "Agatha Christie",
   "slug": "agatha-christie",
-  "book_count": 7,
+  "book_count": 15,
   "bio": "Dame Agatha Mary Clarissa Mallowan, Lady Mallowan, usually known by her first married name, Agatha Christie, was an English author known for her 66 detective novels and 14 short-story collections, particularly those revolving around fictional detectives Hercule Poirot and Miss Marple. She is widely regarded as one of the greatest writers, particularly in the mystery genre.",
   "photo_url": "/tsundoku/cached/authors/agatha-christie.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Agatha_Christie",

--- a/src/content/authors/aho-lam-sethi.json
+++ b/src/content/authors/aho-lam-sethi.json
@@ -1,6 +1,6 @@
 {
   "name": "Aho, Lam, Sethi,",
   "slug": "aho-lam-sethi",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "family name"
 }

--- a/src/content/authors/albert-l-szl-barab-si.json
+++ b/src/content/authors/albert-l-szl-barab-si.json
@@ -1,7 +1,7 @@
 {
   "name": "Albert‑László Barabási",
   "slug": "albert-l-szl-barab-si",
-  "book_count": 2,
+  "book_count": 3,
   "photo_url": "/tsundoku/cached/authors/albert-l-szl-barab-si.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL6792561A",
   "photo_url_source": "https://covers.openlibrary.org/a/olid/OL6792561A-M.jpg",

--- a/src/content/authors/aldous-huxley.json
+++ b/src/content/authors/aldous-huxley.json
@@ -1,7 +1,7 @@
 {
   "name": "Aldous Huxley",
   "slug": "aldous-huxley",
-  "book_count": 2,
+  "book_count": 6,
   "bio": "Aldous Leonard Huxley was an English writer and philosopher. His bibliography spans nearly 50 books, including non-fiction works, as well as essays, narratives and poems.",
   "photo_url": "/tsundoku/cached/authors/aldous-huxley.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Aldous_Huxley",

--- a/src/content/authors/alexander-hamilton.json
+++ b/src/content/authors/alexander-hamilton.json
@@ -1,7 +1,7 @@
 {
   "name": "Alexander Hamilton",
   "slug": "alexander-hamilton",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Alexander Hamilton (January 11, 1755 or 1757] – July 12, 1804) was an American military officer, statesman, and Founding Father who served as the first U.S. secretary of the treasury from 1789 to 1795 during George Washington's presidency.",
   "photo_url": "/tsundoku/cached/authors/alexander-hamilton.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL363754A",

--- a/src/content/authors/alexis-de-tocqueville.json
+++ b/src/content/authors/alexis-de-tocqueville.json
@@ -1,7 +1,7 @@
 {
   "name": "Alexis de Tocqueville",
   "slug": "alexis-de-tocqueville",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Alexis Charles Henri Clérel, comte de Tocqueville, was a French diplomat, political philosopher and historian. He is best known for his works Democracy in America and The Old Regime and the Revolution (1856). In both, he analyzed the living standards and social conditions of individuals as well as their relationship to the market and state in Western societies. Democracy in America was published after Tocqueville's travels in the United States and is today considered an early work of sociology and political science.",
   "photo_url": "/tsundoku/cached/authors/alexis-de-tocqueville.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Alexis_de_Tocqueville",

--- a/src/content/authors/algernon-blackwood.json
+++ b/src/content/authors/algernon-blackwood.json
@@ -1,7 +1,7 @@
 {
   "name": "Algernon Blackwood",
   "slug": "algernon-blackwood",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Algernon Henry Blackwood was an English broadcasting narrator, journalist, novelist and short story writer, and among the most prolific ghost story writers in the history of the genre. The literary critic S. T. Joshi stated, \"His work is more consistently meritorious than any weird writer's except Dunsany's\" and that his short story collection Incredible Adventures (1914) \"may be the premier weird collection of this or any other century\".",
   "photo_url": "/tsundoku/cached/authors/algernon-blackwood.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Algernon_Blackwood",

--- a/src/content/authors/allen-downey.json
+++ b/src/content/authors/allen-downey.json
@@ -1,7 +1,7 @@
 {
   "name": "Allen Downey",
   "slug": "allen-downey",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Allen Benjamin Downey is an American computer scientist who is currently working as a Principal Data Scientist at PyMC Labs. He is a former Professor of Computer Science at the Franklin W. Olin College of Engineering.",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Allen_B._Downey",
   "photo_url": "/tsundoku/cached/authors/allen-downey.jpg",

--- a/src/content/authors/allen-ginsberg.json
+++ b/src/content/authors/allen-ginsberg.json
@@ -1,7 +1,7 @@
 {
   "name": "Allen Ginsberg",
   "slug": "allen-ginsberg",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Irwin Allen Ginsberg was an American poet and writer. As a student at Columbia University in the 1940s, he began friendships with Lucien Carr, William S. Burroughs and Jack Kerouac, forming the core of the Beat Generation. He vigorously opposed militarism, economic materialism and sexual repression and he embodied various aspects of this counterculture with his views on drugs, sex, multiculturalism, hostility to bureaucracy and openness to Eastern religions.",
   "photo_url": "/tsundoku/cached/authors/allen-ginsberg.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Allen_Ginsberg",

--- a/src/content/authors/amartya-sen.json
+++ b/src/content/authors/amartya-sen.json
@@ -1,7 +1,7 @@
 {
   "name": "Amartya Sen",
   "slug": "amartya-sen",
-  "book_count": 4,
+  "book_count": 3,
   "bio": "Amartya Kumar Sen is an Indian economist and philosopher. Sen has taught and worked in England and the United States since 1972. In 1998, he received the Nobel Prize in Economic Sciences for his contributions to welfare economics. He has also made major contributions to social choice theory, economic and social justice, economic theories of famines, decision theory, development economics, public health, and the measures of well-being of countries.",
   "photo_url": "/tsundoku/cached/authors/amartya-sen.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Amartya_Sen",

--- a/src/content/authors/and-john-jay.json
+++ b/src/content/authors/and-john-jay.json
@@ -1,7 +1,7 @@
 {
   "name": "and John Jay",
   "slug": "and-john-jay",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Collective pseudonym of Alexander Hamilton, James Madison, and John Jay to help \" promote the ratification of the United States Constitution\"  - https://en.wikipedia.org/wiki/The_Federalist_Papers",
   "open_library_url": "https://openlibrary.org/authors/OL10141871A"
 }

--- a/src/content/authors/andrew-hunt-and-david-thomas.json
+++ b/src/content/authors/andrew-hunt-and-david-thomas.json
@@ -1,7 +1,7 @@
 {
   "name": "Andrew Hunt and David Thomas",
   "slug": "andrew-hunt-and-david-thomas",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "British artist (1790-1861)",
   "birth_year": 1790,
   "death_year": 1861

--- a/src/content/authors/andrew-hunt.json
+++ b/src/content/authors/andrew-hunt.json
@@ -1,7 +1,7 @@
 {
   "name": "Andrew Hunt",
   "slug": "andrew-hunt",
-  "book_count": 2,
+  "book_count": 1,
   "open_library_url": "https://openlibrary.org/authors/OL2670651A",
   "bio": "British artist (1790-1861)",
   "birth_year": 1790,

--- a/src/content/authors/andy-weir.json
+++ b/src/content/authors/andy-weir.json
@@ -1,7 +1,7 @@
 {
   "name": "Andy Weir",
   "slug": "andy-weir",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Andy Weir is an American science fiction author. His 2011 novel The Martian was adapted into the 2015 film of the same name directed by Ridley Scott. He received the John W. Campbell Award for Best New Writer in 2016. His 2021 novel Project Hail Mary was a finalist for the 2022 Hugo Award for Best Novel, and has also been adapted into a film, released in March 2026.",
   "photo_url": "/tsundoku/cached/authors/andy-weir.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Andy_Weir",

--- a/src/content/authors/ann-radcliffe.json
+++ b/src/content/authors/ann-radcliffe.json
@@ -1,7 +1,7 @@
 {
   "name": "Ann Radcliffe",
   "slug": "ann-radcliffe",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Ann Radcliffe was an English novelist who pioneered the Gothic novel, and a minor poet. Her fourth and most popular novel, The Mysteries of Udolpho, was published in 1794. She is also remembered for her third novel, The Romance of the Forest (1791) and her fifth novel, The Italian (1797). Her novels combine suspenseful narratives, exotic historical settings, and apparently-supernatural events.",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ann_Radcliffe",
   "photo_url": "/tsundoku/cached/authors/ann-radcliffe.jpg",

--- a/src/content/authors/anna-katharine-green.json
+++ b/src/content/authors/anna-katharine-green.json
@@ -1,7 +1,7 @@
 {
   "name": "Anna Katharine Green",
   "slug": "anna-katharine-green",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Anna Katharine Green was an American poet and novelist. She was one of the first authors of detective fiction in the United States and distinguished herself by writing well plotted, legally accurate stories. Green has been called \"the mother of the detective novel\".",
   "photo_url": "/tsundoku/cached/authors/anna-katharine-green.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Anna_Katharine_Green",

--- a/src/content/authors/anonymous.json
+++ b/src/content/authors/anonymous.json
@@ -1,7 +1,7 @@
 {
   "name": "Anonymous",
   "slug": "anonymous",
-  "book_count": 1,
+  "book_count": 6,
   "photo_url": "/tsundoku/cached/authors/anonymous.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL10886069A",
   "bio": "unknown creator of a work (do not use as value of P50; use \"unknown value\" instead)",

--- a/src/content/authors/anselm-of-canterbury.json
+++ b/src/content/authors/anselm-of-canterbury.json
@@ -1,7 +1,7 @@
 {
   "name": "Anselm of Canterbury",
   "slug": "anselm-of-canterbury",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Anselm of Canterbury OSB, also known as Anselm of Aosta after his birthplace and Anselm of Bec after his monastery, was an Italian Benedictine monk, abbot, philosopher, and theologian of the Catholic Church, who served as Archbishop of Canterbury from 1093 to 1109.",
   "photo_url": "/tsundoku/cached/authors/anselm-of-canterbury.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Anselm_of_Canterbury",

--- a/src/content/authors/anthony-trollope.json
+++ b/src/content/authors/anthony-trollope.json
@@ -1,7 +1,7 @@
 {
   "name": "Anthony Trollope",
   "slug": "anthony-trollope",
-  "book_count": 4,
+  "book_count": 19,
   "bio": "Anthony Trollope was an English novelist and civil servant of the Victorian era. Among the best-known of his 47 novels are two series of six novels each collectively known as the Chronicles of Barsetshire and the Palliser novels, as well as The Way We Live Now. His novels address political, social, and gender issues and other topical matters. He also wrote an autobiography, a book on William Makepeace Thackeray, a book on Lord Palmerston, five travel books, and 42 short stories.",
   "photo_url": "/tsundoku/cached/authors/anthony-trollope.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Anthony_Trollope",

--- a/src/content/authors/apollonius-rhodius-apollonius.json
+++ b/src/content/authors/apollonius-rhodius-apollonius.json
@@ -1,6 +1,6 @@
 {
   "name": "Apollonius (Rhodius), Apollonius",
   "slug": "apollonius-rhodius-apollonius",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL7791739A"
 }

--- a/src/content/authors/arthur-conan-doyle.json
+++ b/src/content/authors/arthur-conan-doyle.json
@@ -1,7 +1,7 @@
 {
   "name": "Arthur Conan Doyle",
   "slug": "arthur-conan-doyle",
-  "book_count": 6,
+  "book_count": 10,
   "bio": "Sir Arthur Ignatius Conan Doyle was a British writer and physician. He is best known for his four novels and fifty-six short stories about the fictional consulting detective Sherlock Holmes and his assistant Dr. Watson, which are milestones in crime fiction, and for his first work featuring Professor Challenger, The Lost World (1912), which gave its name to a subgenre of speculative fiction. He was a prolific writer who produced over 200 stories and articles, four volumes of poetry, and a number of works for the stage. He was knighted by King Edward VII in the 1902 Coronation Honours.",
   "photo_url": "/tsundoku/cached/authors/arthur-conan-doyle.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Arthur_Conan_Doyle",

--- a/src/content/authors/arthur-machen.json
+++ b/src/content/authors/arthur-machen.json
@@ -1,7 +1,7 @@
 {
   "name": "Arthur Machen",
   "slug": "arthur-machen",
-  "book_count": 2,
+  "book_count": 5,
   "bio": "Arthur Llewellyn Jones, known by his pen name Arthur Machen, was a Welsh author and mystic of the late 19th and early 20th centuries. He is best known for his influential supernatural, fantasy and horror fiction. His novella The Great God Pan has garnered a reputation as a classic of horror; Stephen King described it as \"Maybe the best [horror story] in the English language.\" He is also known for \"The Bowmen\", a short story that was widely read as fact, creating the legend of the Angels of Mons.",
   "photo_url": "/tsundoku/cached/authors/arthur-machen.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Arthur_Machen",

--- a/src/content/authors/arthur-rimbaud.json
+++ b/src/content/authors/arthur-rimbaud.json
@@ -1,7 +1,7 @@
 {
   "name": "Arthur Rimbaud",
   "slug": "arthur-rimbaud",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Jean Nicolas Arthur Rimbaud was a French poet known for his transgressive and surreal themes and for his influence on modern literature and arts, prefiguring surrealism.",
   "photo_url": "/tsundoku/cached/authors/arthur-rimbaud.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Arthur_Rimbaud",

--- a/src/content/authors/augustine.json
+++ b/src/content/authors/augustine.json
@@ -1,7 +1,7 @@
 {
   "name": "Augustine",
   "slug": "augustine",
-  "book_count": 4,
+  "book_count": 3,
   "bio": "Augustine of Hippo was a Christian theologian and philosopher from Roman Africa. He was the bishop of Hippo Regius from Thagaste in Numidia Cirtensis,. His writings deeply influenced the development of Western philosophy and Western Christianity, and he is viewed as one of the most important Church Fathers of the Latin Church in the Patristic Period. His many important works include The City of God, On Christian Doctrine, and Confessions.",
   "photo_url": "/tsundoku/cached/authors/augustine.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Augustine_of_Hippo",

--- a/src/content/authors/bertolt-brecht.json
+++ b/src/content/authors/bertolt-brecht.json
@@ -1,7 +1,7 @@
 {
   "name": "Bertolt Brecht",
   "slug": "bertolt-brecht",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Eugen Berthold Friedrich Brecht, known as Bertolt Brecht and Bert Brecht, was a German theatre practitioner, playwright, and poet. Coming of age during the Weimar Republic, he had his first successes as a playwright in Munich and moved to Berlin in 1924, where he wrote The Threepenny Opera with Elisabeth Hauptmann and Kurt Weill and began a life-long collaboration with the composer Hanns Eisler. Immersed in Marxist thought during this period, Brecht wrote didactic Lehrstücke and became a leading theoretician of epic theatre and the Verfremdungseffekt.",
   "photo_url": "/tsundoku/cached/authors/bertolt-brecht.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Bertolt_Brecht",

--- a/src/content/authors/bertrand-russell.json
+++ b/src/content/authors/bertrand-russell.json
@@ -1,7 +1,7 @@
 {
   "name": "Bertrand Russell",
   "slug": "bertrand-russell",
-  "book_count": 7,
+  "book_count": 8,
   "bio": "Bertrand Arthur William Russell, 3rd Earl Russell, was an English philosopher, logician, mathematician, and public intellectual. He influenced mathematics, logic, set theory, and various areas of analytic philosophy.",
   "photo_url": "/tsundoku/cached/authors/bertrand-russell.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Bertrand_Russell",

--- a/src/content/authors/blake-pierce.json
+++ b/src/content/authors/blake-pierce.json
@@ -1,6 +1,6 @@
 {
   "name": "Blake Pierce",
   "slug": "blake-pierce",
-  "book_count": 2,
+  "book_count": 1,
   "open_library_url": "https://openlibrary.org/authors/OL7958834A"
 }

--- a/src/content/authors/brandon-perry.json
+++ b/src/content/authors/brandon-perry.json
@@ -1,7 +1,7 @@
 {
   "name": "Brandon Perry",
   "slug": "brandon-perry",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Brandon Perry, better known as K.A.A.N., is an American rapper and singer from Maryland. He is best known for his fast-rhyming Chopper style, breathless-style, vast vocabulary, and cynical lyrics based on mental health issues, abuse, politics, and religion.",
   "wikipedia_url": "https://en.wikipedia.org/wiki/K.A.A.N.",
   "open_library_url": "https://openlibrary.org/authors/OL7495869A",

--- a/src/content/authors/brandon-sanderson.json
+++ b/src/content/authors/brandon-sanderson.json
@@ -1,7 +1,7 @@
 {
   "name": "Brandon Sanderson",
   "slug": "brandon-sanderson",
-  "book_count": 6,
+  "book_count": 9,
   "bio": "Brandon Winn Sanderson is an American author of high fantasy, science fiction, and young adult books. His best known novels include the Mistborn series and The Stormlight Archive, which are set in the Cosmere fictional universe. Outside of the Cosmere, he has written several young adult and juvenile series including The Reckoners, the Skyward series, and the Alcatraz series. He is also known for finishing author Robert Jordan's high fantasy series The Wheel of Time. Sanderson has created two graphic novels, White Sand and Dark One.",
   "photo_url": "/tsundoku/cached/authors/brandon-sanderson.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Brandon_Sanderson",

--- a/src/content/authors/brian-greene.json
+++ b/src/content/authors/brian-greene.json
@@ -1,7 +1,7 @@
 {
   "name": "Brian Greene",
   "slug": "brian-greene",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Brian Randolph Greene is an American physicist known for his research on string theory. He is a professor of physics and mathematics at Columbia University, director of its center for theoretical physics, and the chairman of the World Science Festival, which he co-founded in 2008. Greene co-discovered mirror symmetry, relating two different Calabi–Yau manifolds. He also described the flop transition, a mild form of topology change, and the conifold transition, a more severe transformation of space, showing that topology can smoothly change in string theory.",
   "photo_url": "/tsundoku/cached/authors/brian-greene.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Brian_Greene",

--- a/src/content/authors/bruce-schneier.json
+++ b/src/content/authors/bruce-schneier.json
@@ -1,7 +1,7 @@
 {
   "name": "Bruce Schneier",
   "slug": "bruce-schneier",
-  "book_count": 4,
+  "book_count": 6,
   "bio": "Bruce Schneier is an American cryptographer, computer security professional, privacy specialist, and writer. Schneier is an Adjunct Lecturer in Public Policy at the Harvard Kennedy School and a Fellow at the Berkman Klein Center for Internet & Society as of November, 2013. He is a board member of the Electronic Frontier Foundation, Access Now, and The Tor Project; and an advisory board member of Electronic Privacy Information Center and VerifiedVoting.org. He is the author of several books on general security topics, computer security and cryptography and is a squid enthusiast.",
   "photo_url": "/tsundoku/cached/authors/bruce-schneier.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Bruce_Schneier",

--- a/src/content/authors/carl-sagan.json
+++ b/src/content/authors/carl-sagan.json
@@ -1,7 +1,7 @@
 {
   "name": "Carl Sagan",
   "slug": "carl-sagan",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Carl Edward Sagan was an American astronomer, planetary scientist and science communicator. Initially an assistant professor at Harvard, Sagan later moved to Cornell, where he was the David Duncan Professor of Astronomy and Space Sciences and directed the Laboratory for Planetary Studies. He played an active role in the Mariner, Viking and Voyager programs. He published more than 600 scientific papers and articles and several popular science books, starting with The Cosmic Connection. He won the Pulitzer Prize for General Nonfiction for The Dragons of Eden.",
   "photo_url": "/tsundoku/cached/authors/carl-sagan.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Carl_Sagan",

--- a/src/content/authors/cass-r-sunstein.json
+++ b/src/content/authors/cass-r-sunstein.json
@@ -1,7 +1,7 @@
 {
   "name": "Cass R. Sunstein",
   "slug": "cass-r-sunstein",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "American legal scholar known for his work in constitutional law, administrative law, environmental law, and behavioral economics.",
   "open_library_url": "https://openlibrary.org/authors/OL234141A",
   "birth_year": 1954,

--- a/src/content/authors/charles-dickens.json
+++ b/src/content/authors/charles-dickens.json
@@ -1,7 +1,7 @@
 {
   "name": "Charles Dickens",
   "slug": "charles-dickens",
-  "book_count": 12,
+  "book_count": 15,
   "bio": "Charles John Huffam Dickens was an English writer and journalist. He created some of literature's best-known fictional characters, and is regarded by many as the greatest novelist of the Victorian era. His works enjoyed unprecedented popularity during his lifetime and, by the 20th century, critics and scholars had recognised him as a literary genius. His novels and short stories are widely read today.",
   "photo_url": "/tsundoku/cached/authors/charles-dickens.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Charles_Dickens",

--- a/src/content/authors/charles-petzold.json
+++ b/src/content/authors/charles-petzold.json
@@ -1,7 +1,7 @@
 {
   "name": "Charles Petzold",
   "slug": "charles-petzold",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Charles Petzold is an American programmer and technical author on Microsoft Windows applications. He is also a Microsoft Most Valuable Professional and was named one of Microsoft's seven Windows Pioneers.",
   "photo_url": "/tsundoku/cached/authors/charles-petzold.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Charles_Petzold",

--- a/src/content/authors/charles-stross.json
+++ b/src/content/authors/charles-stross.json
@@ -1,7 +1,7 @@
 {
   "name": "Charles Stross",
   "slug": "charles-stross",
-  "book_count": 3,
+  "book_count": 6,
   "bio": "Charles David George \"Charlie\" Stross is a British writer of science fiction and fantasy. Stross specialises in hard science fiction and space opera.",
   "photo_url": "/tsundoku/cached/authors/charles-stross.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Charles_Stross",

--- a/src/content/authors/charles-w-chesnutt.json
+++ b/src/content/authors/charles-w-chesnutt.json
@@ -1,7 +1,7 @@
 {
   "name": "Charles W. Chesnutt",
   "slug": "charles-w-chesnutt",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Charles Waddell Chesnutt was an African-American author, essayist, political activist, and lawyer, best known for his novels and short stories exploring complex issues of racial and social identity in the post-Civil War South. Two of his books were adapted as silent films in 1926 and 1927 by the African-American director and producer Oscar Micheaux. Following the Civil Rights Movement during the 20th century, interest in the works of Chesnutt was revived. Several of his books were published in new editions, and he received formal recognition. A commemorative stamp was printed in 2008.",
   "photo_url": "/tsundoku/cached/authors/charles-w-chesnutt.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Charles_W._Chesnutt",

--- a/src/content/authors/chris-eagle.json
+++ b/src/content/authors/chris-eagle.json
@@ -1,7 +1,7 @@
 {
   "name": "Chris Eagle",
   "slug": "chris-eagle",
-  "book_count": 1,
+  "book_count": 2,
   "open_library_url": "https://openlibrary.org/authors/OL2638454A",
   "bio": "English footballer (born 1985)",
   "photo_url": "/tsundoku/cached/authors/chris-eagle.jpg",

--- a/src/content/authors/commission-on-geosciences.json
+++ b/src/content/authors/commission-on-geosciences.json
@@ -1,6 +1,6 @@
 {
   "name": "Commission on Geosciences",
   "slug": "commission-on-geosciences",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL3426958A"
 }

--- a/src/content/authors/committee-on-grand-canyon-monitoring.json
+++ b/src/content/authors/committee-on-grand-canyon-monitoring.json
@@ -1,6 +1,6 @@
 {
   "name": "Committee on Grand Canyon Monitoring",
   "slug": "committee-on-grand-canyon-monitoring",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL10848452A"
 }

--- a/src/content/authors/cory-doctorow.json
+++ b/src/content/authors/cory-doctorow.json
@@ -1,7 +1,7 @@
 {
   "name": "Cory Doctorow",
   "slug": "cory-doctorow",
-  "book_count": 3,
+  "book_count": 8,
   "bio": "Cory Efram Doctorow is a Canadian-British blogger, journalist, and science fiction author who served as co-editor of the blog Boing Boing. He is an activist in favour of liberalizing copyright laws and a proponent of the Creative Commons organization, using some of its licences for his books. Some common themes of his work include digital rights management, file sharing, and post-scarcity economics.",
   "photo_url": "/tsundoku/cached/authors/cory-doctorow.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Cory_Doctorow",

--- a/src/content/authors/courant-robbins.json
+++ b/src/content/authors/courant-robbins.json
@@ -1,7 +1,7 @@
 {
   "name": "Courant & Robbins",
   "slug": "courant-robbins",
-  "book_count": 1,
+  "book_count": 0,
   "photo_url": "/tsundoku/cached/authors/courant-robbins.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL9416701A",
   "bio": "commune in Charente-Maritime, France",

--- a/src/content/authors/courant.json
+++ b/src/content/authors/courant.json
@@ -1,7 +1,7 @@
 {
   "name": "Courant",
   "slug": "courant",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Richard Courant was a German American mathematician. *--Wikipedia*",
   "photo_url": "/tsundoku/cached/authors/courant.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL68351A",

--- a/src/content/authors/daniel-defoe.json
+++ b/src/content/authors/daniel-defoe.json
@@ -1,7 +1,7 @@
 {
   "name": "Daniel Defoe",
   "slug": "daniel-defoe",
-  "book_count": 3,
+  "book_count": 5,
   "bio": "Daniel Defoe was an English writer, journalist, merchant and spy. He is famous for his novels Robinson Crusoe (1719), Moll Flanders (1722) and Roxana: The Fortunate Mistress (1724). He has been seen as one of the earliest proponents of the English novel, and helped to popularise the form in Britain with others such as Aphra Behn and Samuel Richardson. Defoe wrote many political tracts, was often in trouble with the authorities, and spent a period in prison. Intellectuals and political leaders paid attention to his fresh ideas and sometimes consulted him.",
   "photo_url": "/tsundoku/cached/authors/daniel-defoe.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Daniel_Defoe",

--- a/src/content/authors/dante.json
+++ b/src/content/authors/dante.json
@@ -1,7 +1,7 @@
 {
   "name": "Dante",
   "slug": "dante",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Dante Alighieri, widely known mononymously as Dante, was an Italian poet, writer, and philosopher. His Divine Comedy, originally called Comedìa and later christened Divina by Giovanni Boccaccio, is widely considered one of the most important poems of the Middle Ages and the greatest literary work in the Italian language.",
   "photo_url": "/tsundoku/cached/authors/dante.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Dante_Alighieri",

--- a/src/content/authors/david-thomas.json
+++ b/src/content/authors/david-thomas.json
@@ -1,7 +1,7 @@
 {
   "name": "David Thomas",
   "slug": "david-thomas",
-  "book_count": 2,
+  "book_count": 1,
   "open_library_url": "https://openlibrary.org/authors/OL36621A",
   "bio": "historian"
 }

--- a/src/content/authors/division-on-earth.json
+++ b/src/content/authors/division-on-earth.json
@@ -1,7 +1,7 @@
 {
   "name": "Division on Earth",
   "slug": "division-on-earth",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL7301250A",
   "bio": "conducts a range of activities where policy meets the life sciences"
 }

--- a/src/content/authors/donald-e-knuth.json
+++ b/src/content/authors/donald-e-knuth.json
@@ -1,7 +1,7 @@
 {
   "name": "Donald E. Knuth",
   "slug": "donald-e-knuth",
-  "book_count": 8,
+  "book_count": 9,
   "bio": "Donald Ervin Knuth is an American computer scientist and mathematician. He is a professor emeritus at Stanford University. He is the 1974 recipient of the ACM Turing Award, informally considered the Nobel Prize of computer science. Knuth has been called the \"father of the analysis of algorithms\".",
   "photo_url": "/tsundoku/cached/authors/donald-e-knuth.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Donald_Knuth",

--- a/src/content/authors/donald-knuth-and-ronald-graham-and-oren-patashnik.json
+++ b/src/content/authors/donald-knuth-and-ronald-graham-and-oren-patashnik.json
@@ -1,7 +1,7 @@
 {
   "name": "Donald Knuth and Ronald Graham and Oren Patashnik",
   "slug": "donald-knuth-and-ronald-graham-and-oren-patashnik",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "American computer scientist and mathematician (born 1938)",
   "photo_url": "/tsundoku/cached/authors/donald-knuth-and-ronald-graham-and-oren-patashnik.jpg",
   "birth_year": 1938,

--- a/src/content/authors/donald-knuth.json
+++ b/src/content/authors/donald-knuth.json
@@ -1,7 +1,7 @@
 {
   "name": "Donald Knuth",
   "slug": "donald-knuth",
-  "book_count": 1,
+  "book_count": 0,
   "photo_url": "/tsundoku/cached/authors/donald-knuth.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL229501A",
   "birth_year": 1938,

--- a/src/content/authors/dorothy-l-sayers.json
+++ b/src/content/authors/dorothy-l-sayers.json
@@ -1,7 +1,7 @@
 {
   "name": "Dorothy L. Sayers",
   "slug": "dorothy-l-sayers",
-  "book_count": 4,
+  "book_count": 9,
   "bio": "Dorothy Leigh Sayers was an English crime novelist, playwright, translator and critic.",
   "photo_url": "/tsundoku/cached/authors/dorothy-l-sayers.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Dorothy_L._Sayers",

--- a/src/content/authors/du-fu.json
+++ b/src/content/authors/du-fu.json
@@ -1,7 +1,7 @@
 {
   "name": "Du Fu",
   "slug": "du-fu",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Du Fu was a Chinese poet and politician during the Tang dynasty. Together with his elder contemporary and friend Li Bai, Du is often considered one of the greatest Chinese poets of his time. His greatest ambition was to serve his country as a successful civil servant, but Du proved unable to make the necessary accommodations. His life, like all of China, was devastated by the An Lushan rebellion of 755, and his last 15 years were a time of almost constant unrest.",
   "photo_url": "/tsundoku/cached/authors/du-fu.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Du_Fu",

--- a/src/content/authors/dylan-thomas.json
+++ b/src/content/authors/dylan-thomas.json
@@ -1,7 +1,7 @@
 {
   "name": "Dylan Thomas",
   "slug": "dylan-thomas",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Dylan Marlais Thomas was a Welsh poet and writer, whose works include the poems \"Do not go gentle into that good night\" and \"And death shall have no dominion\", as well as the \"play for voices\" Under Milk Wood. He also wrote stories and radio broadcasts such as A Child's Christmas in Wales and Portrait of the Artist as a Young Dog. He became widely popular in his lifetime, and remained so after his death at the age of 39 in New York City. By then, he had acquired a reputation, which he had encouraged, as a \"roistering, drunken and doomed poet\".",
   "photo_url": "/tsundoku/cached/authors/dylan-thomas.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Dylan_Thomas",

--- a/src/content/authors/e-m-forster.json
+++ b/src/content/authors/e-m-forster.json
@@ -1,7 +1,7 @@
 {
   "name": "E.M. Forster",
   "slug": "e-m-forster",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Edward Morgan Forster was an English author. He is best known for his novels, particularly A Room with a View (1908), Howards End (1910) and A Passage to India (1924). He also wrote numerous short stories, essays, speeches and broadcasts, as well as biographies and pageant plays. His short story \"The Machine Stops\" (1909) is often viewed as the beginning of technological dystopian fiction. He also co-authored the libretto to Benjamin Britten's opera Billy Budd (1951). Many of his novels examine class differences and hypocrisy. His views as a humanist are at the heart of his work.",
   "photo_url": "/tsundoku/cached/authors/e-m-forster.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/E._M._Forster",

--- a/src/content/authors/e-t-a-hoffmann.json
+++ b/src/content/authors/e-t-a-hoffmann.json
@@ -1,7 +1,7 @@
 {
   "name": "E.T.A. Hoffmann",
   "slug": "e-t-a-hoffmann",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Ernst Theodor Amadeus Hoffmann was a German Romantic author of fantasy and gothic horror, a jurist, composer, music critic and artist. His short story \"The Sandman\" is seen as a pioneering work of horror fiction, while his novella Mademoiselle de Scuderi is regarded as one of the earliest examples of crime fiction.",
   "photo_url": "/tsundoku/cached/authors/e-t-a-hoffmann.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/E._T._A._Hoffmann",

--- a/src/content/authors/earl-derr-biggers.json
+++ b/src/content/authors/earl-derr-biggers.json
@@ -1,7 +1,7 @@
 {
   "name": "Earl Derr Biggers",
   "slug": "earl-derr-biggers",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Earl Derr Biggers was an American novelist and playwright. His novels featuring the fictional Chinese American detective Charlie Chan were adapted into popular films made in the United States and China.",
   "photo_url": "/tsundoku/cached/authors/earl-derr-biggers.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Earl_Derr_Biggers",

--- a/src/content/authors/edgar-allan-poe.json
+++ b/src/content/authors/edgar-allan-poe.json
@@ -1,7 +1,7 @@
 {
   "name": "Edgar Allan Poe",
   "slug": "edgar-allan-poe",
-  "book_count": 3,
+  "book_count": 5,
   "bio": "Edgar Allan Poe was an American writer, poet, editor, and literary critic who is best known for his poetry and short stories, particularly his tales involving mystery and the macabre. He is widely regarded as one of the central figures of Romanticism and Gothic fiction in the United States and of early American literature. Poe was one of the country's first successful practitioners of the short story, and is generally considered to be one of the pioneers of the detective fiction genre. In addition, he is credited with contributing significantly to the emergence of science fiction. He is the first well-known American writer to earn a living exclusively through writing, which resulted in a financially difficult life and career.",
   "photo_url": "/tsundoku/cached/authors/edgar-allan-poe.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Edgar_Allan_Poe",

--- a/src/content/authors/edgar-rice-burroughs.json
+++ b/src/content/authors/edgar-rice-burroughs.json
@@ -1,7 +1,7 @@
 {
   "name": "Edgar Rice Burroughs",
   "slug": "edgar-rice-burroughs",
-  "book_count": 17,
+  "book_count": 19,
   "bio": "Edgar Rice Burroughs was an American writer, recognized for his prolific output in the adventure, science fiction, and fantasy genres. Best known for creating the characters Tarzan and John Carter, he also wrote the Pellucidar series, the Amtor series, and the Caspak trilogy.",
   "photo_url": "/tsundoku/cached/authors/edgar-rice-burroughs.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Edgar_Rice_Burroughs",

--- a/src/content/authors/edward-gibbon.json
+++ b/src/content/authors/edward-gibbon.json
@@ -1,7 +1,7 @@
 {
   "name": "Edward Gibbon",
   "slug": "edward-gibbon",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Edward Gibbon was a British essayist, historian and minor politician. His most important and influential work, The History of the Decline and Fall of the Roman Empire, was published in six volumes between 1776 and 1789, to critical and commercial success. It is known for the quality and irony of its prose, its use of primary sources, and its polemical criticism of organized religion.",
   "photo_url": "/tsundoku/cached/authors/edward-gibbon.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Edward_Gibbon",

--- a/src/content/authors/elizabeth-von-arnim.json
+++ b/src/content/authors/elizabeth-von-arnim.json
@@ -1,7 +1,7 @@
 {
   "name": "Elizabeth von Arnim",
   "slug": "elizabeth-von-arnim",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Elizabeth von Arnim, born Mary Annette Beauchamp, was an English novelist. Born in Australia, she married a German aristocrat, and her earliest works are set in Germany. Her first marriage made her Countess von Arnim-Schlagenthin and her second Elizabeth Russell, Countess Russell. After her first husband's death, she had a three-year affair with the writer H. G. Wells, then later married Frank Russell, elder brother of the Nobel Prize-winner and philosopher Bertrand Russell. She was a cousin of the New Zealand-born writer Katherine Mansfield. Though known in early life as May, her first book introduced her to readers as Elizabeth, which she eventually became to friends and finally to family.",
   "photo_url": "/tsundoku/cached/authors/elizabeth-von-arnim.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Elizabeth_von_Arnim",

--- a/src/content/authors/emmuska-orczy.json
+++ b/src/content/authors/emmuska-orczy.json
@@ -1,7 +1,7 @@
 {
   "name": "Emmuska Orczy",
   "slug": "emmuska-orczy",
-  "book_count": 3,
+  "book_count": 7,
   "bio": "Baroness Emma Magdalena Rozália Mária Jozefa Borbála Orczy de Orci, usually known as Baroness Orczy, was a Hungarian-born British novelist and playwright. She is best known for her series of novels featuring The Scarlet Pimpernel, the alter ego of Sir Percy Blakeney, a wealthy English fop who turns into a quick-thinking escape artist in order to save French aristocrats from \"Madame Guillotine\" during the French Revolution, establishing the \"hero with a secret identity\" in popular culture.",
   "photo_url": "/tsundoku/cached/authors/emmuska-orczy.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Baroness_Orczy",

--- a/src/content/authors/engels.json
+++ b/src/content/authors/engels.json
@@ -1,7 +1,7 @@
 {
   "name": "Engels",
   "slug": "engels",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Friedrich Engels (German pronunciation: [ˈfʁiːdʁɪç ˈɛŋəls]; 28 November 1820 – 5 August 1895) was a German social scientist, author, political theorist, philosopher, and father of communist theory, alongside Karl Marx. Together they produced *The Communist Manifesto* in 1848. Engels also edited the second and third volumes of *Das Kapital* after Marx's death.",
   "photo_url": "/tsundoku/cached/authors/engels.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL1368A",

--- a/src/content/authors/ford-madox-ford.json
+++ b/src/content/authors/ford-madox-ford.json
@@ -1,7 +1,7 @@
 {
   "name": "Ford Madox Ford",
   "slug": "ford-madox-ford",
-  "book_count": 3,
+  "book_count": 5,
   "bio": "Ford Madox Ford was an English novelist, poet, critic and editor whose journals The English Review and The Transatlantic Review were important in the development of early 20th-century English and American literature.",
   "photo_url": "/tsundoku/cached/authors/ford-madox-ford.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ford_Madox_Ford",

--- a/src/content/authors/frances-hodgson-burnett.json
+++ b/src/content/authors/frances-hodgson-burnett.json
@@ -1,7 +1,7 @@
 {
   "name": "Frances Hodgson Burnett",
   "slug": "frances-hodgson-burnett",
-  "book_count": 4,
+  "book_count": 3,
   "bio": "Frances Eliza Hodgson Burnett was a British-American novelist and playwright. She is best known for the three children's novels Little Lord Fauntleroy (1886), A Little Princess (1905), and The Secret Garden (1911).",
   "photo_url": "/tsundoku/cached/authors/frances-hodgson-burnett.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Frances_Hodgson_Burnett",

--- a/src/content/authors/frank-herbert.json
+++ b/src/content/authors/frank-herbert.json
@@ -1,7 +1,7 @@
 {
   "name": "Frank Herbert",
   "slug": "frank-herbert",
-  "book_count": 9,
+  "book_count": 10,
   "bio": "Franklin Patrick Herbert Jr. was an American science-fiction author, best known for his 1965 novel Dune and five sequels to it. He also wrote short stories and worked as a newspaper journalist, photographer, book reviewer, ecological consultant, and lecturer.",
   "photo_url": "/tsundoku/cached/authors/frank-herbert.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Frank_Herbert",

--- a/src/content/authors/fred-brooks.json
+++ b/src/content/authors/fred-brooks.json
@@ -1,7 +1,7 @@
 {
   "name": "Fred Brooks",
   "slug": "fred-brooks",
-  "book_count": 3,
+  "book_count": 2,
   "bio": "Frederick Phillips Brooks Jr. was an American computer architect, software engineer, and computer scientist, best known for managing development of IBM's System/360 family of mainframe computers and the OS/360 software support package, then later writing candidly about those experiences in his seminal book The Mythical Man-Month.",
   "photo_url": "/tsundoku/cached/authors/fred-brooks.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Fred_Brooks",

--- a/src/content/authors/friedrich-nietzsche.json
+++ b/src/content/authors/friedrich-nietzsche.json
@@ -1,7 +1,7 @@
 {
   "name": "Friedrich Nietzsche",
   "slug": "friedrich-nietzsche",
-  "book_count": 10,
+  "book_count": 11,
   "bio": "Friedrich Wilhelm Nietzsche was a German philosopher who started his career as a classical philologist and turned to philosophy early in his academic career. In 1869, aged 24, he was appointed Professor of Classical Philology at the University of Basel. Plagued by health problems for most of his life, he resigned from the university in 1879. He afterward lived as an independent writer, spending much of his life in relative solitude and financial insecurity while moving between Switzerland, Italy, and southern France in search of climates that might alleviate his condition, and in the following decade, he completed much of his core writing. In 1889, aged 44, he suffered a mental breakdown and thereafter a complete loss of his mental faculties, with paralysis and vascular dementia, living his remaining 11 years under the care of his family until his death. His works and his philosophy have fostered not only extensive scholarship but also much popular interest.",
   "photo_url": "/tsundoku/cached/authors/friedrich-nietzsche.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Friedrich_Nietzsche",

--- a/src/content/authors/garcia-marquez.json
+++ b/src/content/authors/garcia-marquez.json
@@ -1,7 +1,7 @@
 {
   "name": "Garcia Marquez",
   "slug": "garcia-marquez",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Gabriel José García Márquez was a Colombian writer and journalist, known affectionately as Gabo or Gabito throughout Latin America. Considered one of the most significant authors of the 20th century, particularly in the Spanish language, he was awarded the 1972 Neustadt International Prize for Literature and the 1982 Nobel Prize in Literature. He pursued a self-directed education that resulted in leaving law school for a career in journalism. From early on he showed no inhibitions in his criticism of Colombian and foreign politics. In 1958, he married Mercedes Barcha Pardo; they had two sons, Rodrigo and Gonzalo.",
   "photo_url": "/tsundoku/cached/authors/garcia-marquez.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Gabriel_Garc%C3%ADa_M%C3%A1rquez",

--- a/src/content/authors/gary-snyder.json
+++ b/src/content/authors/gary-snyder.json
@@ -1,7 +1,7 @@
 {
   "name": "Gary Snyder",
   "slug": "gary-snyder",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Gary Sherman Snyder is an American poet, essayist, lecturer, and environmental activist. His early poetry has been associated with the Beat Generation and the San Francisco Renaissance and he has been described as the \"poet laureate of Deep Ecology\".\nSnyder is a winner of a Pulitzer Prize for Poetry and the American Book Award. His work, in his various roles, reflects an immersion in both Buddhist spirituality and nature. He has translated literature into English from ancient Chinese and modern Japanese. For many years, Snyder was an academic at the University of California, Davis, and for a time served as a member of the California Arts Council.",
   "photo_url": "/tsundoku/cached/authors/gary-snyder.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Gary_Snyder",

--- a/src/content/authors/george-berkeley.json
+++ b/src/content/authors/george-berkeley.json
@@ -1,7 +1,7 @@
 {
   "name": "George Berkeley",
   "slug": "george-berkeley",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "George Berkeley, known as Bishop Berkeley, was an Anglo-Irish philosopher, writer, and clergyman who is regarded as the founder of immaterialism, a philosophical theory he developed which later came to be known as subjective idealism. He has also been called \"the father of idealism\" by German philosopher Arthur Schopenhauer. Berkeley played a leading role in the empiricism movement and was one of its pioneers. He was among the most cited philosophers of 18th-century Europe, and his works deeply influenced later thinkers such as Immanuel Kant and David Hume.",
   "photo_url": "/tsundoku/cached/authors/george-berkeley.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/George_Berkeley",

--- a/src/content/authors/george-bernard-shaw.json
+++ b/src/content/authors/george-bernard-shaw.json
@@ -1,7 +1,7 @@
 {
   "name": "George Bernard Shaw",
   "slug": "george-bernard-shaw",
-  "book_count": 5,
+  "book_count": 9,
   "bio": "George Bernard Shaw, known at his insistence as Bernard Shaw, was an Irish playwright, critic, polemicist and political activist. His influence on Western theatre, culture and politics extended from the 1880s to his death and beyond. He wrote more than sixty plays, including major works such as Man and Superman (1902), Pygmalion (1913) and Saint Joan (1923). With a range incorporating both contemporary satire and historical allegory, Shaw became the leading dramatist of his generation, and in 1925 was awarded the Nobel Prize in Literature.",
   "photo_url": "/tsundoku/cached/authors/george-bernard-shaw.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/George_Bernard_Shaw",

--- a/src/content/authors/george-gissing.json
+++ b/src/content/authors/george-gissing.json
@@ -1,7 +1,7 @@
 {
   "name": "George Gissing",
   "slug": "george-gissing",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "George Robert Gissing was an English novelist, who published 23 novels between 1880 and 1903. In the 1890s he was considered one of the three greatest novelists in England, and by the 1940s he had been recognised as a literary genius. Gissing's best-known works have reappeared in modern editions. They include The Nether World (1889), New Grub Street (1891) and The Odd Women (1893). He retains a small but devoted group of followers.",
   "photo_url": "/tsundoku/cached/authors/george-gissing.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/George_Gissing",

--- a/src/content/authors/george-orwell.json
+++ b/src/content/authors/george-orwell.json
@@ -1,7 +1,7 @@
 {
   "name": "George Orwell",
   "slug": "george-orwell",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Eric Arthur Blair was an English novelist, poet, essayist, journalist, and critic who wrote under the pen name of George Orwell. His work is characterised by lucid prose, social criticism, opposition to all totalitarianism, and support of democratic socialism.",
   "photo_url": "/tsundoku/cached/authors/george-orwell.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/George_Orwell",

--- a/src/content/authors/george-sand.json
+++ b/src/content/authors/george-sand.json
@@ -1,7 +1,7 @@
 {
   "name": "George Sand",
   "slug": "george-sand",
-  "book_count": 3,
+  "book_count": 5,
   "bio": "Amantine Lucile Aurore Dupin de Francueil, best known by her pen name George Sand, was a French novelist, memoirist and journalist. Being more renowned than either Victor Hugo or Honoré de Balzac in Britain in the 1830s and 1840s, Sand is recognised as one of the most notable writers of the European Romantic era. She has more than 50 volumes of various works to her credit, including tales, plays and political texts, alongside her 70 novels.",
   "photo_url": "/tsundoku/cached/authors/george-sand.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/George_Sand",

--- a/src/content/authors/gerald-jay-sussman.json
+++ b/src/content/authors/gerald-jay-sussman.json
@@ -1,7 +1,7 @@
 {
   "name": "Gerald Jay Sussman",
   "slug": "gerald-jay-sussman",
-  "book_count": 2,
+  "book_count": 1,
   "photo_url": "/tsundoku/cached/authors/gerald-jay-sussman.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL1963807A",
   "birth_year": 1947,

--- a/src/content/authors/h-g-wells.json
+++ b/src/content/authors/h-g-wells.json
@@ -1,7 +1,7 @@
 {
   "name": "H.G. Wells",
   "slug": "h-g-wells",
-  "book_count": 8,
+  "book_count": 13,
   "bio": "Herbert George Wells was an English writer, prolific in many genres. He wrote more than forty novels and dozens of short stories. His non-fiction output included works of social commentary, politics, history, popular science, satire, biography, and autobiography. Wells is most known today for his groundbreaking science fiction novels; he has sometimes been called the \"father of science fiction\", a title that has also been given to Jules Verne and Hugo Gernsback.",
   "photo_url": "/tsundoku/cached/authors/h-g-wells.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/H._G._Wells",

--- a/src/content/authors/harold-abelson-and-gerald-jay-sussman.json
+++ b/src/content/authors/harold-abelson-and-gerald-jay-sussman.json
@@ -1,7 +1,7 @@
 {
   "name": "Harold Abelson and Gerald Jay Sussman",
   "slug": "harold-abelson-and-gerald-jay-sussman",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "computer scientist",
   "photo_url": "/tsundoku/cached/authors/harold-abelson-and-gerald-jay-sussman.jpg",
   "birth_year": 1947,

--- a/src/content/authors/harold-abelson.json
+++ b/src/content/authors/harold-abelson.json
@@ -1,7 +1,7 @@
 {
   "name": "Harold Abelson",
   "slug": "harold-abelson",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "American computer scientist",
   "open_library_url": "https://openlibrary.org/authors/OL532838A",
   "birth_year": 1947,

--- a/src/content/authors/heinrich-b-ll.json
+++ b/src/content/authors/heinrich-b-ll.json
@@ -1,7 +1,7 @@
 {
   "name": "Heinrich Böll",
   "slug": "heinrich-b-ll",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Heinrich Theodor Böll was a German writer. Considered one of Germany's foremost post–World War II writers, Böll received the Georg Büchner Prize (1967) and the Nobel Prize for Literature (1972).",
   "photo_url": "/tsundoku/cached/authors/heinrich-b-ll.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Heinrich_B%C3%B6ll",

--- a/src/content/authors/henry-david-thoreau.json
+++ b/src/content/authors/henry-david-thoreau.json
@@ -1,7 +1,7 @@
 {
   "name": "Henry David Thoreau",
   "slug": "henry-david-thoreau",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Henry David Thoreau was an American naturalist, essayist, poet, and philosopher. A leading transcendentalist, he is best known for his book Walden, a reflection upon simple living in natural surroundings, and his essay \"Civil Disobedience\", an argument in favor of citizen disobedience against an unjust state.",
   "photo_url": "/tsundoku/cached/authors/henry-david-thoreau.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Henry_David_Thoreau",

--- a/src/content/authors/henryk-sienkiewicz.json
+++ b/src/content/authors/henryk-sienkiewicz.json
@@ -1,7 +1,7 @@
 {
   "name": "Henryk Sienkiewicz",
   "slug": "henryk-sienkiewicz",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Henryk Adam Aleksander Pius Sienkiewicz, also known by the pseudonym Litwos, was a Polish epic writer. He is remembered for his historical novels, such as the Trilogy series and especially for his internationally known best-seller Quo Vadis (1895–1896).",
   "photo_url": "/tsundoku/cached/authors/henryk-sienkiewicz.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Henryk_Sienkiewicz",

--- a/src/content/authors/herman-melville.json
+++ b/src/content/authors/herman-melville.json
@@ -1,7 +1,7 @@
 {
   "name": "Herman Melville",
   "slug": "herman-melville",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Herman Melville was an American writer of the American Renaissance period. Among his best-known works are Moby-Dick (1851); Typee (1846), a romanticized account of his experiences in Polynesia; and Billy Budd, Sailor, a posthumously published novella. At the time of his death, Melville was not well known to the public, but 1919, the centennial of his birth, was the starting point of a Melville revival. Moby-Dick would eventually be considered one of the Great American Novels.",
   "photo_url": "/tsundoku/cached/authors/herman-melville.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Herman_Melville",

--- a/src/content/authors/herodotus.json
+++ b/src/content/authors/herodotus.json
@@ -1,7 +1,7 @@
 {
   "name": "Herodotus",
   "slug": "herodotus",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Herodotus was a Greek historian and geographer from the Greek city of Halicarnassus, under Persian control in the 5th century BC, and a later citizen of Thurii in modern Calabria, Italy. He wrote the Histories, a detailed account of the Greco-Persian Wars, among other subjects such as the rise of the Achaemenid dynasty of Cyrus. He has been described as \"The Father of History\", a title conferred on him by the ancient Roman orator Cicero.",
   "photo_url": "/tsundoku/cached/authors/herodotus.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Herodotus",

--- a/src/content/authors/hesiod.json
+++ b/src/content/authors/hesiod.json
@@ -1,7 +1,7 @@
 {
   "name": "Hesiod",
   "slug": "hesiod",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Hesiod was an Ancient Greek poet generally thought to have been active between 750 and 650 BC, around the same time as Homer.",
   "photo_url": "/tsundoku/cached/authors/hesiod.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Hesiod",

--- a/src/content/authors/hg-wells.json
+++ b/src/content/authors/hg-wells.json
@@ -1,7 +1,7 @@
 {
   "name": "HG Wells",
   "slug": "hg-wells",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Herbert George Wells was an English writer, prolific in many genres. He wrote more than forty novels and dozens of short stories. His non-fiction output included works of social commentary, politics, history, popular science, satire, biography, and autobiography. Wells is most known today for his groundbreaking science fiction novels; he has sometimes been called the \"father of science fiction\", a title that has also been given to Jules Verne and Hugo Gernsback.",
   "photo_url": "/tsundoku/cached/authors/hg-wells.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/H._G._Wells",

--- a/src/content/authors/homer.json
+++ b/src/content/authors/homer.json
@@ -1,7 +1,7 @@
 {
   "name": "Homer",
   "slug": "homer",
-  "book_count": 5,
+  "book_count": 3,
   "bio": "Homer was an ancient Greek poet who is widely credited as the author of the Iliad and the Odyssey, two epic poems that are foundational works of ancient Greek literature. Although his life and authorship remain obscure, Homer was highly revered in ancient Greek society and is considered one of the most influential authors in history.",
   "photo_url": "/tsundoku/cached/authors/homer.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Homer",

--- a/src/content/authors/honor-de-balzac.json
+++ b/src/content/authors/honor-de-balzac.json
@@ -1,7 +1,7 @@
 {
   "name": "Honoré de Balzac",
   "slug": "honor-de-balzac",
-  "book_count": 7,
+  "book_count": 15,
   "bio": "Honoré de Balzac was a French novelist and playwright. The novel sequence La Comédie humaine, described as a panorama of post-Napoleonic French life, is generally viewed as his magnum opus.",
   "photo_url": "/tsundoku/cached/authors/honor-de-balzac.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Honor%C3%A9_de_Balzac",

--- a/src/content/authors/immanuel-kant.json
+++ b/src/content/authors/immanuel-kant.json
@@ -1,7 +1,7 @@
 {
   "name": "Immanuel Kant",
   "slug": "immanuel-kant",
-  "book_count": 7,
+  "book_count": 8,
   "bio": "Immanuel Kant was a German philosopher. Born in Königsberg in the Kingdom of Prussia, he is considered one of the central thinkers of the Enlightenment. His comprehensive and systematic works in epistemology, metaphysics, ethics, and aesthetics have made him one of the most influential and highly discussed figures in modern Western philosophy.",
   "photo_url": "/tsundoku/cached/authors/immanuel-kant.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Immanuel_Kant",

--- a/src/content/authors/ismail-kadare.json
+++ b/src/content/authors/ismail-kadare.json
@@ -1,7 +1,7 @@
 {
   "name": "Ismail Kadare",
   "slug": "ismail-kadare",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Ismail Kadare was an Albanian novelist, poet, essayist, screenwriter and playwright. He was a leading international literary figure and intellectual, focusing on poetry until the publication of his first novel, The General of the Dead Army, which made him famous internationally.",
   "photo_url": "/tsundoku/cached/authors/ismail-kadare.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ismail_Kadare",

--- a/src/content/authors/ivan-turgenev.json
+++ b/src/content/authors/ivan-turgenev.json
@@ -1,7 +1,7 @@
 {
   "name": "Ivan Turgenev",
   "slug": "ivan-turgenev",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Ivan Sergeyevich Turgenev was a Russian novelist, short story writer, poet, playwright, translator and popularizer of Russian literature in the West.",
   "photo_url": "/tsundoku/cached/authors/ivan-turgenev.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ivan_Turgenev",

--- a/src/content/authors/j-j-connington.json
+++ b/src/content/authors/j-j-connington.json
@@ -1,7 +1,7 @@
 {
   "name": "J J Connington",
   "slug": "j-j-connington",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Alfred Walter Stewart (5 September 1880 – 1 July 1947) was a Scottish chemist, academic, and part-time novelist who wrote seventeen detective novels and a pioneering science fiction work between 1923 and 1947 under the pseudonym of J. J. Connington. He created several fictional detectives, including Superintendent Ross and Chief Constable Sir Clinton Driffield. [Wikipedia]\r\n\r\nHe was born in Glasgow and educated at the universities of Glasgow, Marburg, and London. He was Professor of Chemistry from 1919 to 1944 at Queen's University, Belfast, and author of a number of respected treatises on chemistry.\r\n\r\nAs J. J. Connington, he wrote over twenty detective stories, beginning with *Death at Swaythling Court* (1926), in which the investigation is usually carried out either by Superintendent Ross (*The Eye in the Museum*, 1929; *The Two Tickets Puzzle*, 1930) or, more often, by Chief Constable Sir Clinton Driffield (*Murder in the Maze*, 1927; *The Sweepstake Murders*, 1931). As Connington he also published an unusual science fiction novel, *Nordenholt's Millions* (1923). - from https://www.jrank.org/literature/pages/3659/J-J-Connington-pseudonym-Alfred-Walter-Stewart.html",
   "photo_url": "/tsundoku/cached/authors/j-j-connington.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL5634689A",

--- a/src/content/authors/j-r-r-tolkien.json
+++ b/src/content/authors/j-r-r-tolkien.json
@@ -1,7 +1,7 @@
 {
   "name": "J.R.R. Tolkien",
   "slug": "j-r-r-tolkien",
-  "book_count": 10,
+  "book_count": 11,
   "bio": "John Ronald Reuel Tolkien was an English writer and philologist. He was the author of the high fantasy works The Hobbit (1937) and The Lord of the Rings (1954–55).",
   "photo_url": "/tsundoku/cached/authors/j-r-r-tolkien.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/J._R._R._Tolkien",

--- a/src/content/authors/j-s-fletcher.json
+++ b/src/content/authors/j-s-fletcher.json
@@ -1,7 +1,7 @@
 {
   "name": "J. S. Fletcher",
   "slug": "j-s-fletcher",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "\n\nJoseph Smith Fletcher was an English journalist and author. He wrote more than 230 books on a wide variety of subjects, both fiction and non-fiction, and was one of the most prolific English writers of detective fiction.",
   "photo_url": "/tsundoku/cached/authors/j-s-fletcher.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/J._S._Fletcher",

--- a/src/content/authors/jack-kerouac.json
+++ b/src/content/authors/jack-kerouac.json
@@ -1,7 +1,7 @@
 {
   "name": "Jack Kerouac",
   "slug": "jack-kerouac",
-  "book_count": 2,
+  "book_count": 4,
   "bio": "Jean-Louis Lebris de Kérouac, known as Jack Kerouac, was an American novelist and poet who, alongside William S. Burroughs and Allen Ginsberg, was a pioneer of the Beat Generation.",
   "photo_url": "/tsundoku/cached/authors/jack-kerouac.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Jack_Kerouac",

--- a/src/content/authors/james-c-scott.json
+++ b/src/content/authors/james-c-scott.json
@@ -1,7 +1,7 @@
 {
   "name": "James C Scott",
   "slug": "james-c-scott",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "James Campbell Scott was an American political scientist and anthropologist specializing in comparative politics. He was a comparative scholar of agrarian and non-state societies.",
   "photo_url": "/tsundoku/cached/authors/james-c-scott.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/James_C._Scott",

--- a/src/content/authors/james-madison.json
+++ b/src/content/authors/james-madison.json
@@ -1,7 +1,7 @@
 {
   "name": "James Madison",
   "slug": "james-madison",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Madison was an American politician who served as the fourth President of the United States between 1809–1817.",
   "photo_url": "/tsundoku/cached/authors/james-madison.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL240767A",

--- a/src/content/authors/james-s-a-corey.json
+++ b/src/content/authors/james-s-a-corey.json
@@ -1,7 +1,7 @@
 {
   "name": "James S.A. Corey",
   "slug": "james-s-a-corey",
-  "book_count": 3,
+  "book_count": 6,
   "bio": "James S. A. Corey is the pen name used by collaborators Daniel Abraham and Ty Franck, authors of the science fiction series The Expanse. The first and last name are taken from Abraham's and Franck's middle names, respectively, and S. A. are the initials of Abraham's daughter. The name is also meant to emulate many of the space opera writers of the 1970s. In Germany, their books are published under the name James Corey with the middle initials omitted.",
   "photo_url": "/tsundoku/cached/authors/james-s-a-corey.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/James_S._A._Corey",

--- a/src/content/authors/jean-genet.json
+++ b/src/content/authors/jean-genet.json
@@ -1,7 +1,7 @@
 {
   "name": "Jean Genet",
   "slug": "jean-genet",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Jean Genet was a French novelist, playwright, poet, essayist, and political activist. In his early life he was a vagabond and petty criminal, but he later became a writer and playwright. His major works include the novels The Thief's Journal and Our Lady of the Flowers and the plays The Balcony, The Maids and The Screens.",
   "photo_url": "/tsundoku/cached/authors/jean-genet.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Jean_Genet",

--- a/src/content/authors/jean-jacques-rousseau.json
+++ b/src/content/authors/jean-jacques-rousseau.json
@@ -1,7 +1,7 @@
 {
   "name": "Jean-Jacques Rousseau",
   "slug": "jean-jacques-rousseau",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Jean-Jacques Rousseau was a Genevan philosopher, philosophe, writer, and composer. His political philosophy influenced the progress of the Age of Enlightenment throughout Europe, as well as aspects of the French Revolution and the development of modern political, economic, and educational thought.",
   "photo_url": "/tsundoku/cached/authors/jean-jacques-rousseau.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Jacques_Rousseau",

--- a/src/content/authors/jean-paul-sartre.json
+++ b/src/content/authors/jean-paul-sartre.json
@@ -1,7 +1,7 @@
 {
   "name": "Jean-Paul Sartre",
   "slug": "jean-paul-sartre",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Jean-Paul Charles Aymard Sartre was a French philosopher, playwright, novelist, screenwriter, political activist, biographer, and literary critic, considered a leading figure in 20th-century French philosophy and Marxism. Sartre was one of the key figures in the philosophy of existentialism. His work has influenced sociology, critical theory, post-colonial theory, and literary studies. He was awarded the 1964 Nobel Prize in Literature despite attempting to refuse it, saying that he always declined official honors and that \"a writer should not allow himself to be turned into an institution.\"",
   "photo_url": "/tsundoku/cached/authors/jean-paul-sartre.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Jean-Paul_Sartre",

--- a/src/content/authors/jean-philippe-aumasson.json
+++ b/src/content/authors/jean-philippe-aumasson.json
@@ -1,7 +1,7 @@
 {
   "name": "Jean-Philippe Aumasson",
   "slug": "jean-philippe-aumasson",
-  "book_count": 2,
+  "book_count": 1,
   "open_library_url": "https://openlibrary.org/authors/OL7940749A",
   "bio": "French researcher"
 }

--- a/src/content/authors/johann-wolfgang-von-goethe.json
+++ b/src/content/authors/johann-wolfgang-von-goethe.json
@@ -1,7 +1,7 @@
 {
   "name": "Johann Wolfgang von Goethe",
   "slug": "johann-wolfgang-von-goethe",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Johann Wolfgang von Goethe was a German polymath who is widely regarded as the most influential writer in the German language. His work has had a wide-ranging influence on literary, political, christian views, and philosophical thought in the Western world from the late 18th century to the present. A poet, playwright, novelist, scientist, statesman, theatre-director, and critic, Goethe wrote a wide range of works, including plays, poetry and aesthetic criticism, as well as treatises on botany, anatomy, and colour.",
   "photo_url": "/tsundoku/cached/authors/johann-wolfgang-von-goethe.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Johann_Wolfgang_von_Goethe",

--- a/src/content/authors/john-buchan.json
+++ b/src/content/authors/john-buchan.json
@@ -1,7 +1,7 @@
 {
   "name": "John Buchan",
   "slug": "john-buchan",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "John Buchan, 1st Baron Tweedsmuir was a Scottish novelist, historian, British Army officer, and Unionist politician who served as Governor General of Canada, the 15th since Canadian Confederation.",
   "photo_url": "/tsundoku/cached/authors/john-buchan.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/John_Buchan",

--- a/src/content/authors/john-locke.json
+++ b/src/content/authors/john-locke.json
@@ -1,7 +1,7 @@
 {
   "name": "John Locke",
   "slug": "john-locke",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "John Locke was an English philosopher and physician, widely regarded as one of the most influential of the Enlightenment thinkers and commonly known as the \"father of liberalism\". His important works include A Letter Concerning Toleration (1689), Two Treatises of Government (1689/90), both published anonymously, and An Essay Concerning Human Understanding (1689/90). His writing on toleration contends that religion is a matter for the individual and that the churches are voluntary associations, ruling out religious coercion and uniformity; these lead to the idea of separation of church and state. His Two Treatises on Government argues for government based on the consent of the governed and the right to revolt against tyrannous government, which has lost consent. The Two Treatises had a direct influence on the language that Thomas Jefferson chose in his drafting the July 1776 Declaration of Independence during the American Revolution.",
   "photo_url": "/tsundoku/cached/authors/john-locke.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/John_Locke",

--- a/src/content/authors/john-maynard-keynes.json
+++ b/src/content/authors/john-maynard-keynes.json
@@ -1,7 +1,7 @@
 {
   "name": "John Maynard Keynes",
   "slug": "john-maynard-keynes",
-  "book_count": 3,
+  "book_count": 2,
   "bio": "John Maynard Keynes, 1st Baron Keynes, was an English economist whose ideas fundamentally changed the theory and practice of macroeconomics and the economic policies of governments. Originally trained in mathematics, he built on and greatly refined earlier work on the causes of business cycles. One of the most influential economists of the 20th century, he produced writings that are the basis for the school of thought known as Keynesian economics, and its various offshoots. His ideas, reformulated as New Keynesianism, are fundamental to mainstream macroeconomics. He is known as the \"father of macroeconomics\".",
   "photo_url": "/tsundoku/cached/authors/john-maynard-keynes.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/John_Maynard_Keynes",

--- a/src/content/authors/john-steinbeck.json
+++ b/src/content/authors/john-steinbeck.json
@@ -1,7 +1,7 @@
 {
   "name": "John Steinbeck",
   "slug": "john-steinbeck",
-  "book_count": 6,
+  "book_count": 7,
   "bio": "John Ernst Steinbeck was an American writer and novelist. He won the 1962 Nobel Prize in Literature \"for his realistic and imaginative writings, combining as they do sympathetic humor and keen social perception\". He has been called \"a giant of American letters\".",
   "photo_url": "/tsundoku/cached/authors/john-steinbeck.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/John_Steinbeck",

--- a/src/content/authors/john-stuart-mill.json
+++ b/src/content/authors/john-stuart-mill.json
@@ -1,7 +1,7 @@
 {
   "name": "John Stuart Mill",
   "slug": "john-stuart-mill",
-  "book_count": 3,
+  "book_count": 5,
   "bio": "John Stuart Mill was an English philosopher, political economist, politician and civil servant. One of the most influential thinkers in the history of liberalism and social liberalism, he contributed widely to social theory, political theory, and political economy. Dubbed \"the most influential English-speaking philosopher of the nineteenth century\" by the Stanford Encyclopedia of Philosophy, he conceived of liberty as justifying the freedom of the individual in opposition to unlimited state and social control. He advocated political and social reforms such as proportional representation, the emancipation of women, and the development of labour organisations and farm cooperatives.",
   "photo_url": "/tsundoku/cached/authors/john-stuart-mill.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/John_Stuart_Mill",

--- a/src/content/authors/jon-bentley.json
+++ b/src/content/authors/jon-bentley.json
@@ -1,7 +1,7 @@
 {
   "name": "Jon Bentley",
   "slug": "jon-bentley",
-  "book_count": 1,
+  "book_count": 2,
   "photo_url": "/tsundoku/cached/authors/jon-bentley.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL2670803A",
   "bio": "Jon Louis Bentley is an American computer scientist who is known for his contributions to computer programming, algorithms and data structure research.",

--- a/src/content/authors/joseph-conrad.json
+++ b/src/content/authors/joseph-conrad.json
@@ -1,7 +1,7 @@
 {
   "name": "Joseph Conrad",
   "slug": "joseph-conrad",
-  "book_count": 6,
+  "book_count": 8,
   "bio": "Joseph Conrad was a Polish-British novelist and story writer. He is regarded as one of the greatest writers in the English language and – though he did not speak English fluently until his twenties – he became a master prose stylist who brought a non-English sensibility into English literature.",
   "photo_url": "/tsundoku/cached/authors/joseph-conrad.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Joseph_Conrad",

--- a/src/content/authors/joseph-shuldiner.json
+++ b/src/content/authors/joseph-shuldiner.json
@@ -1,6 +1,6 @@
 {
   "name": "Joseph Shuldiner",
   "slug": "joseph-shuldiner",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL7298935A"
 }

--- a/src/content/authors/judea-pearl.json
+++ b/src/content/authors/judea-pearl.json
@@ -1,7 +1,7 @@
 {
   "name": "Judea Pearl",
   "slug": "judea-pearl",
-  "book_count": 4,
+  "book_count": 3,
   "bio": "Judea Pearl is an Israeli-American electrical engineer, computer scientist and philosopher, best known for championing the probabilistic approach to artificial intelligence and the development of Bayesian networks. He is also credited for developing a theory of causal and counterfactual inference based on structural models. In 2011, the Association for Computing Machinery (ACM) awarded Pearl with the Turing Award, the highest distinction in computer science, \"for fundamental contributions to artificial intelligence through the development of a calculus for probabilistic and causal reasoning\". He is the author of several books, including the technical Causality: Models, Reasoning and Inference, and The Book of Why, a book on causality aimed at the general public.",
   "photo_url": "/tsundoku/cached/authors/judea-pearl.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Judea_Pearl",

--- a/src/content/authors/jules-verne.json
+++ b/src/content/authors/jules-verne.json
@@ -1,7 +1,7 @@
 {
   "name": "Jules Verne",
   "slug": "jules-verne",
-  "book_count": 5,
+  "book_count": 17,
   "bio": "Jules Gabriel Verne was a French novelist, poet, and playwright.",
   "photo_url": "/tsundoku/cached/authors/jules-verne.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Jules_Verne",

--- a/src/content/authors/julius-caesar.json
+++ b/src/content/authors/julius-caesar.json
@@ -1,7 +1,7 @@
 {
   "name": "Julius Caesar",
   "slug": "julius-caesar",
-  "book_count": 1,
+  "book_count": 3,
   "bio": "Gaius Julius Caesar was a Roman general, statesman, and author who was the dictator of the Roman Republic almost continuously from 49 BC until his assassination in 44 BC. A member of the First Triumvirate, he led the Roman armies through the Gallic Wars and defeated his political rival Pompey in Caesar's civil war. He consolidated power and proclaimed himself dictator for life in 44 BC, which contributed to the political conditions that led to the collapse of the Roman Republic and the emergence of the Roman Empire. For his role in these events, he is regarded as one of the most influential historical figures.",
   "photo_url": "/tsundoku/cached/authors/julius-caesar.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Julius_Caesar",

--- a/src/content/authors/karen-morgan.json
+++ b/src/content/authors/karen-morgan.json
@@ -1,7 +1,7 @@
 {
   "name": "Karen Morgan",
   "slug": "karen-morgan",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL3102544A",
   "bio": "researcher (ORCID 0000-0001-6193-1747)",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Karen_Morgan",

--- a/src/content/authors/karl-marx.json
+++ b/src/content/authors/karl-marx.json
@@ -1,7 +1,7 @@
 {
   "name": "Karl Marx",
   "slug": "karl-marx",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Karl Marx was a German philosopher, social and political theorist, economist, journalist, and revolutionary socialist. He is best-known for the 1848 pamphlet The Communist Manifesto, and his three-volume Das Kapital (1867–1894), a critique of classical political economy which employs his theory of historical materialism in an analysis of capitalism, in the culmination of his life's work. Marx's ideas and their subsequent development, collectively known as Marxism, have had enormous influence.",
   "photo_url": "/tsundoku/cached/authors/karl-marx.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Karl_Marx",

--- a/src/content/authors/kevin-mitnick.json
+++ b/src/content/authors/kevin-mitnick.json
@@ -1,7 +1,7 @@
 {
   "name": "Kevin Mitnick",
   "slug": "kevin-mitnick",
-  "book_count": 3,
+  "book_count": 2,
   "bio": "Kevin David Mitnick was an American computer security consultant, author, and convicted hacker. In 1995, he was arrested for various computer and communications-related crimes, and spent five years in prison after being convicted of fraud and illegally intercepting communications.\nMitnick's pursuit, arrest, trial and sentence were all controversial, as were the associated media coverage, books, and films, with his supporters arguing that his punishment was excessive and that many of the charges against him were fraudulent, and not based on actual losses. After his release from prison, he ran his own security firm, Mitnick Security Consulting, LLC, and was also involved with other computer security businesses.",
   "photo_url": "/tsundoku/cached/authors/kevin-mitnick.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Kevin_Mitnick",

--- a/src/content/authors/l-m-montgomery.json
+++ b/src/content/authors/l-m-montgomery.json
@@ -1,7 +1,7 @@
 {
   "name": "L. M. Montgomery",
   "slug": "l-m-montgomery",
-  "book_count": 1,
+  "book_count": 4,
   "bio": "Lucy Maud Montgomery, published as L. M. Montgomery, was a Canadian author best known for a collection of novels, essays, short stories, and poetry beginning in 1908 with Anne of Green Gables.",
   "photo_url": "/tsundoku/cached/authors/l-m-montgomery.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Lucy_Maud_Montgomery",

--- a/src/content/authors/laozi.json
+++ b/src/content/authors/laozi.json
@@ -1,7 +1,7 @@
 {
   "name": "Laozi",
   "slug": "laozi",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Laozi, formerly latinized as Laocius, was a legendary Chinese philosopher considered to be the author of the Tao Te Ching, one of the foundational texts of Taoism. Modern scholarship generally regards his biographical details as later inventions and his opus a collaboration of various writers, with the name Laozi, literally meaning 'Old Master', likely intended to portray an archaic anonymity that could converse with Confucianism. Traditional accounts addend him as Li Er, born in the 6th-century BC state of Chu during China's Spring and Autumn period. Serving as the royal archivist for the Zhou court at Wangcheng, he met and impressed Confucius on one occasion, composing the Dào Dé Jīng in a single session before retiring into the western wilderness.",
   "photo_url": "/tsundoku/cached/authors/laozi.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Laozi",

--- a/src/content/authors/last-post.json
+++ b/src/content/authors/last-post.json
@@ -1,7 +1,7 @@
 {
   "name": "Last post",
   "slug": "last-post",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "The \"Last Post\" is a British and Commonwealth bugle call used at military funerals, and at ceremonies commemorating those who have died in war.",
   "photo_url": "/tsundoku/cached/authors/last-post.png",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Last_Post",

--- a/src/content/authors/li-bai.json
+++ b/src/content/authors/li-bai.json
@@ -1,7 +1,7 @@
 {
   "name": "Li Bai",
   "slug": "li-bai",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Li Bai also known by his courtesy name of Taibai (太白) was a Chinese poet acclaimed as one of the best and most important poets of the Tang dynasty, and even in the whole of Chinese poetry. He and his friends such as Du Fu (712–770) were among the prominent figures in the flourishing of Chinese poetry of the Tang dynasty, often called the \"Golden Age of Chinese Poetry\". The expression \"Three Wonders\" denotes Li Bai's poetry, Pei Min's swordplay, and Zhang Xu's calligraphy.",
   "photo_url": "/tsundoku/cached/authors/li-bai.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Li_Bai",

--- a/src/content/authors/life-studies.json
+++ b/src/content/authors/life-studies.json
@@ -1,7 +1,7 @@
 {
   "name": "Life Studies",
   "slug": "life-studies",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL7301250A",
   "bio": "book by Robert Lowell",
   "photo_url": "/tsundoku/cached/authors/life-studies.jpg",

--- a/src/content/authors/liu-cixin.json
+++ b/src/content/authors/liu-cixin.json
@@ -1,7 +1,7 @@
 {
   "name": "Liu Cixin",
   "slug": "liu-cixin",
-  "book_count": 5,
+  "book_count": 4,
   "bio": "Liu Cixin is a Chinese computer engineer and science fiction writer. In English translations of his works, his name is given as Cixin Liu. He is sometimes called \"Da Liu\" by his fellow science fiction writers in China.",
   "photo_url": "/tsundoku/cached/authors/liu-cixin.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Liu_Cixin",

--- a/src/content/authors/lord-dunsany.json
+++ b/src/content/authors/lord-dunsany.json
@@ -1,7 +1,7 @@
 {
   "name": "Lord Dunsany",
   "slug": "lord-dunsany",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Edward John Moreton Drax Plunkett, 18th Baron Dunsany, commonly known as Lord Dunsany, was an Anglo-Irish writer and dramatist. He published more than 90 books during his lifetime, and his output consisted of hundreds of short stories, plays, novels, and essays; further works were published posthumously. Having gained a name in the 1910s as a writer in the English-speaking world, he is best known today for the 1924 fantasy novel The King of Elfland's Daughter, and his first book, The Gods of Pegāna, which depicts a fictional pantheon. Many critics feel his early work laid grounds for the fantasy genre.",
   "photo_url": "/tsundoku/cached/authors/lord-dunsany.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Lord_Dunsany",

--- a/src/content/authors/maimonides.json
+++ b/src/content/authors/maimonides.json
@@ -1,7 +1,7 @@
 {
   "name": "Maimonides",
   "slug": "maimonides",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Moses ben Maimon, commonly known as Maimonides and also referred to by the Hebrew acronym Rambam, was a Sephardic Jewish rabbi who is widely acknowledged as one of the most prolific and influential Torah scholars of the Middle Ages. Originally from Córdoba, where he was born on Passover Eve of 1135 or 1138, his family was exiled from Muslim-ruled Spain when they refused to convert to Islam shortly after the Almohad Caliphate conquered the Almoravid dynasty in 1148. Over the course of the next two decades, Maimonides resided in Fez, Acre, Jerusalem, Alexandria, and Cairo before finally settling in Fustat between 1168 and 1171. During this period, he advanced his vocations and became renowned for his achievements as an astronomer, philosopher, and physician—even being appointed to serve as personal physician to Saladin of the Ayyubid Sultanate.",
   "photo_url": "/tsundoku/cached/authors/maimonides.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Maimonides",

--- a/src/content/authors/marcel-proust.json
+++ b/src/content/authors/marcel-proust.json
@@ -1,7 +1,7 @@
 {
   "name": "Marcel Proust",
   "slug": "marcel-proust",
-  "book_count": 7,
+  "book_count": 8,
   "bio": "Valentin Louis Georges Eugène Marcel Proust was a French novelist, literary critic, and essayist best known for his novel À la recherche du temps perdu, which was published in seven volumes between 1913 and 1927. He is considered by critics and writers to be one of the most influential authors of the twentieth century.",
   "photo_url": "/tsundoku/cached/authors/marcel-proust.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Marcel_Proust",

--- a/src/content/authors/marcus-tullius-cicero.json
+++ b/src/content/authors/marcus-tullius-cicero.json
@@ -1,7 +1,7 @@
 {
   "name": "Marcus Tullius Cicero",
   "slug": "marcus-tullius-cicero",
-  "book_count": 1,
+  "book_count": 3,
   "bio": "Marcus Tullius Cicero was a Roman statesman, lawyer, scholar, philosopher, orator, writer and Academic skeptic, who tried to uphold optimate principles during the political crises that led to the establishment of the Roman Empire. His extensive writings include treatises on rhetoric, philosophy and politics. He is considered one of Rome's greatest orators and prose stylists and the innovator of what became known as \"Ciceronian rhetoric\". Cicero was educated in Rome and in Greece. He came from a wealthy municipal family of the Roman equestrian order, and served as consul in 63 BC.",
   "photo_url": "/tsundoku/cached/authors/marcus-tullius-cicero.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Cicero",

--- a/src/content/authors/margaret-oliphant.json
+++ b/src/content/authors/margaret-oliphant.json
@@ -1,7 +1,7 @@
 {
   "name": "Margaret Oliphant",
   "slug": "margaret-oliphant",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Margaret Oliphant Wilson Oliphant was a Scottish novelist and historical writer, who usually wrote as Mrs. Oliphant. Her fictional works cover \"domestic realism, the historical novel and tales of the supernatural\".",
   "photo_url": "/tsundoku/cached/authors/margaret-oliphant.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Margaret_Oliphant",

--- a/src/content/authors/margery-allingham.json
+++ b/src/content/authors/margery-allingham.json
@@ -1,7 +1,7 @@
 {
   "name": "Margery Allingham",
   "slug": "margery-allingham",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Margery Louise Allingham was an English novelist from the \"Golden Age of Detective Fiction\", and considered one of its four \"Queens of Crime\", alongside Agatha Christie, Dorothy L. Sayers and Ngaio Marsh.",
   "photo_url": "/tsundoku/cached/authors/margery-allingham.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Margery_Allingham",

--- a/src/content/authors/mark-russinovich.json
+++ b/src/content/authors/mark-russinovich.json
@@ -1,7 +1,7 @@
 {
   "name": "Mark Russinovich",
   "slug": "mark-russinovich",
-  "book_count": 1,
+  "book_count": 4,
   "bio": "Mark Eugene Russinovich is a Spanish-born American software engineer and author who serves as CTO of Microsoft Azure. He was a cofounder of software producers Winternals before Microsoft acquired it in 2006.",
   "photo_url": "/tsundoku/cached/authors/mark-russinovich.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Mark_Russinovich",

--- a/src/content/authors/martin-luther.json
+++ b/src/content/authors/martin-luther.json
@@ -1,7 +1,7 @@
 {
   "name": "Martin Luther",
   "slug": "martin-luther",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Martin Luther was a German priest, theologian, author, hymnwriter, professor, and former Augustinian friar. Luther was the seminal figure of the Protestant Reformation, and his theological beliefs form the basis of Lutheranism. He is widely regarded as one of the most influential figures in Western and Christian history.",
   "photo_url": "/tsundoku/cached/authors/martin-luther.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Martin_Luther",

--- a/src/content/authors/marx-engels.json
+++ b/src/content/authors/marx-engels.json
@@ -1,7 +1,7 @@
 {
   "name": "Marx & Engels",
   "slug": "marx-engels",
-  "book_count": 1,
+  "book_count": 0,
   "photo_url": "/tsundoku/cached/authors/marx-engels.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL3120184A",
   "bio": "scholarly article in Journal of Henan University (Social Science), no. 4, 2011",

--- a/src/content/authors/marx.json
+++ b/src/content/authors/marx.json
@@ -1,7 +1,7 @@
 {
   "name": "Marx",
   "slug": "marx",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "German philosopher, economist, sociologist, journalist and revolutionary socialist",
   "photo_url": "/tsundoku/cached/authors/marx.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL48230A",

--- a/src/content/authors/mary-mary.json
+++ b/src/content/authors/mary-mary.json
@@ -1,7 +1,7 @@
 {
   "name": "Mary Mary",
   "slug": "mary-mary",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Mary Mary is an American urban contemporary gospel duo formed in 1998, consisting of sisters Erica Atkins-Campbell and Trecina Atkins-Campbell. Their name is inspired by two biblical figures: Mary, mother of Jesus, and Mary Magdalene. They are credited with expanding the reach of urban contemporary gospel in the 2000s by blending elements of soul, hip-hop, funk, and jazz. The duo has been nominated for eleven Grammy Awards, winning four, including Best Gospel Performance and Best Contemporary Soul Gospel Album.",
   "photo_url": "/tsundoku/cached/authors/mary-mary.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Mary_Mary",

--- a/src/content/authors/maurice-le-blanc.json
+++ b/src/content/authors/maurice-le-blanc.json
@@ -1,7 +1,7 @@
 {
   "name": "Maurice le Blanc",
   "slug": "maurice-le-blanc",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Maurice Marie Émile Leblanc was a French novelist and writer of short stories, known primarily as the creator of the fictional gentleman thief and detective Arsène Lupin, often described as a French counterpart to Arthur Conan Doyle's creation Sherlock Holmes.",
   "photo_url": "/tsundoku/cached/authors/maurice-le-blanc.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Maurice_Leblanc",

--- a/src/content/authors/mcgraw.json
+++ b/src/content/authors/mcgraw.json
@@ -1,7 +1,7 @@
 {
   "name": "McGraw",
   "slug": "mcgraw",
-  "book_count": 1,
+  "book_count": 2,
   "photo_url": "/tsundoku/cached/authors/mcgraw.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL2624612A",
   "bio": "family name",

--- a/src/content/authors/michael-crichton.json
+++ b/src/content/authors/michael-crichton.json
@@ -1,7 +1,7 @@
 {
   "name": "Michael Crichton",
   "slug": "michael-crichton",
-  "book_count": 1,
+  "book_count": 3,
   "bio": "John Michael Crichton was an American author, screenwriter and filmmaker. His books have sold over 200 million copies worldwide, and over a dozen have been adapted into films. His literary works heavily feature technology and are usually within the science fiction, techno-thriller, and medical fiction genres. Crichton's novels often explore human technological advancement and attempted dominance over nature, both with frequently catastrophic results; many of his works are cautionary tales, especially regarding themes of biotechnology. Several of his stories center on themes of genetic modification, hybridization, paleontology and/or zoology. Many feature medical or scientific underpinnings, reflective of his own medical background.",
   "photo_url": "/tsundoku/cached/authors/michael-crichton.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Michael_Crichton",

--- a/src/content/authors/michel-foucault.json
+++ b/src/content/authors/michel-foucault.json
@@ -1,7 +1,7 @@
 {
   "name": "Michel Foucault",
   "slug": "michel-foucault",
-  "book_count": 6,
+  "book_count": 7,
   "bio": "Paul-Michel Foucault was a French historian of ideas and philosopher, who was also an author, literary critic, political activist, and teacher. Foucault's theories primarily addressed the relationships between power versus knowledge and liberty, and he analyzed how they are used as a form of social control through multiple institutions. Though often cited as a structuralist and postmodernist, Foucault rejected these labels and sought to critique authority without limits on himself. His thought has influenced academics within a large number of contrasting areas of study, with this especially including those working in anthropology, communication studies, criminology, cultural studies, feminism, literary theory, psychology, and sociology. His efforts against homophobia and racial prejudice as well as against other ideological doctrines have also shaped research into critical theory and Marxism–Leninism alongside other topics.",
   "photo_url": "/tsundoku/cached/authors/michel-foucault.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Michel_Foucault",

--- a/src/content/authors/milan-kundera.json
+++ b/src/content/authors/milan-kundera.json
@@ -1,7 +1,7 @@
 {
   "name": "Milan Kundera",
   "slug": "milan-kundera",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Milan Kundera was a Czech and French novelist. Kundera went into exile in France in 1975, acquiring citizenship in 1981. His Czechoslovak citizenship was revoked in 1979, but he was granted Czech citizenship in 2019.",
   "photo_url": "/tsundoku/cached/authors/milan-kundera.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Milan_Kundera",

--- a/src/content/authors/mitchell-waldrop.json
+++ b/src/content/authors/mitchell-waldrop.json
@@ -1,7 +1,7 @@
 {
   "name": "Mitchell Waldrop",
   "slug": "mitchell-waldrop",
-  "book_count": 2,
+  "book_count": 1,
   "photo_url": "/tsundoku/cached/authors/mitchell-waldrop.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL835465A",
   "bio": "science writer and editor",

--- a/src/content/authors/miyamoto-musashi.json
+++ b/src/content/authors/miyamoto-musashi.json
@@ -1,7 +1,7 @@
 {
   "name": "Miyamoto Musashi",
   "slug": "miyamoto-musashi",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Miyamoto Musashi  was a Japanese swordsman, strategist, artist and writer who became renowned through stories of his unique double-bladed swordsmanship and undefeated record in his 62 duels. Musashi is considered a kensei of Japan. He was the founder of the Niten Ichi-ryū style of swordsmanship, and in his final years authored The Book of Five Rings  and Dokkōdō.",
   "photo_url": "/tsundoku/cached/authors/miyamoto-musashi.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Miyamoto_Musashi",

--- a/src/content/authors/n-k-jemisin.json
+++ b/src/content/authors/n-k-jemisin.json
@@ -1,7 +1,7 @@
 {
   "name": "N. K. Jemisin",
   "slug": "n-k-jemisin",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Nora Keita Jemisin is an American science fiction and fantasy writer. Her fiction includes a wide range of themes, notably cultural conflict and oppression. Her debut novel, The Hundred Thousand Kingdoms (2010), and the subsequent books in her Inheritance Trilogy received critical acclaim.",
   "photo_url": "/tsundoku/cached/authors/n-k-jemisin.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/N._K._Jemisin",

--- a/src/content/authors/nassim-nicholas-taleb.json
+++ b/src/content/authors/nassim-nicholas-taleb.json
@@ -1,7 +1,7 @@
 {
   "name": "Nassim Nicholas Taleb",
   "slug": "nassim-nicholas-taleb",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Nassim Nicholas Taleb is a Lebanese-American New York Polytech professor, essayist, mathematical statistician, former option trader, risk analyst, and aphorist. His work concerns problems of randomness, probability, complexity, and uncertainty.",
   "photo_url": "/tsundoku/cached/authors/nassim-nicholas-taleb.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Nassim_Nicholas_Taleb",

--- a/src/content/authors/nathaniel-hawthorne.json
+++ b/src/content/authors/nathaniel-hawthorne.json
@@ -1,7 +1,7 @@
 {
   "name": "Nathaniel Hawthorne",
   "slug": "nathaniel-hawthorne",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Nathaniel Hawthorne was an American novelist and short story writer. His works often focus on history, morality, and religion.",
   "photo_url": "/tsundoku/cached/authors/nathaniel-hawthorne.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Nathaniel_Hawthorne",

--- a/src/content/authors/national-research-council.json
+++ b/src/content/authors/national-research-council.json
@@ -1,7 +1,7 @@
 {
   "name": "National Research Council",
   "slug": "national-research-council",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL2153461A",
   "bio": "Italian national research funding organization",
   "photo_url": "/tsundoku/cached/authors/national-research-council.jpg",

--- a/src/content/authors/neal-stephenson.json
+++ b/src/content/authors/neal-stephenson.json
@@ -1,7 +1,7 @@
 {
   "name": "Neal Stephenson",
   "slug": "neal-stephenson",
-  "book_count": 7,
+  "book_count": 8,
   "bio": "Neal Town Stephenson is an American writer known for his works of speculative fiction. His novels have been categorized as science fiction, historical fiction, cyberpunk, and baroque.",
   "photo_url": "/tsundoku/cached/authors/neal-stephenson.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Neal_Stephenson",

--- a/src/content/authors/neil-gaiman.json
+++ b/src/content/authors/neil-gaiman.json
@@ -1,7 +1,7 @@
 {
   "name": "Neil Gaiman",
   "slug": "neil-gaiman",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Neil Richard MacKinnon Gaiman is an English author of short fiction, novels, comic books, audio theatre, and screenplays. His works include the comic series The Sandman (1989–1996) and the novels Good Omens (1990), Stardust (1999), American Gods (2001), Coraline (2002), Anansi Boys (2005), The Graveyard Book (2008) and The Ocean at the End of the Lane (2013). He co-created the TV adaptations of Good Omens and The Sandman.",
   "photo_url": "/tsundoku/cached/authors/neil-gaiman.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Neil_Gaiman",

--- a/src/content/authors/niccol-machiavelli.json
+++ b/src/content/authors/niccol-machiavelli.json
@@ -1,7 +1,7 @@
 {
   "name": "Niccolò Machiavelli",
   "slug": "niccol-machiavelli",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Niccolò di Bernardo dei Machiavelli was a Florentine diplomat, author, philosopher, and historian who lived during the Italian Renaissance. He is best known for his political treatise The Prince, written around 1513 but not published until 1532, five years after his death. He has often been called the father of modern political philosophy and political science.",
   "photo_url": "/tsundoku/cached/authors/niccol-machiavelli.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Niccol%C3%B2_Machiavelli",

--- a/src/content/authors/oren-patashnik.json
+++ b/src/content/authors/oren-patashnik.json
@@ -1,7 +1,7 @@
 {
   "name": "Oren Patashnik",
   "slug": "oren-patashnik",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL2669938A",
   "bio": "American computer scientist",
   "birth_year": 1954,

--- a/src/content/authors/orson-scott-card.json
+++ b/src/content/authors/orson-scott-card.json
@@ -1,7 +1,7 @@
 {
   "name": "Orson Scott Card",
   "slug": "orson-scott-card",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Orson Scott Card is an American writer known best for his science fiction works. As of 2024, he is the only person to have won a Hugo Award and a Nebula Award in consecutive years, winning both awards for his novel Ender's Game (1985) and its sequel Speaker for the Dead (1986). A feature film adaptation of Ender's Game, which Card coproduced, was released in 2013. Card also wrote the Locus Fantasy Award-winning series The Tales of Alvin Maker (1987–2003). Card's fiction often features characters with exceptional gifts who make difficult choices with high stakes. Card has also written political, religious, and social commentary in his columns and other writing; he has provoked controversy and criticism for his public opposition to homosexuality.",
   "photo_url": "/tsundoku/cached/authors/orson-scott-card.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Orson_Scott_Card",

--- a/src/content/authors/oscar-wilde.json
+++ b/src/content/authors/oscar-wilde.json
@@ -1,7 +1,7 @@
 {
   "name": "Oscar Wilde",
   "slug": "oscar-wilde",
-  "book_count": 4,
+  "book_count": 6,
   "bio": "Oscar Fingal O'Fflahertie Wills Wilde was an Irish author, poet and playwright. After writing in different literary styles throughout the 1880s, he became one of the most popular and influential dramatists in London in the early 1890s. He was a key figure in the emerging Aestheticism movement of the late 19th century and is regarded by many as the greatest playwright of the Victorian era. Wilde is best known for his Gothic novel The Picture of Dorian Gray (1890), his epigrams, plays and bedtime stories for children, as well as his criminal conviction in 1895 for gross indecency and for practicing homosexual acts.",
   "photo_url": "/tsundoku/cached/authors/oscar-wilde.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Oscar_Wilde",

--- a/src/content/authors/owasp-foundation.json
+++ b/src/content/authors/owasp-foundation.json
@@ -1,7 +1,7 @@
 {
   "name": "OWASP Foundation",
   "slug": "owasp-foundation",
-  "book_count": 2,
+  "book_count": 1,
   "photo_url": "/tsundoku/cached/authors/owasp-foundation.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL13221465A",
   "photo_url_source": "https://covers.openlibrary.org/a/olid/OL13221465A-M.jpg",

--- a/src/content/authors/p-g-wodehouse.json
+++ b/src/content/authors/p-g-wodehouse.json
@@ -1,7 +1,7 @@
 {
   "name": "P. G. Wodehouse",
   "slug": "p-g-wodehouse",
-  "book_count": 8,
+  "book_count": 9,
   "bio": "Sir Pelham Grenville Wodehouse was an English writer and one of the most widely read humorists of the 20th century. His creations include the feather-brained Bertie Wooster and his sagacious valet, Jeeves; the immaculate and loquacious Psmith; Lord Emsworth and the Blandings Castle set; the Oldest Member, with stories about golf; and Mr. Mulliner, with tall tales on subjects ranging from bibulous bishops to megalomaniac movie moguls.",
   "photo_url": "/tsundoku/cached/authors/p-g-wodehouse.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/P._G._Wodehouse",

--- a/src/content/authors/pelham-grenville-wodehouse.json
+++ b/src/content/authors/pelham-grenville-wodehouse.json
@@ -1,7 +1,7 @@
 {
   "name": "Pelham Grenville Wodehouse",
   "slug": "pelham-grenville-wodehouse",
-  "book_count": 5,
+  "book_count": 7,
   "bio": "Sir Pelham Grenville Wodehouse was an English writer and one of the most widely read humorists of the 20th century. His creations include the feather-brained Bertie Wooster and his sagacious valet, Jeeves; the immaculate and loquacious Psmith; Lord Emsworth and the Blandings Castle set; the Oldest Member, with stories about golf; and Mr. Mulliner, with tall tales on subjects ranging from bibulous bishops to megalomaniac movie moguls.",
   "photo_url": "/tsundoku/cached/authors/pelham-grenville-wodehouse.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/P._G._Wodehouse",

--- a/src/content/authors/philip-k-dick.json
+++ b/src/content/authors/philip-k-dick.json
@@ -1,7 +1,7 @@
 {
   "name": "Philip K. Dick",
   "slug": "philip-k-dick",
-  "book_count": 8,
+  "book_count": 9,
   "bio": "Philip Kindred Dick was an American science fiction short story writer and novelist. He wrote 45 novels and about 121 short stories, most of which appeared in science fiction magazines. His fiction explored varied philosophical and social questions such as the nature of reality, perception, human nature, and identity, and commonly featured characters struggling against alternate realities, illusory environments, monopolistic corporations, drug abuse, authoritarian governments, and altered states of consciousness. He is considered one of the most important figures in 20th-century science fiction.",
   "photo_url": "/tsundoku/cached/authors/philip-k-dick.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Philip_K._Dick",

--- a/src/content/authors/piers-anthony.json
+++ b/src/content/authors/piers-anthony.json
@@ -1,7 +1,7 @@
 {
   "name": "Piers Anthony",
   "slug": "piers-anthony",
-  "book_count": 5,
+  "book_count": 7,
   "bio": "Piers Anthony Dillingham Jacob is an American author in the science fiction and fantasy genres, publishing under the name Piers Anthony. He is best known for his long-running novel series set in the fictional realm of Xanth.",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Piers_Anthony",
   "photo_url": "/tsundoku/cached/authors/piers-anthony.jpg",

--- a/src/content/authors/plutarch.json
+++ b/src/content/authors/plutarch.json
@@ -1,7 +1,7 @@
 {
   "name": "Plutarch",
   "slug": "plutarch",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Plutarch was a Greek and later Roman Middle Platonist philosopher, historian, biographer, essayist, and priest at the Temple of Apollo in Delphi. He is known primarily for his Parallel Lives, a series of biographies of illustrious Greeks and Romans, and Moralia, a collection of essays and speeches. Upon becoming a Roman citizen, he was possibly named Lucius Mestrius Plutarchus.",
   "photo_url": "/tsundoku/cached/authors/plutarch.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Plutarch",

--- a/src/content/authors/rabindranath-tagore.json
+++ b/src/content/authors/rabindranath-tagore.json
@@ -1,7 +1,7 @@
 {
   "name": "Rabindranath Tagore",
   "slug": "rabindranath-tagore",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Rabindranath Thakur, also known by his pseudonym Bhanusimha was a Bengali polymath of the Bengal Renaissance period. In 1913, Tagore became the first Asian to win a Nobel Prize in any category, and also the first lyricist and non-European to win the Nobel Prize in Literature. A significant moulder of culture within the Indian subcontinent, he has written and composed the national anthems of India and Bangladesh.",
   "photo_url": "/tsundoku/cached/authors/rabindranath-tagore.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Rabindranath_Tagore",

--- a/src/content/authors/rainer-maria-rilke.json
+++ b/src/content/authors/rainer-maria-rilke.json
@@ -1,7 +1,7 @@
 {
   "name": "Rainer Maria Rilke",
   "slug": "rainer-maria-rilke",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "René Karl Wilhelm Johann Josef Maria Rilke, known as Rainer Maria Rilke, was an Austrian poet. Acclaimed as an idiosyncratic and expressive poet, he is widely recognized as a significant writer in the German language. His work is viewed by critics and scholars as possessing undertones of mysticism, exploring themes of subjective experience and disbelief. His writings include one novel, several collections of poetry, several volumes of correspondence and a few early novellas.",
   "photo_url": "/tsundoku/cached/authors/rainer-maria-rilke.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Rainer_Maria_Rilke",

--- a/src/content/authors/ralph-waldo-emerson.json
+++ b/src/content/authors/ralph-waldo-emerson.json
@@ -1,7 +1,7 @@
 {
   "name": "Ralph Waldo Emerson",
   "slug": "ralph-waldo-emerson",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Ralph Waldo Emerson, who went by his middle name Waldo, was an American essayist, lecturer, philosopher, minister, abolitionist, and poet who led the Transcendentalist movement of the mid-19th century. He was seen as a champion of individualism and critical thinking, as well as a prescient critic of the countervailing pressures of society and conformity. Friedrich Nietzsche thought he was \"the most gifted of the Americans,\" and Walt Whitman called Emerson his \"master\".",
   "photo_url": "/tsundoku/cached/authors/ralph-waldo-emerson.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ralph_Waldo_Emerson",

--- a/src/content/authors/richard-h-thaler-and-cass-r-sunstein.json
+++ b/src/content/authors/richard-h-thaler-and-cass-r-sunstein.json
@@ -1,7 +1,7 @@
 {
   "name": "Richard H. Thaler and Cass R. Sunstein",
   "slug": "richard-h-thaler-and-cass-r-sunstein",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "American economist",
   "photo_url": "/tsundoku/cached/authors/richard-h-thaler-and-cass-r-sunstein.jpg",
   "birth_year": 1945,

--- a/src/content/authors/richard-h-thaler.json
+++ b/src/content/authors/richard-h-thaler.json
@@ -1,7 +1,7 @@
 {
   "name": "Richard H. Thaler",
   "slug": "richard-h-thaler",
-  "book_count": 1,
+  "book_count": 0,
   "photo_url": "/tsundoku/cached/authors/richard-h-thaler.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL717241A",
   "birth_year": 1945,

--- a/src/content/authors/richard-jefferies.json
+++ b/src/content/authors/richard-jefferies.json
@@ -1,7 +1,7 @@
 {
   "name": "Richard Jefferies",
   "slug": "richard-jefferies",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "John Richard Jefferies was an English nature writer, noted for his depiction of English rural life in essays, books of natural history, and novels. His childhood on a small Wiltshire farm had a great influence on him and provides the background to all his major works of fiction.",
   "photo_url": "/tsundoku/cached/authors/richard-jefferies.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Richard_Jefferies",

--- a/src/content/authors/rob-pike.json
+++ b/src/content/authors/rob-pike.json
@@ -1,7 +1,7 @@
 {
   "name": "Rob Pike",
   "slug": "rob-pike",
-  "book_count": 2,
+  "book_count": 4,
   "bio": "Robert Pike is a Canadian programmer and author.\nHe is best known for his work on the Go programming language while working at Google\nand the Plan 9 operating system while working at Bell Labs, where he was a member of the Unix team.",
   "photo_url": "/tsundoku/cached/authors/rob-pike.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Rob_Pike",

--- a/src/content/authors/robbins.json
+++ b/src/content/authors/robbins.json
@@ -1,7 +1,7 @@
 {
   "name": "Robbins",
   "slug": "robbins",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL390061A",
   "birth_year": 1898,
   "death_year": 1984,

--- a/src/content/authors/robert-a-heinlein.json
+++ b/src/content/authors/robert-a-heinlein.json
@@ -1,7 +1,7 @@
 {
   "name": "Robert A. Heinlein",
   "slug": "robert-a-heinlein",
-  "book_count": 10,
+  "book_count": 11,
   "bio": "Robert Anson Heinlein was an American science fiction author, engineer, and naval officer. Sometimes called the \"dean of science fiction writers\", he was among the first to emphasize scientific accuracy in his fiction and was thus a pioneer of the subgenre of hard science fiction. His published works, both fiction and non-fiction, express admiration for competence and emphasize the value of critical thinking. His plots often presented provocative situations which challenged conventional social mores. His work continues to have an influence on the science fiction genre and on modern culture more generally.",
   "photo_url": "/tsundoku/cached/authors/robert-a-heinlein.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Robert_A._Heinlein",

--- a/src/content/authors/robert-e-howard.json
+++ b/src/content/authors/robert-e-howard.json
@@ -1,7 +1,7 @@
 {
   "name": "Robert E. Howard",
   "slug": "robert-e-howard",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Robert Ervin Howard was an American writer who wrote pulp fiction in a diverse range of genres. He created the character Conan the Barbarian and is regarded as the father of the sword and sorcery subgenre.",
   "photo_url": "/tsundoku/cached/authors/robert-e-howard.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Robert_E._Howard",

--- a/src/content/authors/robert-jordan.json
+++ b/src/content/authors/robert-jordan.json
@@ -1,7 +1,7 @@
 {
   "name": "Robert Jordan",
   "slug": "robert-jordan",
-  "book_count": 12,
+  "book_count": 15,
   "bio": "James Oliver Rigney Jr., known by his pen name Robert Jordan, was an American author of epic fantasy. He is best known as the author of The Wheel of Time series, which comprises 14 books and a prequel novel. The series is among the highest selling book series of all time, with 90 million copies sold. In his earlier career he became one of several writers to produce original Conan the Barbarian novels; his are considered by fans to be some of the best of the non-Robert E. Howard efforts. Robert Jordan was the most well known of several pen names he used, adopting different monikers for different genres.",
   "photo_url": "/tsundoku/cached/authors/robert-jordan.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Robert_Jordan",

--- a/src/content/authors/robert-louis-stevenson.json
+++ b/src/content/authors/robert-louis-stevenson.json
@@ -1,7 +1,7 @@
 {
   "name": "Robert Louis Stevenson",
   "slug": "robert-louis-stevenson",
-  "book_count": 1,
+  "book_count": 8,
   "bio": "Robert Louis Stevenson was a Scottish novelist, essayist, poet and travel writer. He is best known for the novels Treasure Island (1883), Strange Case of Dr Jekyll and Mr Hyde (1886), and Kidnapped (1886) and for the poetry collection A Child's Garden of Verses (1885).",
   "photo_url": "/tsundoku/cached/authors/robert-louis-stevenson.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Robert_Louis_Stevenson",

--- a/src/content/authors/robert-ludlum.json
+++ b/src/content/authors/robert-ludlum.json
@@ -1,7 +1,7 @@
 {
   "name": "Robert Ludlum",
   "slug": "robert-ludlum",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Robert Ludlum was an American author of 27 thriller novels, best known as the creator of Jason Bourne from the original The Bourne Trilogy series. The number of copies of his books in print is estimated between 300 million and 500 million. They have been published in 33 languages and 40 countries. Ludlum also published books under the pseudonyms Jonathan Ryder and Michael Shepherd.",
   "photo_url": "/tsundoku/cached/authors/robert-ludlum.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Robert_Ludlum",

--- a/src/content/authors/robin-asbell.json
+++ b/src/content/authors/robin-asbell.json
@@ -1,6 +1,6 @@
 {
   "name": "Robin Asbell",
   "slug": "robin-asbell",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL2833526A"
 }

--- a/src/content/authors/robinson.json
+++ b/src/content/authors/robinson.json
@@ -1,7 +1,7 @@
 {
   "name": "Robinson",
   "slug": "robinson",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "Joan Robinson was educated at Girton College, Cambridge, and was Reader in Economics at Cambridge University since 1949. In addition to Economic Philosophy, she was the author of *Economics of Imperfect Competition, Essays in the Theory of Employment, Essay on Marxian Economics, The Accumulation of Capital*, and many other articles in economic journals. One of last century's most distinguished economic theorists, Mrs. Robinson always lived in Cambridge, England.",
   "open_library_url": "https://openlibrary.org/authors/OL120843A",
   "birth_year": 1903,

--- a/src/content/authors/roland-barthes.json
+++ b/src/content/authors/roland-barthes.json
@@ -1,7 +1,7 @@
 {
   "name": "Roland Barthes",
   "slug": "roland-barthes",
-  "book_count": 5,
+  "book_count": 6,
   "bio": "Roland Gérard Barthes was a French literary theorist, essayist, philosopher, critic, and semiotician. His work engaged in the analysis of a variety of sign systems, mainly derived from Western popular culture. His ideas explored a diverse range of fields, including structuralism, anthropology, literary theory, and post-structuralism, and influenced the development of multiple schools of theory.",
   "photo_url": "/tsundoku/cached/authors/roland-barthes.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Roland_Barthes",

--- a/src/content/authors/ronald-graham.json
+++ b/src/content/authors/ronald-graham.json
@@ -1,7 +1,7 @@
 {
   "name": "Ronald Graham",
   "slug": "ronald-graham",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL1317530A",
   "bio": "American mathematician (1935-2020)",
   "photo_url": "/tsundoku/cached/authors/ronald-graham.jpg",

--- a/src/content/authors/ronald-knox.json
+++ b/src/content/authors/ronald-knox.json
@@ -1,7 +1,7 @@
 {
   "name": "Ronald Knox",
   "slug": "ronald-knox",
-  "book_count": 1,
+  "book_count": 3,
   "bio": "Ronald Arbuthnott Knox was an English Catholic priest, theologian, author, and radio broadcaster. Educated at Eton and Balliol College, Oxford, where he earned a high reputation as a classicist, Knox was ordained as a priest of the Church of England in 1912. He was a fellow and chaplain of Trinity College, Oxford until he resigned from those positions following his conversion to Catholicism in 1917. Knox became a Catholic priest in 1918, continuing in that capacity his scholarly and literary work.",
   "photo_url": "/tsundoku/cached/authors/ronald-knox.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ronald_Knox",

--- a/src/content/authors/ross-anderson.json
+++ b/src/content/authors/ross-anderson.json
@@ -1,7 +1,7 @@
 {
   "name": "Ross Anderson",
   "slug": "ross-anderson",
-  "book_count": 1,
+  "book_count": 2,
   "photo_url": "/tsundoku/cached/authors/ross-anderson.jpg",
   "open_library_url": "https://openlibrary.org/authors/OL7576941A",
   "bio": "Ross John Anderson was a British researcher, author, and industry consultant in security engineering. He was Professor of Security Engineering at the Department of Computer Science and Technology, University of Cambridge where he was part of the University's security group.",

--- a/src/content/authors/s-ren-kierkegaard.json
+++ b/src/content/authors/s-ren-kierkegaard.json
@@ -1,7 +1,7 @@
 {
   "name": "Søren Kierkegaard",
   "slug": "s-ren-kierkegaard",
-  "book_count": 7,
+  "book_count": 8,
   "bio": "Søren Aabye Kierkegaard was a Danish theologian, philosopher, poet, social critic, and religious author who is widely considered to be the first existentialist philosopher. He wrote critical texts on organized religion, Christianity, morality, ethics, psychology, love, and the philosophy of religion, displaying a fondness for metaphor, irony, and parables. Much of his philosophical work deals with the issues of how one lives as a \"single individual\", highlighting the importance of authenticity, personal choice and commitment, and the duty to love. Kierkegaard prioritized concrete human reality over abstract thinking.",
   "photo_url": "/tsundoku/cached/authors/s-ren-kierkegaard.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/S%C3%B8ren_Kierkegaard",

--- a/src/content/authors/s-s-van-dine.json
+++ b/src/content/authors/s-s-van-dine.json
@@ -1,7 +1,7 @@
 {
   "name": "S. S. Van Dine",
   "slug": "s-s-van-dine",
-  "book_count": 1,
+  "book_count": 3,
   "bio": "S. S. Van Dine is the pen name used by American art critic Willard Huntington Wright when he wrote detective novels. Wright was active in avant-garde cultural circles in pre–World War I New York, and under the pen name he created the fictional detective Philo Vance, a sleuth and aesthete who first appeared in books in the 1920s, then in films and on the radio.",
   "photo_url": "/tsundoku/cached/authors/s-s-van-dine.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/S._S._Van_Dine",

--- a/src/content/authors/salman-rushdie.json
+++ b/src/content/authors/salman-rushdie.json
@@ -1,7 +1,7 @@
 {
   "name": "Salman Rushdie",
   "slug": "salman-rushdie",
-  "book_count": 4,
+  "book_count": 3,
   "bio": "Sir Ahmed Salman Rushdie is an Indian-born British and American novelist. His work often combines magical realism with historical fiction and primarily deals with connections, disruptions, and migrations between Eastern and Western civilizations, typically set on the Indian subcontinent. Rushdie's second novel, Midnight's Children (1981), won the Booker Prize in 1981 and was deemed to be \"the best novel of all winners\" on two occasions that marked the 25th and the 40th anniversary of the prize.",
   "photo_url": "/tsundoku/cached/authors/salman-rushdie.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Salman_Rushdie",

--- a/src/content/authors/school-stories.json
+++ b/src/content/authors/school-stories.json
@@ -1,5 +1,5 @@
 {
   "name": "School Stories",
   "slug": "school-stories",
-  "book_count": 1
+  "book_count": 0
 }

--- a/src/content/authors/sheridan-le-fanu.json
+++ b/src/content/authors/sheridan-le-fanu.json
@@ -1,7 +1,7 @@
 {
   "name": "Sheridan Le Fanu",
   "slug": "sheridan-le-fanu",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Joseph Thomas Sheridan Le Fanu, often shortened to J. S. Le Fanu, was an Irish writer of Gothic tales and mystery novels. He is considered by literary critics to be among the greatest ghost story writers of the Victorian era, as several of his works were central to the development of the genre. In addition to short stories, Le Fanu was also the author of novels such as Uncle Silas (1864), macabre poems, and the collection of five stories In a Glass Darkly (1872), in which the novella Carmilla (1872) is significant as a foundational work of vampire literature.",
   "photo_url": "/tsundoku/cached/authors/sheridan-le-fanu.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Sheridan_Le_Fanu",

--- a/src/content/authors/sinclair-lewis.json
+++ b/src/content/authors/sinclair-lewis.json
@@ -1,7 +1,7 @@
 {
   "name": "Sinclair Lewis",
   "slug": "sinclair-lewis",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Harry Sinclair Lewis was an American novelist, short-story writer, and playwright. In 1930, he became the first author from the United States to receive the Nobel Prize in Literature, which was awarded \"for his vigorous and graphic art of description and his ability to create, with wit and humor, new types of characters.\" Lewis wrote six popular novels: Main Street (1920), Babbitt (1922), Arrowsmith (1925), Elmer Gantry (1927), Dodsworth (1929), and It Can't Happen Here (1935).",
   "photo_url": "/tsundoku/cached/authors/sinclair-lewis.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Sinclair_Lewis",

--- a/src/content/authors/sophocles.json
+++ b/src/content/authors/sophocles.json
@@ -1,7 +1,7 @@
 {
   "name": "Sophocles",
   "slug": "sophocles",
-  "book_count": 7,
+  "book_count": 8,
   "bio": "Sophocles was an ancient Greek tragedian, one of three from whom at least two plays have survived in full. His first plays were written later than, or contemporary with, those of Aeschylus and earlier than, or contemporary with, those of Euripides. Sophocles wrote more than 120 plays, but only seven have survived in a complete form: Ajax, Antigone, Women of Trachis, Oedipus Rex, Electra, Philoctetes, and Oedipus at Colonus. For almost 50 years, Sophocles was the most celebrated playwright in the dramatic competitions of the city-state of Athens, which took place during the religious festivals of the Lenaea and the Dionysia. He competed in 30 competitions, won 24, and was never judged lower than second place. Aeschylus won 13 competitions and was sometimes beaten by Sophocles; Euripides won four.",
   "photo_url": "/tsundoku/cached/authors/sophocles.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Sophocles",

--- a/src/content/authors/stephen-king.json
+++ b/src/content/authors/stephen-king.json
@@ -1,7 +1,7 @@
 {
   "name": "Stephen King",
   "slug": "stephen-king",
-  "book_count": 9,
+  "book_count": 10,
   "bio": "Stephen Edwin King is an American author. Dubbed the \"King of Horror\", he is widely known for his horror novels and has also explored other genres, among them suspense, crime, science-fiction, fantasy, and mystery. Though known primarily for his novels, he has written approximately 200 short stories, most of which have been published in collections.",
   "photo_url": "/tsundoku/cached/authors/stephen-king.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Stephen_King",

--- a/src/content/authors/suetonius.json
+++ b/src/content/authors/suetonius.json
@@ -1,7 +1,7 @@
 {
   "name": "Suetonius",
   "slug": "suetonius",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Gaius Suetonius Tranquillus, commonly referred to as Suetonius, was a Roman historian who wrote during the early Imperial era of the Roman Empire. His most important surviving work is De vita Caesarum, commonly known in English as The Twelve Caesars, a set of biographies of 12 successive Roman rulers from Julius Caesar to Domitian. Other works by Suetonius concerned the daily life of Rome, politics, oratory, and the lives of famous writers, including poets, historians, and grammarians. A few of these books have partially survived, but many have been lost.",
   "photo_url": "/tsundoku/cached/authors/suetonius.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Suetonius",

--- a/src/content/authors/sun-tzu.json
+++ b/src/content/authors/sun-tzu.json
@@ -1,7 +1,7 @@
 {
   "name": "Sun Tzu",
   "slug": "sun-tzu",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Sun Tzu was a Chinese military general, strategist, philosopher, and writer who lived during the Eastern Zhou period. Sun Tzu is traditionally credited as the author of The Art of War, a Classical Chinese text on military strategy from the Warring States period, though the earliest parts of the work probably date to at least a century after him.",
   "photo_url": "/tsundoku/cached/authors/sun-tzu.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Sun_Tzu",

--- a/src/content/authors/susie-middleton.json
+++ b/src/content/authors/susie-middleton.json
@@ -1,6 +1,6 @@
 {
   "name": "Susie Middleton",
   "slug": "susie-middleton",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL6935044A"
 }

--- a/src/content/authors/t-s-eliot.json
+++ b/src/content/authors/t-s-eliot.json
@@ -1,7 +1,7 @@
 {
   "name": "T.S. Eliot",
   "slug": "t-s-eliot",
-  "book_count": 3,
+  "book_count": 5,
   "bio": "Thomas Stearns Eliot was a poet, essayist and playwright. He was a leading figure of modernist poetry in the English language where he reinvigorated the art through his use of language, writing style, and verse structure. He is also noted for his critical essays, which often re-evaluated long-held cultural beliefs.",
   "photo_url": "/tsundoku/cached/authors/t-s-eliot.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/T._S._Eliot",

--- a/src/content/authors/tacitus.json
+++ b/src/content/authors/tacitus.json
@@ -1,7 +1,7 @@
 {
   "name": "Tacitus",
   "slug": "tacitus",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "Publius Cornelius Tacitus, known simply as Tacitus, was a Roman historian and politician. He is widely regarded as one of the greatest Roman historians by modern scholars.",
   "photo_url": "/tsundoku/cached/authors/tacitus.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Tacitus",

--- a/src/content/authors/terry-pratchett.json
+++ b/src/content/authors/terry-pratchett.json
@@ -1,7 +1,7 @@
 {
   "name": "Terry Pratchett",
   "slug": "terry-pratchett",
-  "book_count": 8,
+  "book_count": 12,
   "bio": "Sir Terence David John Pratchett was an English author, humorist, and satirist, best known for the Discworld series of 41 comic fantasy novels published between 1983 and 2015, and for the apocalyptic comedy novel Good Omens (1990), which he co-wrote with Neil Gaiman.",
   "photo_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Terry_Pratchett_%283x4_cropped%29.jpg/400px-Terry_Pratchett_%283x4_cropped%29.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Terry_Pratchett",

--- a/src/content/authors/the-new-testament.json
+++ b/src/content/authors/the-new-testament.json
@@ -1,7 +1,7 @@
 {
   "name": "The New Testament",
   "slug": "the-new-testament",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "The New Testament (NT) is the second division of the Christian biblical canon. It discusses the teachings and person of Jesus, as well as events relating to first-century Christianity. The New Testament's background, the first division of the Christian Bible, has the name of Old Testament, which is based primarily upon the Hebrew Bible; together they are regarded as Sacred Scripture by Christians.",
   "photo_url": "/tsundoku/cached/authors/the-new-testament.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/New_Testament",

--- a/src/content/authors/the-qur-an.json
+++ b/src/content/authors/the-qur-an.json
@@ -1,7 +1,7 @@
 {
   "name": "The Qur'an",
   "slug": "the-qur-an",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "The Quran, also romanized Qur'an or Koran, is the central religious text of Islam, believed by Muslims to be a revelation directly from God (Allāh). It is organized in 114 chapters which consist of individual verses. Besides its religious significance, it is widely regarded as the finest work in Arabic literature, and has significantly influenced the Arabic language.",
   "photo_url": "/tsundoku/cached/authors/the-qur-an.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Quran",

--- a/src/content/authors/the-upanishads.json
+++ b/src/content/authors/the-upanishads.json
@@ -1,7 +1,7 @@
 {
   "name": "The Upanishads",
   "slug": "the-upanishads",
-  "book_count": 1,
+  "book_count": 0,
   "bio": "The Upanishads are Sanskrit texts of the late Vedic and post-Vedic periods that \"document the transition from the archaic ritualism of the Veda into new religious ideas and institutions\" and the emergence of the central religious concepts of Hinduism. They are the most recent addition to the Vedas, the oldest scriptures of Hinduism, and deal with meditation, philosophy, consciousness, and ontological knowledge. Earlier parts of the Vedas dealt with mantras, benedictions, rituals, ceremonies, and sacrifices.",
   "photo_url": "/tsundoku/cached/authors/the-upanishads.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Upanishads",

--- a/src/content/authors/thomas-h-cormen-et-al.json
+++ b/src/content/authors/thomas-h-cormen-et-al.json
@@ -1,5 +1,5 @@
 {
   "name": "Thomas H. Cormen et al.",
   "slug": "thomas-h-cormen-et-al",
-  "book_count": 1
+  "book_count": 0
 }

--- a/src/content/authors/thomas-h-cormen.json
+++ b/src/content/authors/thomas-h-cormen.json
@@ -1,7 +1,7 @@
 {
   "name": "Thomas H. Cormen",
   "slug": "thomas-h-cormen",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Thomas H. Cormen is an American politician and retired academic. He is the co-author of Introduction to Algorithms, along with Charles Leiserson, Ron Rivest, and Cliff Stein. In 2013, he published a new book titled Algorithms Unlocked. He is an emeritus professor of computer science at Dartmouth College and former chairman of the Dartmouth College Department of Computer Science. Between 2004 and 2008 he directed the Dartmouth College Writing Program. His research interests are algorithm engineering, parallel computing, and speeding up computations with high latency. In 2022, he was elected as a Democratic member of the New Hampshire House of Representatives.",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Thomas_H._Cormen",
   "open_library_url": "https://openlibrary.org/authors/OL1004780A",

--- a/src/content/authors/thomas-hardy.json
+++ b/src/content/authors/thomas-hardy.json
@@ -1,7 +1,7 @@
 {
   "name": "Thomas Hardy",
   "slug": "thomas-hardy",
-  "book_count": 6,
+  "book_count": 8,
   "bio": "Thomas Hardy was an English novelist and poet. A Victorian realist in the tradition of George Eliot, he was influenced both in his novels and in his poetry by Romanticism, including the poetry of William Wordsworth. He was highly critical of much in Victorian society, especially on the declining status of rural people in Britain such as those from his native South West England.",
   "photo_url": "/tsundoku/cached/authors/thomas-hardy.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Thomas_Hardy",

--- a/src/content/authors/thomas-kuhn.json
+++ b/src/content/authors/thomas-kuhn.json
@@ -1,7 +1,7 @@
 {
   "name": "Thomas Kuhn",
   "slug": "thomas-kuhn",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Thomas Samuel Kuhn was an American historian and philosopher of science whose 1962 book The Structure of Scientific Revolutions was influential in both academic and popular circles, introducing the term paradigm shift, which has since become an English-language idiom.",
   "photo_url": "/tsundoku/cached/authors/thomas-kuhn.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Thomas_Kuhn",

--- a/src/content/authors/thomas-nagel.json
+++ b/src/content/authors/thomas-nagel.json
@@ -1,7 +1,7 @@
 {
   "name": "Thomas Nagel",
   "slug": "thomas-nagel",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "Thomas Nagel is an American philosopher. He is the University Professor of Philosophy and Law Emeritus at New York University, where he taught from 1980 until his retirement in 2016. His main areas of philosophical interest are political philosophy, ethics and philosophy of mind.",
   "photo_url": "/tsundoku/cached/authors/thomas-nagel.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Thomas_Nagel",

--- a/src/content/authors/thomas-sowell.json
+++ b/src/content/authors/thomas-sowell.json
@@ -1,7 +1,7 @@
 {
   "name": "Thomas Sowell",
   "slug": "thomas-sowell",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Thomas Sowell is an American economist, economic historian, and social theorist. \nWith widely published commentary and books—and as a guest on TV and radio—he is a well-known voice in the American conservative movement as a prominent black conservative. \nHe is a senior fellow at the Hoover Institution \nand was a recipient of the National Humanities Medal from President George W. Bush in 2002.",
   "photo_url": "/tsundoku/cached/authors/thomas-sowell.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Thomas_Sowell",

--- a/src/content/authors/thucydides.json
+++ b/src/content/authors/thucydides.json
@@ -1,7 +1,7 @@
 {
   "name": "Thucydides",
   "slug": "thucydides",
-  "book_count": 2,
+  "book_count": 1,
   "bio": "Thucydides was an Athenian historian and general. His History of the Peloponnesian War recounts the fifth-century BC war between Sparta and Athens until the year 411 BC. Thucydides has been dubbed the father of \"scientific history\" by those who accept his claims to have applied strict standards of impartiality and evidence-gathering and analysis of cause and effect, without reference to intervention by the gods, as outlined in his introduction to his work.",
   "photo_url": "/tsundoku/cached/authors/thucydides.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Thucydides",

--- a/src/content/authors/tom-clancy.json
+++ b/src/content/authors/tom-clancy.json
@@ -1,7 +1,7 @@
 {
   "name": "Tom Clancy",
   "slug": "tom-clancy",
-  "book_count": 1,
+  "book_count": 5,
   "bio": "Thomas Leo Clancy Jr. was an American novelist. He is best known for his technically detailed espionage and military-science storylines set during and after the Cold War. Seventeen of his novels have been bestsellers and more than 100 million copies of his books have been sold. His name has also been used on screenplays written by ghostwriters, nonfiction books on military subjects occasionally with co-authors, and video games. He was a part-owner of his hometown Major League Baseball team, the Baltimore Orioles, and vice-chairman of their community activities and public affairs committees.",
   "photo_url": "/tsundoku/cached/authors/tom-clancy.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Tom_Clancy",

--- a/src/content/authors/tove-jansson.json
+++ b/src/content/authors/tove-jansson.json
@@ -1,7 +1,7 @@
 {
   "name": "Tove Jansson",
   "slug": "tove-jansson",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "Tove Marika Jansson was a Finland-Swedish author, novelist and comic strip author. She was also a painter and illustrator. Brought up by artistic parents, Jansson studied art from 1930 to 1938 in Helsinki, Stockholm, and Paris. She held her first solo art exhibition in 1943. Over the same period, she penned short stories and articles for publication, and subsequently drew illustrations for book covers, advertisements, and postcards. She continued her work as an artist and writer for the rest of her life.",
   "photo_url": "/tsundoku/cached/authors/tove-jansson.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Tove_Jansson",

--- a/src/content/authors/ullman.json
+++ b/src/content/authors/ullman.json
@@ -1,7 +1,7 @@
 {
   "name": "Ullman",
   "slug": "ullman",
-  "book_count": 2,
+  "book_count": 1,
   "open_library_url": "https://openlibrary.org/authors/OL480206A",
   "bio": "Israeli computer scientist",
   "photo_url": "/tsundoku/cached/authors/ullman.jpg",

--- a/src/content/authors/ulysses-s-grant.json
+++ b/src/content/authors/ulysses-s-grant.json
@@ -1,7 +1,7 @@
 {
   "name": "Ulysses S. Grant",
   "slug": "ulysses-s-grant",
-  "book_count": 1,
+  "book_count": 2,
   "bio": "Ulysses S. Grant was the 18th president of the United States, serving from 1869 to 1877. He previously led the Union Army to victory in the American Civil War in 1865 as commanding general.",
   "photo_url": "/tsundoku/cached/authors/ulysses-s-grant.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ulysses_S._Grant",

--- a/src/content/authors/ursula-k-le-guin.json
+++ b/src/content/authors/ursula-k-le-guin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ursula K. Le Guin",
   "slug": "ursula-k-le-guin",
-  "book_count": 15,
+  "book_count": 17,
   "bio": "Ursula Kroeber Le Guin was an American author. She is best known for her works of speculative fiction, including science fiction works set in her Hainish universe, and the Earthsea fantasy series. Her work was first published in 1959, and her literary career spanned nearly sixty years, producing more than twenty novels and more than a hundred short stories, in addition to poetry, literary criticism, translations, and children's books. Frequently described as an author of science fiction, Le Guin has also been called a \"major voice in American Letters\". Le Guin said that she would prefer to be known as an \"American novelist\".",
   "photo_url": "/tsundoku/cached/authors/ursula-k-le-guin.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Ursula_K._Le_Guin",

--- a/src/content/authors/vernor-vinge.json
+++ b/src/content/authors/vernor-vinge.json
@@ -1,7 +1,7 @@
 {
   "name": "Vernor Vinge",
   "slug": "vernor-vinge",
-  "book_count": 5,
+  "book_count": 4,
   "bio": "Vernor Steffen Vinge was an American science fiction author and professor. He taught mathematics and computer science at San Diego State University. He was the first wide-scale popularizer of the technological singularity concept and among the first authors to present a fictional \"cyberspace\". He won the Hugo Award for his novels A Fire Upon the Deep (1992), A Deepness in the Sky (1999), and Rainbows End (2006), and novellas Fast Times at Fairmont High (2001) and The Cookie Monster (2004).",
   "photo_url": "/tsundoku/cached/authors/vernor-vinge.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Vernor_Vinge",

--- a/src/content/authors/virgil.json
+++ b/src/content/authors/virgil.json
@@ -1,7 +1,7 @@
 {
   "name": "Virgil",
   "slug": "virgil",
-  "book_count": 4,
+  "book_count": 3,
   "bio": "Publius Vergilius Maro, usually called Virgil or Vergil in English, was an ancient Roman poet of the Augustan period. He composed three of the most famous poems in Latin literature: the Eclogues, the Georgics, and the epic Aeneid. Some minor poems, collected in the Appendix Vergiliana, were attributed to him in ancient times, but modern scholars regard these as spurious, with the possible exception of some short pieces.",
   "photo_url": "/tsundoku/cached/authors/virgil.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Virgil",

--- a/src/content/authors/virginia-woolf.json
+++ b/src/content/authors/virginia-woolf.json
@@ -1,7 +1,7 @@
 {
   "name": "Virginia Woolf",
   "slug": "virginia-woolf",
-  "book_count": 7,
+  "book_count": 9,
   "bio": "Adeline Virginia Woolf was an English writer and one of the most influential 20th-century modernist authors. She helped to pioneer the use of stream of consciousness narration as a literary device.",
   "photo_url": "/tsundoku/cached/authors/virginia-woolf.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Virginia_Woolf",

--- a/src/content/authors/w-b-yeats.json
+++ b/src/content/authors/w-b-yeats.json
@@ -1,7 +1,7 @@
 {
   "name": "W.B. Yeats",
   "slug": "w-b-yeats",
-  "book_count": 2,
+  "book_count": 4,
   "bio": "William Butler Yeats was an Irish poet, dramatist, writer and literary critic who was one of the foremost figures of 20th-century literature. He was a driving force behind the Irish Literary Revival and, along with John Millington Synge and Lady Gregory, founded the Abbey Theatre, serving as its chief during its early years. He was awarded the 1923 Nobel Prize in Literature and later served two terms as a Senator of the Irish Free State.",
   "photo_url": "/tsundoku/cached/authors/w-b-yeats.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/W._B._Yeats",

--- a/src/content/authors/w-e-b-du-bois.json
+++ b/src/content/authors/w-e-b-du-bois.json
@@ -1,7 +1,7 @@
 {
   "name": "W.E.B. Du Bois",
   "slug": "w-e-b-du-bois",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "William Edward Burghardt Du Bois was an American sociologist, writer, historian, and Pan-Africanist civil rights activist. Born in Great Barrington, Massachusetts, Du Bois grew up in a relatively tolerant and integrated community. He completed graduate work at Harvard University, where he was the first African American to earn a doctorate. He was a professor at Atlanta University and over the course of his life wrote a large number of books and articles. He spent the last years of his life in Ghana and died in Accra on August 27, 1963.",
   "photo_url": "/tsundoku/cached/authors/w-e-b-du-bois.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/W._E._B._Du_Bois",

--- a/src/content/authors/wilkie-collins.json
+++ b/src/content/authors/wilkie-collins.json
@@ -1,7 +1,7 @@
 {
   "name": "Wilkie Collins",
   "slug": "wilkie-collins",
-  "book_count": 4,
+  "book_count": 5,
   "bio": "William Wilkie Collins was an English novelist and playwright known especially for The Woman in White (1860), a mystery novel and early sensation novel, and for The Moonstone (1868), which established many of the ground rules of the modern detective novel and is also perhaps the earliest clear example of the police procedural genre.",
   "photo_url": "/tsundoku/cached/authors/wilkie-collins.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Wilkie_Collins",

--- a/src/content/authors/willa-cather.json
+++ b/src/content/authors/willa-cather.json
@@ -1,7 +1,7 @@
 {
   "name": "Willa Cather",
   "slug": "willa-cather",
-  "book_count": 4,
+  "book_count": 6,
   "bio": "Willa Sibert Cather was an American writer known for her novels of life on the Great Plains, including O Pioneers!, The Song of the Lark, and My Ántonia. In 1923, she was awarded the Pulitzer Prize for One of Ours, a novel set during World War I.",
   "photo_url": "/tsundoku/cached/authors/willa-cather.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Willa_Cather",

--- a/src/content/authors/william-blake.json
+++ b/src/content/authors/william-blake.json
@@ -1,7 +1,7 @@
 {
   "name": "William Blake",
   "slug": "william-blake",
-  "book_count": 5,
+  "book_count": 4,
   "bio": "William Blake was an English poet, painter and printmaker. Largely unrecognised during his life, Blake has become a seminal figure in the history of the poetry and visual art of the Romantic Age. What he called his \"prophetic works\" were said by the 20th-century critic Northrop Frye to form \"what is in proportion to its merits the least read body of poetry in the English language\". While he lived in London his entire life, except for three years spent in Felpham, he produced a diverse and symbolically rich collection of works, which embraced the imagination as \"the body of God\", or \"human existence itself\".",
   "photo_url": "/tsundoku/cached/authors/william-blake.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/William_Blake",

--- a/src/content/authors/william-hertling.json
+++ b/src/content/authors/william-hertling.json
@@ -1,7 +1,7 @@
 {
   "name": "William Hertling",
   "slug": "william-hertling",
-  "book_count": 3,
+  "book_count": 4,
   "bio": "William Hertling is an American science fiction writer and programmer. He was a co-founder and Director of Engineering at Tripwire, and a web strategist and software developer at Hewlett-Packard where he obtained numerous software engineering patents in the areas of networking protocols, printing, and web applications.",
   "photo_url": "/tsundoku/cached/authors/william-hertling.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/William_Hertling",

--- a/src/content/authors/william-makepeace-thackeray.json
+++ b/src/content/authors/william-makepeace-thackeray.json
@@ -1,7 +1,7 @@
 {
   "name": "William Makepeace Thackeray",
   "slug": "william-makepeace-thackeray",
-  "book_count": 2,
+  "book_count": 3,
   "bio": "William Makepeace Thackeray was an English novelist and illustrator. He is known for his satirical works, particularly his 1847–1848 novel Vanity Fair, a panoramic portrait of British society, and the 1844 novel The Luck of Barry Lyndon, which was adapted for a 1975 film by Stanley Kubrick.",
   "photo_url": "/tsundoku/cached/authors/william-makepeace-thackeray.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/William_Makepeace_Thackeray",

--- a/src/content/authors/william-shakespeare.json
+++ b/src/content/authors/william-shakespeare.json
@@ -1,7 +1,7 @@
 {
   "name": "William Shakespeare",
   "slug": "william-shakespeare",
-  "book_count": 28,
+  "book_count": 29,
   "bio": "William Shakespeare was an English playwright, poet and actor. He is widely regarded as the greatest writer in the English language and the world's pre-eminent dramatist. He is often called England's national poet and the \"Bard of Avon\" or simply \"the Bard\". His extant works, including collaborations, consist of some 39 plays, 154 sonnets, three long narrative poems and a few other verses, some of uncertain authorship. His plays have been translated into every major living language and are performed more often than those of any other playwright. Shakespeare remains arguably the most influential writer in the English language, and his works continue to be studied and reinterpreted.",
   "photo_url": "/tsundoku/cached/authors/william-shakespeare.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/William_Shakespeare",

--- a/src/content/authors/winston-churchill.json
+++ b/src/content/authors/winston-churchill.json
@@ -1,7 +1,7 @@
 {
   "name": "Winston Churchill",
   "slug": "winston-churchill",
-  "book_count": 1,
+  "book_count": 3,
   "bio": "Sir Winston Leonard Spencer Churchill was a British statesman, military officer, and writer who was Prime Minister of the United Kingdom from 1940 to 1945, during the Second World War, and again from 1951 to 1955. For some 62 of the years between 1900 and 1964, he was a Member of Parliament (MP) and represented a total of five constituencies over that time. Ideologically an adherent to economic liberalism and imperialism, he was for most of his career a member of the Conservative Party, which he led from 1940 to 1955. He was a member of the Liberal Party from 1904 to 1924.",
   "photo_url": "/tsundoku/cached/authors/winston-churchill.jpg",
   "wikipedia_url": "https://en.wikipedia.org/wiki/Winston_Churchill",

--- a/src/content/authors/world-variety-produce.json
+++ b/src/content/authors/world-variety-produce.json
@@ -1,6 +1,6 @@
 {
   "name": "World Variety Produce",
   "slug": "world-variety-produce",
-  "book_count": 1,
+  "book_count": 0,
   "open_library_url": "https://openlibrary.org/authors/OL10335771A"
 }


### PR DESCRIPTION
## Root cause

`scripts/generate-author-stubs.py` only **created** missing author files; it never refreshed `book_count` on **existing** records. Since `book_count` is a derived field (count of books attributable to an author — full author string plus each split component name), it drifted out of sync every time a book was added or removed. The review found **220** author records with the wrong count.

## Fix

- The generator now authoritatively overwrites `book_count` on **every existing** record on **every run**, keyed off each record's own `name`. Orphaned records (whose name no longer attributes to any book) correctly drop to `0` instead of retaining a stale count.
- `book_count` is overwritten outright (it's derived) rather than additive-merged — additive merge (`json_merge.py`) would never correct a non-empty stale value. All other fields (`bio`, `photo_url`, `wikipedia_url`, …) are preserved exactly.
- Stub creation now writes a trailing newline to match the repo's file convention.
- The change is idempotent: a second run reports `0` updates.

## Test

Adds `test_book_count_matches_attribution` to `scripts/test_data_integrity.py`, asserting every author's `book_count` equals its attributable count. It reuses the generator's `split_authors()` (imported via spec, matching existing test precedent) rather than duplicating the attribution logic.

## Results

- 220 author files corrected — diff is exclusively `book_count` value changes (2 of them also gained a trailing newline they were previously missing).
- Example corrections: `William Shakespeare 28→29`, `Winston Churchill 1→3`, `Acemoglu 1→0` (orphaned stub).
- `cd scripts && python3 -m pytest -q` → **398 passed**.
- `npm run typecheck` → **0 errors** (content collection validates the regenerated JSON).
- The prebuild data pipeline (stats / search-index / browse-data) regenerates cleanly. Note: the fresh worktree resolved `astro@7` and the Svelte/rolldown bundler in that build fails to parse pre-existing `SearchModal.svelte` syntax — unrelated to this change (that file is byte-identical to `main`).

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)