### PR TITLE
fix(authors): suppress organizational/alias author stubs from index (#112)

### DIFF
--- a/src/pages/authors/[letter].astro
+++ b/src/pages/authors/[letter].astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { toSlug, isJointAlias } from '../../utils/formatting';
+import { toSlug, isSuppressedAuthorStub } from '../../utils/formatting';
 
 const base = import.meta.env.BASE_URL;
 
@@ -9,11 +9,12 @@ export async function getStaticPaths() {
   const books = await getCollection('books');
   const enrichedAuthors = await getCollection('authors');
 
-  const enrichedMap = new Map<string, { slug: string; photo_url?: string }>();
+  const enrichedMap = new Map<string, { slug: string; photo_url?: string; bio?: string }>();
   for (const a of enrichedAuthors) {
     enrichedMap.set(a.data.name, {
       slug: a.data.slug,
       photo_url: a.data.photo_url,
+      bio: a.data.bio,
     });
   }
 
@@ -22,11 +23,18 @@ export async function getStaticPaths() {
     authorMap.set(book.data.author, (authorMap.get(book.data.author) ?? 0) + 1);
   }
 
-  // Hide joint-name aliases — each component appears via its own record (#108).
+  // Suppress intentionally-empty, non-person stubs (joint-name aliases and
+  // organizational records with no bio AND no photo) — see #112.
   const knownAuthorNames = new Set(enrichedAuthors.map(a => a.data.name));
 
   const allAuthors = [...authorMap.entries()]
-    .filter(([name]) => !isJointAlias(name, knownAuthorNames))
+    .filter(([name]) => {
+      const enriched = enrichedMap.get(name);
+      return !isSuppressedAuthorStub(
+        { name, bio: enriched?.bio, photo_url: enriched?.photo_url },
+        knownAuthorNames,
+      );
+    })
     .map(([name, count]) => {
       const enriched = enrichedMap.get(name);
       return {

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -1,17 +1,18 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
-import { toSlug, isJointAlias } from '../../utils/formatting';
+import { toSlug, isSuppressedAuthorStub } from '../../utils/formatting';
 
 const books = await getCollection('books');
 const enrichedAuthors = await getCollection('authors');
 const base = import.meta.env.BASE_URL;
 
-const enrichedMap = new Map<string, { slug: string; photo_url?: string }>();
+const enrichedMap = new Map<string, { slug: string; photo_url?: string; bio?: string }>();
 for (const a of enrichedAuthors) {
   enrichedMap.set(a.data.name, {
     slug: a.data.slug,
     photo_url: a.data.photo_url,
+    bio: a.data.bio,
   });
 }
 
@@ -21,12 +22,19 @@ for (const book of books) {
   authorMap.set(author, (authorMap.get(author) ?? 0) + 1);
 }
 
-// Hide joint-name aliases (e.g. "Robert Jordan & Brandon Sanderson") from
-// listings — each component has its own record per the splitting in #108.
+// Suppress intentionally-empty, non-person stubs (joint-name aliases and
+// organizational records with no bio AND no photo) from listings and counts —
+// see #112. Legitimate authors merely lacking a bio/photo stay visible.
 const knownAuthorNames = new Set(enrichedAuthors.map(a => a.data.name));
 
 const allAuthors = [...authorMap.entries()]
-  .filter(([name]) => !isJointAlias(name, knownAuthorNames))
+  .filter(([name]) => {
+    const enriched = enrichedMap.get(name);
+    return !isSuppressedAuthorStub(
+      { name, bio: enriched?.bio, photo_url: enriched?.photo_url },
+      knownAuthorNames,
+    );
+  })
   .map(([name, count]) => {
     const enriched = enrichedMap.get(name);
     return {

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -12,6 +12,8 @@ import {
   parseAuthors,
   authorMatches,
   isJointAlias,
+  isOrganizationalAuthorName,
+  isSuppressedAuthorStub,
 } from './formatting.js';
 
 describe('toSlug', () => {
@@ -298,5 +300,75 @@ describe('isJointAlias', () => {
 
   it('false when not a joint name', () => {
     expect(isJointAlias('A.A. Milne', new Set(['A.A. Milne']))).toBe(false);
+  });
+});
+
+describe('isOrganizationalAuthorName', () => {
+  it('matches corporate / committee / staff bylines', () => {
+    expect(isOrganizationalAuthorName('BookCaps Study Guides Staff')).toBe(true);
+    expect(isOrganizationalAuthorName('World Variety Produce, Inc.')).toBe(true);
+    expect(isOrganizationalAuthorName('Commission on Geosciences')).toBe(true);
+    expect(isOrganizationalAuthorName('Committee on Grand Canyon Monitoring')).toBe(true);
+    expect(isOrganizationalAuthorName('Ohio State Board of Commerce')).toBe(true);
+    expect(isOrganizationalAuthorName('Various (Arabic Sources)')).toBe(true);
+  });
+
+  it('does not match ordinary personal names', () => {
+    expect(isOrganizationalAuthorName('Plato')).toBe(false);
+    expect(isOrganizationalAuthorName('Erich Gamma')).toBe(false);
+    expect(isOrganizationalAuthorName('F.W. Hume')).toBe(false);
+    expect(isOrganizationalAuthorName('Ursula K. Le Guin')).toBe(false);
+  });
+});
+
+describe('isSuppressedAuthorStub', () => {
+  const known = new Set<string>();
+
+  it('suppresses an organizational record with no bio and no photo', () => {
+    expect(
+      isSuppressedAuthorStub({ name: 'Commission on Geosciences' }, known),
+    ).toBe(true);
+  });
+
+  it('suppresses a joint-string alias whose components have records', () => {
+    const componentSet = new Set(['Alex Matrosov', 'Eugene Rodionov', 'Sergey Bratus']);
+    expect(
+      isSuppressedAuthorStub(
+        { name: 'Alex Matrosov, Eugene Rodionov, Sergey Bratus' },
+        componentSet,
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT suppress a plain person missing both bio and photo', () => {
+    expect(isSuppressedAuthorStub({ name: 'F.W. Hume' }, known)).toBe(false);
+    expect(isSuppressedAuthorStub({ name: 'Goldie Lieberman' }, known)).toBe(false);
+  });
+
+  it('does NOT suppress a normal author who has a bio', () => {
+    expect(
+      isSuppressedAuthorStub(
+        { name: 'Commission on Geosciences', bio: 'A real bio here.' },
+        known,
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT suppress an organizational name that has a photo', () => {
+    expect(
+      isSuppressedAuthorStub(
+        { name: 'World Variety Produce, Inc.', photo_url: '/cached/x.jpg' },
+        known,
+      ),
+    ).toBe(false);
+  });
+
+  it('treats whitespace-only bio/photo as empty', () => {
+    expect(
+      isSuppressedAuthorStub(
+        { name: 'BookCaps Study Guides Staff', bio: '   ', photo_url: '' },
+        known,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -143,6 +143,52 @@ export function isJointAlias(name: string, knownAuthorNames: Set<string>): boole
 }
 
 /**
+ * Organizational / non-person name patterns. These are corporate, editorial,
+ * or committee bylines rather than individual authors:
+ *   "BookCaps Study Guides Staff", "World Variety Produce, Inc.",
+ *   "Commission on Geosciences", "Committee on Grand Canyon Monitoring",
+ *   "Ohio State Board of Commerce", "Various (Arabic ...)".
+ * Anchored on whole-word boundaries to avoid catching surnames (e.g. a person
+ * named "Board" is unlikely; "Inc"/"Staff"/"Committee" never appear as a real
+ * given/family name in this catalog).
+ */
+const ORG_NAME_PATTERN =
+  /(\bInc\.?\b|\bLLC\b|\bLtd\.?\b|\bCorp\.?\b|\bStaff\b|\bCommittee\b|\bCommission\b|\bEditors?\b|\bCouncil\b|\bSociety\b|\bAssociation\b|\bFoundation\b|\bInstitute\b|\bBoard\b|^Various\b|\(Various\))/i;
+
+/**
+ * True when an author NAME looks organizational / non-person (committee,
+ * corporate byline, editorial staff, "Various ..."), rather than an individual.
+ */
+export function isOrganizationalAuthorName(name: string): boolean {
+  return ORG_NAME_PATTERN.test(name);
+}
+
+/**
+ * A "suppressed author stub" is an intentionally-empty, non-person record that
+ * adds noise to the author index without offering any real content. We hide it
+ * from the letter index and the index counts (see #112, path A) — but ONLY when
+ * it is BOTH content-empty (no bio AND no photo) AND matches an
+ * organizational / joint-alias pattern.
+ *
+ * A plain person who merely lacks a bio/photo is NOT suppressed: those records
+ * still link out (e.g. to Open Library) and represent real authors.
+ *
+ * `knownAuthorNames` is the set of author-record names, used to confirm a
+ * joint-string byline's components have their own pages.
+ */
+export function isSuppressedAuthorStub(
+  author: { name: string; bio?: string; photo_url?: string },
+  knownAuthorNames: Set<string>,
+): boolean {
+  const hasBio = !!(author.bio && author.bio.trim());
+  const hasPhoto = !!(author.photo_url && author.photo_url.trim());
+  if (hasBio || hasPhoto) return false; // real content → always keep
+  if (isOrganizationalAuthorName(author.name)) return true;
+  if (isJointAlias(author.name, knownAuthorNames)) return true;
+  return false;
+}
+
+/**
  * ISO 639-3 language code → human-readable English name.
  * We only enumerate languages that actually appear in the catalog;
  * unknown codes pass through uppercased so the UI is never blank.


### PR DESCRIPTION
## What

Implements **path A** of #112: suppress intentionally-empty, non-person author records from the authors letter index and the author index counts — without hiding legitimate authors who merely lack a bio/photo.

Closes #112.

## Approach

Adds a small, shared, conservative predicate in `src/utils/formatting.ts`:

- `isOrganizationalAuthorName(name)` — matches corporate / committee / editorial bylines via whole-word patterns: `Inc.`, `LLC`, `Ltd`, `Corp`, `Staff`, `Committee`, `Commission`, `Editors`, `Council`, `Society`, `Association`, `Foundation`, `Institute`, `Board`, and leading/parenthetical `Various`.
- `isSuppressedAuthorStub(author, knownAuthorNames)` — returns `true` **only** when the record has **NO bio AND NO photo** AND it is either an organizational name OR a joint-string alias whose components have their own records (`isJointAlias`).

Key guarantees:
- A plain person missing both bio and photo (e.g. `F.W. Hume`) is **NOT** suppressed — those records still link out to Open Library and represent real authors.
- Any record with a real bio or photo is **never** suppressed, even if its name looks organizational. When in doubt, the record stays visible.

The predicate replaces the previous bare `isJointAlias` filter on both:
- `src/pages/authors/[letter].astro` (letter-index listing)
- `src/pages/authors/index.astro` (letter-tile counts + most-prolific)

Both pages now thread the enriched record's `bio`/`photo_url` into the filter.

## Suppression count

**28** distinct author bylines in the current catalog are suppressed — the joint-string multi-author aliases (whose components have their own pages) plus the organizational records (`BookCaps Study Guides Staff`, `Calm Publications Staff, ...`, `Ohio State Board of Commerce`, `Robin Asbell, ... World Variety Produce, Inc.`).

## Tests / build

- Added vitest coverage in `src/utils/formatting.test.ts` for `isOrganizationalAuthorName` and `isSuppressedAuthorStub`: org record (suppressed), joint alias (suppressed), plain person missing bio+photo (NOT suppressed), normal author with bio (NOT suppressed), org name with a photo (NOT suppressed), whitespace-only bio/photo treated as empty.
- `npm run typecheck`: 0 errors (1 pre-existing unrelated hint in `stacks/[class].astro`).
- `npm test`: 60 passed.
- `npm run build`: there is a **pre-existing** build failure in `src/components/SearchModal.svelte` (a TypeScript-in-Svelte preprocess parse error under the Astro 7 / Vite 8 rolldown toolchain) that reproduces on untouched `main` and is unrelated to this change. This change touches only `.astro` pages and `formatting.ts`/`.test.ts`, never any Svelte component. Recent `main` deploys build successfully in CI, so the failure is local-environment-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)