### PR TITLE
fix(security): escape JSON-LD output + harden enrichment fetch/cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
       # don't re-download every Wikimedia thumb on every build. See #94.
       - name: Restore photo cache
         id: photo-cache-restore
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: public/cached
           key: photo-cache-v1-${{ github.run_id }}
@@ -100,7 +100,7 @@ jobs:
       # and save lets us "always save" — the default cache action only saves on
       # cache miss for the exact key.
       - name: Save photo cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         if: always()
         with:
           path: public/cached

--- a/scripts/cache-photos.py
+++ b/scripts/cache-photos.py
@@ -27,6 +27,7 @@ actions/cache@v4 persists it across CI runs.
 
 import argparse
 import json
+import re
 import sys
 import time
 from datetime import datetime, timezone
@@ -42,6 +43,12 @@ from json_merge import save_json
 REPO_ROOT = Path(__file__).parent.parent
 PUBLIC_CACHED = REPO_ROOT / "public" / "cached"
 ASTRO_BASE = "/tsundoku/"  # matches astro.config.mjs base — keep in sync
+
+# Cached files are written to out_dir/{slug}.{ext}. Slugs are toSlug-generated
+# (lowercase, hyphenated) everywhere, but the value is attacker-influenceable
+# in principle (it flows from content JSON). Reject anything that could escape
+# the cache directory before it reaches a filesystem path.
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 DOWNLOAD_TIMEOUT = 30  # seconds — covers can be a few hundred KB
 SKIP_IF_NEWER_THAN_DAYS = 90  # don't re-download files newer than this
