### PR TITLE
fix(scripts): empty-title guard, copyright tests, stats zero-guard, docs (#178 #180 #183)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ python3 scripts/run-all-enrichments.py           # Auto-scan all sources to comp
 python3 scripts/run-all-enrichments.py --status  # Show scan progress
 python3 scripts/enrich-gaps.py --report          # Show data gap report
 python3 scripts/enrich-copyright.py --report     # Show copyright distribution
-python3 scripts/enrich-categories.py --report    # Show category distribution
+python3 scripts/recategorize.py --report         # Show category distribution
 
 # Python tests
 cd scripts && python3 -m pytest -q
@@ -95,7 +95,7 @@ Safety: max 20 iterations, 10s inter-batch delays. State persisted in `data/enri
 After enrichment scans, always run:
 ```bash
 python3 scripts/enrich-copyright.py --apply    # Recompute copyright status
-python3 scripts/enrich-categories.py           # Check for category suggestions
+python3 scripts/recategorize.py                # Check for category suggestions
 python3 scripts/generate-stats.py              # Update stats
 python3 scripts/generate-search-index.py       # Update search index
 ```
@@ -155,7 +155,6 @@ Computed from existing metadata (no API calls):
 | **Additive JSON merge** | `scripts/json_merge.py` (never overwrites non-empty fields — see #90) |
 | **HTTP response cache** | `scripts/http_cache.py` + `data/http-cache.sqlite` (gitignored — see #91) |
 | **Photo / cover cache** | `scripts/cache-photos.py` + `public/cached/` (gitignored — see #94) |
-| **HTTP response cache** | `scripts/http_cache.py` + `data/http-cache.sqlite` (gitignored — see #91) |
 | **Enrichment runner** | `scripts/run-all-enrichments.py` |
 | **Data integrity tests** | `scripts/test_data_integrity.py` |
 | **CI workflow** | `.github/workflows/deploy.yml` |
@@ -181,7 +180,7 @@ cat data/enrichment-errors.jsonl | python3 -m json.tool
 ## Build Pipeline
 
 ```
-apply-reading-status.py → generate-author-stubs.py → generate-stats.py → generate-search-index.py → astro build
+apply-reading-status.py → generate-author-stubs.py → generate-stats.py → generate-search-index.py → generate-browse-data.py → astro build
 ```
 
 ## CI/CD

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,9 +34,12 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 | Script | Purpose |
 |---|---|
 | `apply-reading-status.py` | Merges `data/reading-status.csv` into book JSON files |
-| `generate-author-stubs.py` | Creates minimal author pages for any author without one |
+| `generate-author-stubs.py` | Creates minimal author pages for any author without one; refreshes `book_count` on every existing record (#179) |
 | `generate-stats.py` | Generates `src/data/stats.json` with collection statistics |
 | `generate-search-index.py` | Generates `public/search-index.json` for client-side search |
+| `generate-browse-data.py` | Generates the browse-page data fetched on hydrate (#99) |
+
+`build-world-map-svg.py` is a standalone asset generator (run manually, not part of `prebuild`): it regenerates `src/data/world-map.svg`, which `src/pages/stats.astro` renders.
 
 ## Data Import (one-time use)
 
@@ -69,15 +72,22 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 
 ## Tests
 
+All `scripts/test_*.py` are auto-discovered by `pytest` (CI runs `cd scripts && python3 -m pytest -q`). Run the full suite before committing pipeline changes. Highlights:
+
 | File | Tests |
 |---|---|
-| `test_matching.py` | 27 tests for title similarity, slug generation, author matching |
-| `test_enrichment.py` | 8 tests for state tracking, config validation |
-| `test_json_merge.py` | 18 tests for additive merge invariants |
-| `test_http_cache.py` | 12 tests for hit/miss/expire/negative-cache/persistence |
-| `test_validate_photo_urls.py` | 7 tests for HEAD-probe classification + apply mode |
-| `test_cache_photos.py` | 19 tests for content-type → ext, idempotency, JSON rewrite |
-| `test_author_sources.py` | 20 tests for Open Library author page + Wikidata + name variants |
+| `test_matching.py` | title similarity, slug generation, author matching (incl. empty-title guard) |
+| `test_enrichment.py` | state tracking, config validation |
+| `test_json_merge.py` | additive merge invariants |
+| `test_http_cache.py` | hit/miss/expire/negative-cache/persistence |
+| `test_http_retry.py` | backoff, Retry-After parsing, http(s)-only scheme allowlist |
+| `test_validate_photo_urls.py` | HEAD-probe classification + apply mode |
+| `test_cache_photos.py` | content-type → ext, idempotency, JSON rewrite |
+| `test_author_sources.py` | Open Library author page + Wikidata + name variants |
+| `test_enrich_copyright.py` | copyright-status rule precedence (platform > HathiTrust > year) |
+| `test_data_integrity.py` | content invariants (slugs, required fields, author book_count, ...) |
+
+…plus `test_book_sources`, `test_edition_date`, `test_parallel_fetch`, `test_wikidata`, `test_dedupe_books`, `test_enrich_ol_firstedition`, `test_enrich_wikipedia_books`, `test_merge_google_library`, `test_recategorize_classification`.
 
 ## Usage
 

--- a/scripts/generate-stats.py
+++ b/scripts/generate-stats.py
@@ -30,6 +30,8 @@ def generate_stats() -> dict:
 
     # Basic counts
     total = len(books)
+    # Guard every percentage below against an empty corpus.
+    pct_base = total or 1
     categories = Counter(b["category"] for b in books)
     authors = Counter(b["author"] for b in books)
     priorities = Counter(b["priority"] for b in books)
@@ -141,13 +143,13 @@ def generate_stats() -> dict:
         },
         "enrichment": {
             "covers": has_cover,
-            "covers_pct": round(100 * has_cover / total, 1),
+            "covers_pct": round(100 * has_cover / pct_base, 1),
             "descriptions": has_desc,
-            "descriptions_pct": round(100 * has_desc / total, 1),
+            "descriptions_pct": round(100 * has_desc / pct_base, 1),
             "isbns": has_isbn,
-            "isbns_pct": round(100 * has_isbn / total, 1),
+            "isbns_pct": round(100 * has_isbn / pct_base, 1),
             "pages": has_pages,
-            "pages_pct": round(100 * has_pages / total, 1),
+            "pages_pct": round(100 * has_pages / pct_base, 1),
             "years": has_year,
             "subject_facet": has_subject_facet,
             "ddc": has_ddc,

--- a/scripts/matching.py
+++ b/scripts/matching.py
@@ -39,9 +39,16 @@ def titles_match(query_title: str, result_title: str, threshold: float = 0.6) ->
 
     Returns True if either title contains the other, or if the
     word overlap ratio exceeds the given threshold.
+
+    An empty title never matches: `"" in anything` is always True, so
+    without this guard a result with a missing/blank title field would
+    pass the title gate and leave only the author check guarding against
+    a false enrichment link.
     """
-    a = query_title.lower()
-    b = result_title.lower()
+    a = query_title.lower().strip()
+    b = result_title.lower().strip()
+    if not a or not b:
+        return False
     return a in b or b in a or title_similarity(a, b) > threshold
 
 

--- a/scripts/test_enrich_copyright.py
+++ b/scripts/test_enrich_copyright.py
@@ -1,0 +1,87 @@
+"""Tests for compute_copyright_status in enrich-copyright.py.
+
+Locks down the rule precedence (platform > HathiTrust rights > year),
+which decides the public-domain / copyright badge on every book page.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+_spec = importlib.util.spec_from_file_location(
+    "enrich_copyright", Path(__file__).parent / "enrich-copyright.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+compute_copyright_status = _mod.compute_copyright_status
+
+VALID = {"public_domain", "likely_public_domain", "in_copyright", "undetermined"}
+
+
+class TestPlatformSignals:
+    def test_gutenberg_is_public_domain(self):
+        assert compute_copyright_status({"gutenberg_url": "https://g/1"}) == "public_domain"
+
+    def test_librivox_is_public_domain(self):
+        assert compute_copyright_status({"librivox_url": "https://l/1"}) == "public_domain"
+
+    def test_platform_wins_over_recent_year(self):
+        # A Gutenberg edition guarantees PD even if a (wrong) modern year is set.
+        book = {"gutenberg_url": "https://g/1", "first_published": 2010}
+        assert compute_copyright_status(book) == "public_domain"
+
+
+class TestHathiTrustRights:
+    @pytest.mark.parametrize("rights", ["pd", "pdus", "full view", "PD", "Full View"])
+    def test_pd_rights(self, rights):
+        assert compute_copyright_status({"hathitrust_rights": rights}) == "public_domain"
+
+    @pytest.mark.parametrize("rights", ["ic", "ic-world", "limited (search-only)"])
+    def test_ic_rights(self, rights):
+        assert compute_copyright_status({"hathitrust_rights": rights}) == "in_copyright"
+
+    def test_explicit_ic_wins_over_old_year(self):
+        # Explicit HathiTrust in-copyright beats the pre-1930 year heuristic.
+        book = {"hathitrust_rights": "ic", "first_published": 1850}
+        assert compute_copyright_status(book) == "in_copyright"
+
+    def test_pd_rights_independent_of_year(self):
+        book = {"hathitrust_rights": "pd", "first_published": 1999}
+        assert compute_copyright_status(book) == "public_domain"
+
+
+class TestYearHeuristics:
+    @pytest.mark.parametrize("year", [1500, 1900, 1930])
+    def test_at_or_before_1930_is_public_domain(self, year):
+        assert compute_copyright_status({"first_published": year}) == "public_domain"
+
+    @pytest.mark.parametrize("year", [1931, 1950, 1963])
+    def test_1931_to_1963_is_likely_pd(self, year):
+        assert compute_copyright_status({"first_published": year}) == "likely_public_domain"
+
+    @pytest.mark.parametrize("year", [1964, 2000, 2024])
+    def test_after_1963_is_in_copyright(self, year):
+        assert compute_copyright_status({"first_published": year}) == "in_copyright"
+
+
+class TestUndetermined:
+    def test_no_signal_is_undetermined(self):
+        assert compute_copyright_status({}) == "undetermined"
+
+    def test_blank_rights_no_year_is_undetermined(self):
+        assert compute_copyright_status({"hathitrust_rights": ""}) == "undetermined"
+
+    def test_unknown_rights_no_year_is_undetermined(self):
+        # An unrecognized rights code falls through to the year heuristic.
+        assert compute_copyright_status({"hathitrust_rights": "cc-by"}) == "undetermined"
+
+
+def test_always_returns_valid_enum():
+    for book in [{}, {"first_published": 1800}, {"first_published": 2020},
+                 {"gutenberg_url": "x"}, {"hathitrust_rights": "ic"}]:
+        assert compute_copyright_status(book) in VALID

--- a/scripts/test_matching.py
+++ b/scripts/test_matching.py
@@ -105,6 +105,15 @@ class TestTitlesMatch:
     def test_case_insensitive(self):
         assert titles_match("DRACULA", "dracula")
 
+    def test_empty_result_title_never_matches(self):
+        # "" in anything is True; an empty/blank result title must not
+        # pass the title gate (regression: #178).
+        assert not titles_match("Dune", "")
+        assert not titles_match("Dune", "   ")
+
+    def test_empty_query_title_never_matches(self):
+        assert not titles_match("", "Dune")
+
 
 class TestAuthorsMatch:
     def test_exact_last_name(self):


### PR DESCRIPTION
Three small, independent maintenance fixes from the QA/vestigial review.

### #178 — `titles_match()` false matches on empty titles
`"" in anything` is always `True`, so `titles_match("Dune", "")` returned `True`. An API result with a missing/blank title field passed the title gate, leaving only the author check guarding against a false enrichment link (wrong Gutenberg/LibriVox URL). Now returns `False` when either title is empty/blank. + regression tests. **Closes #178.**

### #180 (partial) — copyright tests + stats zero-guard
- New `test_enrich_copyright.py` locks the `compute_copyright_status` rule precedence (platform > HathiTrust rights > year heuristic) — the field behind every PD/copyright badge. Covers the precedence edge cases (Gutenberg + recent year; HathiTrust `ic` + pre-1930 year; unknown rights → year fallback).
- `generate-stats.py` percentages now guard against an empty corpus (`ZeroDivisionError`).

(The remaining data-integrity invariants from #180 — `language=="eng"`, `copyright_status` enum, etc. — are left on #180.)

### #183 — doc drift
- Drop the duplicate CLAUDE.md "HTTP response cache" Canonical-Paths row.
- Fix stale `enrich-categories.py` → `recategorize.py` references (script was deleted).
- Add `generate-browse-data.py` to the build-pipeline diagram.
- Refresh `scripts/README` tests table (note pytest auto-discovery) and document `build-world-map-svg.py` + `generate-browse-data.py`. **Closes #183.**

### Verification
`cd scripts && python3 -m pytest -q` → 436 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)