### PR TITLE
chore(cleanup): remove dead original_pages field; document spent one-shots (#184)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,20 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 | `dedupe-books.py` | Find and merge duplicate books (article/edition variants) |
 | `update-readme-stats.py` | Inject current stats from stats.json into README.md |
 
+## Completed migrations (spent — do not re-run blindly)
+
+These ran once; their effects are already baked into the content. They have
+zero inbound references and are kept for reference only. Several embed
+hand-curated tables or heuristics — re-running without a fresh audit can
+corrupt data. Treat as historical.
+
+| Script | What it did |
+|---|---|
+| `dedupe-authors-by-diacritic.py` | One-time merge of 5 near-duplicate author pairs differing only by diacritics |
+| `fix-ancient-work-years.py` | Hand-audited `first_published` years for ancient works (uses a hardcoded table) |
+| `fix-non-english-descriptions.py` | One-time cleanup of ~17 non-English descriptions |
+| `derive-classification.py` | One-time DDC/LCC classification backfill (tagged with `derived_v1` provenance) |
+
 ## Shared Modules
 
 | Module | Purpose |

--- a/scripts/enrich-ol-firstedition.py
+++ b/scripts/enrich-ol-firstedition.py
@@ -14,7 +14,6 @@ year by parsing each edition's `publish_date`, and writes:
                               the work's original language
   • original_language       — ISO 639-3 of the earliest non-translation edition
   • original_publisher      — publishers[0] of that edition
-  • original_pages          — number_of_pages of that edition (if known)
   • first_edition_isbn      — ISBN-13 of that edition; explicit `null` for
                               works whose first edition pre-dates ISBNs
                               (we mark this when first_published < 1970)
@@ -65,8 +64,8 @@ ISBN_INTRODUCTION_YEAR = 1970  # before this, first_edition_isbn is null
 # Quality gate: when many editions claim the first-publication year, OL
 # tagging has been smeared across reprints (e.g. Signet paperbacks dated
 # 1949 alongside the actual 1949 Secker & Warburg first). Only derive
-# original_publisher / original_pages / original_title / original_language
-# when the matching set is small enough to be trustworthy.
+# original_publisher / original_title / original_language when the
+# matching set is small enough to be trustworthy.
 MAX_MATCHING_FOR_TRUST = 3
 
 SOURCE = "ol_firstedition_v1"
@@ -314,9 +313,9 @@ def derive_fields(work_editions: list[dict], book: dict) -> dict:
         out["first_published"] = target_year
 
     # Conservative: OL editions are too noisy to derive original_publisher
-    # and original_pages reliably (mis-dated reprints corrupt the picked
-    # first-edition record for famous works). Phase B (Wikidata) is the
-    # canonical source for those — Wikidata has structured P123/P1104.
+    # reliably (mis-dated reprints corrupt the picked first-edition record
+    # for famous works). Phase B (Wikidata) is the canonical source —
+    # Wikidata has structured P123.
     #
     # We DO derive:
     #   * first_published_circa from picked first edition

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -57,7 +57,6 @@ const books = defineCollection({
     original_title: z.string().optional(),
     original_language: z.string().optional(),         // ISO 639-3 code
     original_publisher: z.string().optional(),
-    original_pages: z.number().optional(),
     first_edition_isbn: z.string().nullable().optional(),  // explicit null for pre-ISBN works
     first_published_circa: z.boolean().optional(),    // for "ca. 1850" / "[1900?]"
     translator: z.string().optional(),                // when original_language differs from language


### PR DESCRIPTION
Mechanical, safe parts of #184 (the parts that don't need a product decision).

## `original_pages` — dead field removed
Confirmed dead before removing:
- No script writes it. `enrich-ol-firstedition.py` *defers* first-edition metadata to Wikidata (its comment said "Wikidata is canonical for original_publisher and original_pages"), but the Wikidata enricher (`enrich-wikidata-book.py`) only emits `original_publisher`, never `original_pages`.
- 0 content records carry it; 0 `.astro`/`.svelte`/`.ts` references.

Removed the schema field + the stale docstring/comment claims in `enrich-ol-firstedition.py`. (`original_publisher`, which *is* written by Wikidata, is left untouched.)

## Spent one-shot scripts — documented
Added a "Completed migrations" section to `scripts/README.md` for the four spent one-shots (`dedupe-authors-by-diacritic`, `fix-ancient-work-years`, `fix-non-english-descriptions`, `derive-classification`) — 0 inbound refs, effects already baked in. Documented rather than moved, to preserve their imports/reference value and flag that re-running them blindly can corrupt data.

## Left on #184 (needs your call)
- **`adaptations`** — curated in 33 files but no UI renders it. Build a UI to surface it, or drop the curated data? (Didn't want to delete curated content unilaterally.)
- **`enrich-descriptions.py`** — documented as the consolidated description filler but wired into no runner. Canonicalize it into run-all, or document as the manual gap-filler?

## Verification
- `npm run typecheck` → 0 errors
- `cd scripts && python3 -m pytest -q` (firstedition + integrity) → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)