### PR TITLE
ci: run astro build on PRs to catch bundler/build breaks (#189)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,11 @@ jobs:
 
   build:
     needs: quality
-    # Build + deploy only run on push to main (and manual dispatch); PRs
-    # gate at the quality job and stop there.
-    if: github.event_name != 'pull_request'
+    # Runs on PRs too, so a build/bundler break (e.g. a dependency bump that
+    # changes the bundler) is caught before merge — `astro check` does not
+    # exercise the bundler. On PRs the slow photo-download + cache-save +
+    # artifact-upload steps are skipped (see per-step conditions); only the
+    # actual `astro build` runs. The deploy job stays push-only. See #189.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
@@ -87,6 +89,9 @@ jobs:
       # towards convergence rather than getting stuck on the alphabetically-
       # early entries.
       - name: Download missing photos (chunked)
+        # Skip on PRs — we only need to validate that the site *compiles*,
+        # not populate covers. Keeps the PR build fast (~1-2 min).
+        if: github.event_name != 'pull_request'
         run: python3 scripts/cache-photos.py --limit 1000
         timeout-minutes: 10
         # cache-photos.py is fault-tolerant — failures leave upstream URLs in
@@ -101,12 +106,13 @@ jobs:
       # cache miss for the exact key.
       - name: Save photo cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         with:
           path: public/cached
           key: photo-cache-v1-${{ github.run_id }}
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: dist/


### PR DESCRIPTION
## Why
The astro 6→7 major bump reached `main` and broke the deploy (`SearchModal.svelte` bundler parse error) because the `build` job was gated `if: github.event_name != 'pull_request'`. PRs only ran `quality` (typecheck + unit tests), and `astro check` does **not** exercise the bundler — so a build-only break shipped green checks, then broke main on push.

## Change
- The `build` job now runs on PRs too.
- The slow/irrelevant-for-validation steps stay push-only via per-step `if: github.event_name != 'pull_request'`: **Download missing photos**, **Save photo cache**, **Upload artifact**.
- So a PR build runs just `prebuild` + `astro build` (~1-2 min) to confirm the site compiles. The `deploy` job remains push-only.
- Concurrency already scopes PR runs by ref, so PR builds never cancel a main deploy.

## Bonus
This PR's own checks now include the build job — so its green status is direct evidence the change works and that `main` compiles. Once merged, the held #191 (astro 6.4.8 + vite 8) will show a **red build** on its PR, blocking accidental re-breakage.

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)