@@ -116,6 +123,12 @@ def cache_one(
     """
     if is_already_local(url):
         # Idempotency: if JSON already points local, no work needed.
+        return None
+
+    if not SLUG_RE.match(slug):
+        # Defense-in-depth: never let a malformed slug (e.g. "../secrets")
+        # escape the cache directory when building the output path.
+        print(f"  ⚠ skipping unsafe slug: {slug!r}", file=sys.stderr)
         return None
 
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/http_retry.py
+++ b/scripts/http_retry.py
@@ -30,6 +30,7 @@ from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Optional, Tuple
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -39,8 +40,23 @@ from enrichment_config import USER_AGENT
 DEFAULT_TIMEOUT = 20
 DEFAULT_MAX_ATTEMPTS = 3
 RETRYABLE_STATUSES = frozenset({429, 502, 503, 504})
+ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 log = logging.getLogger(__name__)
+
+
+def is_fetchable_url(url: str) -> bool:
+    """True only for http(s) URLs.
+
+    `urllib.urlopen` also honors `file://`, `ftp://`, and `data:`. Cover/photo
+    URLs are stored verbatim from upstream API JSON, so a poisoned upstream
+    value (e.g. ``file:///etc/passwd``) must never be dereferenced on the CI
+    or dev machine. Reject anything that isn't http(s).
+    """
+    try:
+        return urlsplit(url).scheme.lower() in ALLOWED_SCHEMES
+    except ValueError:
+        return False
 
 
 def _retry_after_seconds(headers) -> Optional[float]:
@@ -87,6 +103,10 @@ def fetch_with_retry(
     On 404 returns (None, 404, {}) immediately — no retry, the resource
     just doesn't exist.
     """
+    if not is_fetchable_url(url):
+        log.warning("Refusing non-http(s) URL: %s", url)
+        return None, 0, {}
+
     headers = {"User-Agent": user_agent}
     if extra_headers:
         headers.update(extra_headers)

--- a/scripts/test_http_retry.py
+++ b/scripts/test_http_retry.py
@@ -15,7 +15,37 @@ from http_retry import (
     fetch_bytes,
     fetch_json,
     fetch_with_retry,
+    is_fetchable_url,
 )
+
+
+class TestSchemeAllowlist:
+    @pytest.mark.parametrize("url", [
+        "http://example.com/a.jpg",
+        "https://example.com/a.jpg",
+        "HTTPS://EXAMPLE.COM/a.jpg",
+    ])
+    def test_allows_http_https(self, url):
+        assert is_fetchable_url(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "data:text/plain,hi",
+        "javascript:alert(1)",
+        "",
+        "not a url",
+    ])
+    def test_rejects_other_schemes(self, url):
+        assert is_fetchable_url(url) is False
+
+    def test_fetch_with_retry_refuses_non_http(self, monkeypatch):
+        # urlopen must never be reached for a file:// URL.
+        def _boom(*a, **k):
+            raise AssertionError("urlopen called for non-http(s) URL")
+        monkeypatch.setattr("http_retry.urlopen", _boom)
+        body, status, headers = fetch_with_retry("file:///etc/passwd")
+        assert body is None and status == 0 and headers == {}
 
 
 class _FakeHeaders(dict):

--- a/scripts/validate-photo-urls.py
+++ b/scripts/validate-photo-urls.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from enrichment_config import AUTHORS_DIR, BOOKS_DIR, USER_AGENT
 from http_cache import cached_fetch
+from http_retry import is_fetchable_url
 from json_merge import save_json
 
 
@@ -41,6 +42,9 @@ def head_probe(url: str) -> dict | None:
     Definitive 4xx (404, 410, 401, 403) → ok=False (clear the URL).
     Transient (429, 5xx) → None (don't draw any conclusion).
     """
+    if not is_fetchable_url(url):
+        # Non-http(s) URL (file://, ftp://, data:) — never dereference.
+        return {"status": 0, "ok": False}
     req = Request(url, method="HEAD", headers={"User-Agent": USER_AGENT})
     try:
         with urlopen(req, timeout=HEAD_TIMEOUT) as resp:

--- a/src/pages/authors/[slug].astro
+++ b/src/pages/authors/[slug].astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import { priorityLabel, priorityBadgeClass, pluralize, thumbnailUrl, authorMatches, toSlug } from '../../utils/formatting';
+import { safeJsonLd } from '../../utils/jsonld';
 
 // ISO 3166-1 alpha-2 → human-readable nationality. Subset matches what
 // the wikidata enricher emits.
@@ -57,7 +58,7 @@ const nationalityLine = (author.nationality ?? [])
 ---
 
 <Layout title={author.name} description={`${books.length} books by ${author.name} in the tsundoku collection`} image={author.photo_url}>
-  <script is:inline type="application/ld+json" set:html={JSON.stringify({
+  <script is:inline type="application/ld+json" set:html={safeJsonLd({
     "@context": "https://schema.org",
     "@type": "Person",
     "name": author.name,

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import { priorityLabel, priorityClass, toSlug, statusLabel, statusClass, parseAuthors, languageLabel, formatYear } from '../../utils/formatting';
+import { safeJsonLd } from '../../utils/jsonld';
 import ShareButton from '../../components/ShareButton.svelte';
 
 export async function getStaticPaths() {
@@ -102,7 +103,7 @@ if (currentLcc) {
 ---
 
 <Layout title={book.title} description={book.description || `${book.title} by ${book.author} — ${book.category}`} image={book.cover_url_large || book.cover_url}>
-  <script is:inline type="application/ld+json" set:html={JSON.stringify({
+  <script is:inline type="application/ld+json" set:html={safeJsonLd({
     "@context": "https://schema.org",
     "@type": "Book",
     "name": book.title,

--- a/src/utils/jsonld.test.ts
+++ b/src/utils/jsonld.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { safeJsonLd } from "./jsonld";
+
+describe("safeJsonLd", () => {
+  it("produces JSON that round-trips back to the original value", () => {
+    const obj = { name: "Dune", year: 1965, tags: ["sf", "classic"] };
+    expect(JSON.parse(safeJsonLd(obj))).toEqual(obj);
+  });
+
+  it("escapes a </script> breakout attempt", () => {
+    const payload = { description: "</script><img src=x onerror=alert(1)>" };
+    const out = safeJsonLd(payload);
+    expect(out).not.toContain("</script>");
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    // ...but the data is preserved once parsed
+    expect(JSON.parse(out).description).toBe(
+      "</script><img src=x onerror=alert(1)>",
+    );
+  });
+
+  it("escapes ampersands and U+2028/U+2029 line separators", () => {
+    const ls = " ";
+    const ps = " ";
+    const bio = `A & B${ls}C${ps}D`;
+    const out = safeJsonLd({ bio });
+    expect(out).not.toContain("&");
+    expect(out).not.toContain(ls);
+    expect(out).not.toContain(ps);
+    expect(JSON.parse(out).bio).toBe(bio);
+  });
+});

--- a/src/utils/jsonld.ts
+++ b/src/utils/jsonld.ts
@@ -1,0 +1,21 @@
+/**
+ * Serialize a value to JSON for safe embedding inside an inline
+ * `<script type="application/ld+json">` block.
+ *
+ * `JSON.stringify` does not escape `<`, `>`, `&`, or the U+2028/U+2029 line
+ * separators. Emitted raw via Astro's `set:html`, a value containing the
+ * literal `</script>` (e.g. a poisoned upstream description/bio) would close
+ * the script element early and let following markup execute — stored XSS.
+ *
+ * Escaping `<` and `>` as `<` / `>` keeps the JSON byte-for-byte
+ * equivalent (parsers decode the escapes) while making a `</script>` breakout
+ * impossible. We also escape `&` and the JS line terminators for robustness.
+ */
+const UNSAFE_JSONLD = new RegExp("[<>&\\u2028\\u2029]", "g");
+
+export function safeJsonLd(value: unknown): string {
+  return JSON.stringify(value).replace(
+    UNSAFE_JSONLD,
+    (ch) => "\\u" + ch.charCodeAt(0).toString(16).padStart(4, "0"),
+  );
+}


### PR DESCRIPTION
Addresses the security-review findings.

## Frontend XSS (Closes #177)
`books/[slug].astro` and `authors/[slug].astro` injected `JSON.stringify({… description / bio …})` raw via `set:html` into a `<script type="application/ld+json">` block. `JSON.stringify` does not escape `<`/`>`/`&`, so a poisoned upstream `description`/`bio` containing `</script>` could close the script element early and execute following markup (stored XSS). Descriptions/bios come verbatim from world-editable upstreams (Google Books / Open Library / Wikipedia).

- New `src/utils/jsonld.ts` `safeJsonLd()` escapes `<`, `>`, `&`, and U+2028/U+2029 — output is byte-equivalent JSON once parsed.
- Wired into both pages. Added `jsonld.test.ts` (round-trip + `</script>` breakout + separator escaping).

## Pipeline hardening (Closes #182)
- `http_retry.is_fetchable_url()` rejects non-http(s) URLs (`file://`, `ftp://`, `data:`) before `urlopen`, in both `fetch_with_retry` and `validate-photo-urls.py` `head_probe`. `cover_url`/`photo_url` are stored verbatim from upstream JSON.
- `cache-photos.py` validates `slug` against `^[a-z0-9-]+$` before building the output path — a malformed slug can't escape `public/cached/`.
- `deploy.yml`: SHA-pin `actions/cache/restore`+`save` (were floating `@v5`; every other action was already SHA-pinned).

## Verification
- `npm run typecheck` → 0 errors
- `npm test` → 55 passed
- `cd scripts && python3 -m pytest -q` → 407 passed (incl. new scheme-allowlist tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)