### PR TITLE
fix(enrichment): route _raw_request through retry + add dead-letter log (#149)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ data/merge-report.json
 data/dirtylist.csv
 data/enrichment-state.json
 data/enrichment-errors.jsonl
+data/enrichment-deadletter.jsonl
 
 # Generated at build time
 public/search-index.json

--- a/scripts/deadletter.py
+++ b/scripts/deadletter.py
@@ -1,0 +1,63 @@
+"""Dead-letter log for permanently-failed enrichment requests.
+
+When an HTTP request can't be satisfied — a 404, a non-retryable 4xx, a
+network error that survives every retry, or a 429/503 that exhausts the
+backoff budget — the record is otherwise silently lost for the run. This
+module appends a single JSON line per such failure to
+``data/enrichment-deadletter.jsonl`` so the loss is auditable and a later
+re-run can target the failed set.
+
+Design notes:
+  * Best-effort: ``write_deadletter`` never raises. A logging failure must
+    never abort an enrichment run.
+  * One JSON object per line (JSONL) — append-only, cheap to tail.
+  * Uses real wall-clock timestamps. These are ordinary enrichment scripts,
+    not deterministic workflow scripts, so ``datetime.now()`` is fine.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Optional
+
+from enrichment_config import DEADLETTER_LOG
+
+
+def write_deadletter(
+    *,
+    source: str,
+    url: str,
+    status: int,
+    error_type: str,
+    message: str = "",
+    path: Optional[Path] = None,
+) -> None:
+    """Append one dead-letter record. Never raises.
+
+    Args:
+        source: enricher / source name (e.g. "gutenberg", "hathitrust").
+        url: the request URL that permanently failed.
+        status: HTTP status code (0 for network errors / no response).
+        error_type: short classification ("not_found", "http_error",
+            "rate_limited", "connection_error", "parse_error", ...).
+        message: optional human-readable detail (truncated).
+        path: override the log path (used by tests); defaults to
+            ``DEADLETTER_LOG``.
+    """
+    target = path if path is not None else DEADLETTER_LOG
+    entry = {
+        "timestamp": datetime.datetime.now().isoformat(),
+        "source": source,
+        "url": url[:1000],
+        "status": status,
+        "error_type": error_type,
+        "message": message[:500],
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "a") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError:
+        pass  # Best-effort: never fail enrichment because of a log write.

--- a/scripts/enrichment_base.py
+++ b/scripts/enrichment_base.py
@@ -20,12 +20,12 @@ import time
 import datetime
 from abc import ABC, abstractmethod
 from pathlib import Path
-from urllib.error import HTTPError, URLError
-from urllib.request import urlopen, Request
 
 from enrichment_config import BOOKS_DIR, USER_AGENT, DEFAULT_TIMEOUT, RATE_LIMITS, ERROR_LOG
 from enrichment_state import EnrichmentState
 from http_cache import cached_fetch
+from http_retry import fetch_with_retry
+from deadletter import write_deadletter
 
 
 class EnrichmentScript(ABC):
@@ -76,26 +76,57 @@ class EnrichmentScript(ABC):
         return cached_fetch(self.source_name, key, lambda: self._raw_request(url), url=url)
 
     def _raw_request(self, url: str) -> dict | None:
-        """Underlying HTTP+JSON fetch. Same error semantics as before."""
-        req = Request(url, headers={"User-Agent": USER_AGENT})
-        try:
-            with urlopen(req, timeout=DEFAULT_TIMEOUT) as resp:
-                return json.loads(resp.read())
-        except HTTPError as e:
-            if e.code == 404:
-                return None  # Not found — permanent, don't retry
-            elif e.code == 429:
-                self._log_error("rate_limited", url, str(e))
-                return None  # Rate limited — skip for now
-            else:
-                self._log_error("http_error", url, f"HTTP {e.code}")
+        """Underlying HTTP+JSON fetch with 429/502/503/504 backoff + retry.
+
+        Routes through ``http_retry.fetch_with_retry``, which honors
+        ``Retry-After`` and applies exponential backoff with jitter on
+        transient statuses instead of silently swallowing them.
+
+        Return contract is unchanged for callers: a parsed JSON object
+        (the truthy payload they index into) on success, or ``None`` on any
+        failure — 404, non-retryable 4xx, retries exhausted, network error,
+        or unparseable body. Permanent failures are recorded both to the
+        legacy error log and to the dead-letter log so a re-run can target
+        the lost set.
+        """
+        body, status, _headers = fetch_with_retry(
+            url,
+            user_agent=USER_AGENT,
+            timeout=DEFAULT_TIMEOUT,
+        )
+
+        if body is not None:
+            try:
+                return json.loads(body)
+            except (json.JSONDecodeError, ValueError) as e:
+                self._log_error("parse_error", url, str(e))
+                self._deadletter(url, status, "parse_error", str(e))
                 return None
-        except URLError as e:
-            self._log_error("connection_error", url, str(e))
-            return None
-        except (json.JSONDecodeError, OSError) as e:
-            self._log_error("parse_error", url, str(e))
-            return None
+
+        # body is None -> permanent failure of some kind. Classify by status.
+        if status == 404:
+            error_type = "not_found"
+        elif status == 0:
+            error_type = "connection_error"
+        elif status in (429, 502, 503, 504):
+            # Transient class, but fetch_with_retry exhausted its budget.
+            error_type = "rate_limited" if status == 429 else "http_error"
+        else:
+            error_type = "http_error"
+
+        self._log_error(error_type, url, f"HTTP {status}" if status else "no response")
+        self._deadletter(url, status, error_type, f"HTTP {status}" if status else "no response")
+        return None
+
+    def _deadletter(self, url: str, status: int, error_type: str, message: str) -> None:
+        """Record a permanently-failed request to the dead-letter log."""
+        write_deadletter(
+            source=self.source_name,
+            url=url,
+            status=status,
+            error_type=error_type,
+            message=message,
+        )
 
     def save_book(self, book_path: Path, book: dict, new_fields: dict) -> bool:
         """Update book JSON with new fields. Only fills missing/empty fields.

--- a/scripts/enrichment_config.py
+++ b/scripts/enrichment_config.py
@@ -13,6 +13,7 @@ BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
 AUTHORS_DIR = Path(__file__).parent.parent / "src" / "content" / "authors"
 DATA_DIR = Path(__file__).parent.parent / "data"
 ERROR_LOG = DATA_DIR / "enrichment-errors.jsonl"
+DEADLETTER_LOG = DATA_DIR / "enrichment-deadletter.jsonl"
 
 # HTTP
 USER_AGENT = "Tsundoku/1.0 (https://github.com/williamzujkowski/tsundoku)"

--- a/scripts/test_deadletter.py
+++ b/scripts/test_deadletter.py
@@ -1,0 +1,199 @@
+"""Tests for the dead-letter writer and enrichment_base._raw_request routing.
+
+_raw_request now goes through http_retry.fetch_with_retry (429/5xx backoff)
+and records permanent failures to the dead-letter log. The return contract
+for callers is unchanged: parsed JSON dict on success, None on any failure.
+"""
+
+import json
+
+import pytest
+
+import deadletter
+from deadletter import write_deadletter
+from enrichment_base import EnrichmentScript
+
+
+class _Enricher(EnrichmentScript):
+    """Minimal concrete subclass so we can exercise the base methods."""
+
+    source_name = "testsource"
+    enrichment_field = "test_field"
+
+    def search(self, book):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# write_deadletter
+# ---------------------------------------------------------------------------
+
+class TestWriteDeadletter:
+    def test_appends_valid_jsonl(self, tmp_path):
+        log = tmp_path / "dl.jsonl"
+        write_deadletter(
+            source="gutenberg", url="http://x/1", status=429,
+            error_type="rate_limited", message="HTTP 429", path=log,
+        )
+        write_deadletter(
+            source="hathitrust", url="http://x/2", status=404,
+            error_type="not_found", message="HTTP 404", path=log,
+        )
+        lines = log.read_text().splitlines()
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        second = json.loads(lines[1])
+        assert first["source"] == "gutenberg"
+        assert first["status"] == 429
+        assert first["error_type"] == "rate_limited"
+        assert first["url"] == "http://x/1"
+        assert "timestamp" in first
+        assert second["error_type"] == "not_found"
+
+    def test_creates_parent_dir(self, tmp_path):
+        log = tmp_path / "nested" / "deeper" / "dl.jsonl"
+        write_deadletter(
+            source="s", url="http://x", status=0,
+            error_type="connection_error", path=log,
+        )
+        assert log.exists()
+        assert json.loads(log.read_text())["error_type"] == "connection_error"
+
+    def test_never_raises_on_oserror(self, monkeypatch, tmp_path):
+        # Point at a directory path so open() for append fails with OSError.
+        bad = tmp_path  # a directory, not a file
+        # Should swallow the error, not propagate.
+        write_deadletter(
+            source="s", url="http://x", status=500,
+            error_type="http_error", path=bad,
+        )
+
+    def test_truncates_long_fields(self, tmp_path):
+        log = tmp_path / "dl.jsonl"
+        write_deadletter(
+            source="s", url="http://x/" + "a" * 5000, status=500,
+            error_type="http_error", message="b" * 5000, path=log,
+        )
+        rec = json.loads(log.read_text())
+        assert len(rec["url"]) <= 1000
+        assert len(rec["message"]) <= 500
+
+
+# ---------------------------------------------------------------------------
+# _raw_request routing
+# ---------------------------------------------------------------------------
+
+class TestRawRequestRetry:
+    def test_success_returns_parsed_json(self, monkeypatch):
+        monkeypatch.setattr(
+            "enrichment_base.fetch_with_retry",
+            lambda url, **kw: (b'{"results": [1, 2]}', 200, {}),
+        )
+        enr = _Enricher()
+        result = enr._raw_request("http://x")
+        assert result == {"results": [1, 2]}
+
+    def test_retries_on_429_via_fetch_with_retry(self, monkeypatch):
+        """_raw_request delegates retry to fetch_with_retry; on eventual
+        success it returns parsed JSON and writes no dead-letter."""
+        calls = {"n": 0}
+
+        def fake_fetch(url, **kw):
+            calls["n"] += 1
+            # Simulate fetch_with_retry having internally retried past a 429
+            # and ultimately succeeding — it returns a 200 body.
+            return b'{"ok": true}', 200, {}
+
+        dl_calls = []
+        monkeypatch.setattr("enrichment_base.fetch_with_retry", fake_fetch)
+        monkeypatch.setattr(
+            "enrichment_base.write_deadletter",
+            lambda **kw: dl_calls.append(kw),
+        )
+        enr = _Enricher()
+        result = enr._raw_request("http://x")
+        assert result == {"ok": True}
+        assert calls["n"] == 1
+        assert dl_calls == []  # success -> no dead-letter
+
+    def test_uses_retryable_path_not_swallow(self, monkeypatch):
+        """The old code swallowed 429 -> None with no retry. Now 429 must go
+        through fetch_with_retry (which performs the backoff/retry)."""
+        seen = {}
+
+        def fake_fetch(url, **kw):
+            seen["url"] = url
+            seen["kw"] = kw
+            return b'{"x": 1}', 200, {}
+
+        monkeypatch.setattr("enrichment_base.fetch_with_retry", fake_fetch)
+        _Enricher()._raw_request("http://api/thing")
+        assert seen["url"] == "http://api/thing"
+
+
+class TestRawRequestDeadLetter:
+    @pytest.mark.parametrize("status,error_type", [
+        (404, "not_found"),
+        (0, "connection_error"),
+        (429, "rate_limited"),
+        (503, "http_error"),
+        (502, "http_error"),
+        (400, "http_error"),
+        (500, "http_error"),
+    ])
+    def test_permanent_failure_returns_none_and_deadletters(
+        self, monkeypatch, status, error_type
+    ):
+        monkeypatch.setattr(
+            "enrichment_base.fetch_with_retry",
+            lambda url, **kw: (None, status, {}),
+        )
+        dl_calls = []
+        monkeypatch.setattr(
+            "enrichment_base.write_deadletter",
+            lambda **kw: dl_calls.append(kw),
+        )
+        # Don't actually touch the error log file.
+        monkeypatch.setattr(EnrichmentScript, "_log_error", lambda *a, **k: None)
+
+        enr = _Enricher()
+        result = enr._raw_request("http://x")
+        assert result is None
+        assert len(dl_calls) == 1
+        assert dl_calls[0]["source"] == "testsource"
+        assert dl_calls[0]["status"] == status
+        assert dl_calls[0]["error_type"] == error_type
+        assert dl_calls[0]["url"] == "http://x"
+
+    def test_unparseable_body_deadletters(self, monkeypatch):
+        monkeypatch.setattr(
+            "enrichment_base.fetch_with_retry",
+            lambda url, **kw: (b"not json{", 200, {}),
+        )
+        dl_calls = []
+        monkeypatch.setattr(
+            "enrichment_base.write_deadletter",
+            lambda **kw: dl_calls.append(kw),
+        )
+        monkeypatch.setattr(EnrichmentScript, "_log_error", lambda *a, **k: None)
+
+        result = _Enricher()._raw_request("http://x")
+        assert result is None
+        assert dl_calls[0]["error_type"] == "parse_error"
+
+    def test_end_to_end_writes_real_file(self, monkeypatch, tmp_path):
+        """Full path: permanent failure -> real JSONL line on disk."""
+        log = tmp_path / "dl.jsonl"
+        monkeypatch.setattr(deadletter, "DEADLETTER_LOG", log)
+        monkeypatch.setattr(
+            "enrichment_base.fetch_with_retry",
+            lambda url, **kw: (None, 429, {}),
+        )
+        monkeypatch.setattr(EnrichmentScript, "_log_error", lambda *a, **k: None)
+
+        result = _Enricher()._raw_request("http://api/fail")
+        assert result is None
+        rec = json.loads(log.read_text().strip())
+        assert rec["source"] == "testsource"
+        assert rec["status"] == 429
+        assert rec["error_type"] == "rate_limited"


### PR DESCRIPTION
## Summary

Closes #149. Handles the residual called out in triage: the last 429-swallowing path (`enrichment_base._raw_request`, used by enrich-gutenberg / librivox / hathitrust / wikipedia-books) plus the dead-letter writer named in the original acceptance criteria.

## What changed

- **`_raw_request` now routes through `http_retry.fetch_with_retry`.** Transient statuses (429/502/503/504) get `Retry-After`-aware exponential backoff with jitter instead of being silently dropped to `None`. The caller return contract is preserved exactly: a parsed JSON object on success, `None` on any failure. Caller signatures are untouched.
- **Dead-letter log.** New best-effort `scripts/deadletter.py::write_deadletter()` appends one JSON line per permanent failure to `data/enrichment-deadletter.jsonl`. A failure is permanent when it's a 404, a non-retryable 4xx, retries are exhausted (429/5xx), a network error, or an unparseable body. Each record carries `timestamp` (real wall-clock — these are ordinary enrichment scripts, not deterministic workflow scripts), `source`, `url`, `status`, `error_type`, and `message`. The writer never raises.
- `DEADLETTER_LOG` path added to `enrichment_config.py`; `data/enrichment-deadletter.jsonl` added to `.gitignore`.
- Removed the now-unused `urllib` imports from `enrichment_base.py`.

## Tests

New `scripts/test_deadletter.py` (16 tests): `_raw_request` returns parsed JSON on success and delegates retry to `fetch_with_retry`; permanent failures across status classes return `None` and write exactly one dead-letter record with the right `error_type`; unparseable body is dead-lettered as `parse_error`; an end-to-end case writes a real JSONL line; the writer appends valid JSONL, creates parent dirs, truncates long fields, and never raises on OSError.

Full suite: **458 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)