### PR TITLE
chore(enrichment): wire enrich-descriptions.py into run-all as canonical (#184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,10 @@ python3 scripts/run-all-enrichments.py           # Scan all sources until comple
 python3 scripts/run-all-enrichments.py --status   # Show scan positions
 ```
 
-The runner loops subjects → gutenberg → librivox → hathitrust in batches of 500.
+The runner loops subjects → gutenberg → librivox → hathitrust → wikipedia_books → descriptions in batches of 500.
 Safety: max 20 iterations, 10s inter-batch delays. State persisted in `data/enrichment-state.json` (gitignored).
+
+**Description filling:** `enrich-descriptions.py` (source `descriptions`) is the canonical multi-strategy description path (OL work → OL editions → Google Books → OL first_sentence → Gutenberg full-text). It runs after `enrich-wikipedia-books.py`, which stays in the loop because it uniquely also supplies a missing `cover_url`. Additive JSON merge means the two never overwrite each other.
 
 ### Post-enrichment
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,8 +26,8 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 | `enrich-gaps.py` | Open Library + Google Books | Multi-source gap filler — fills missing fields with fallback |
 | `enrich-copyright.py` | Internal (metadata) | Computes copyright_status from existing fields (no API calls) |
 | `enrich-tags.py` | Internal (subjects) | Maps Open Library subjects to normalized genre tags (35 genres) |
-| `enrich-wikipedia-books.py` | Wikipedia | Descriptions + covers for books missing them |
-| `enrich-descriptions.py` | OL works + editions, Google Books, Gutenberg | Consolidated five-strategy fallback for missing descriptions |
+| `enrich-wikipedia-books.py` | Wikipedia | Narrow first description pass; uniquely also fills a missing cover_url. Runs in `run-all` before `enrich-descriptions.py` |
+| `enrich-descriptions.py` | OL works + editions, Google Books, OL first_sentence, Gutenberg | **Canonical description path** (#184) — consolidated five-strategy fallback, wired into `run-all-enrichments.py` as the last description pass |
 
 ## Build Pipeline (run automatically by `npm run build`)
 
@@ -113,7 +113,7 @@ python3 scripts/run-all-enrichments.py
 python3 scripts/run-all-enrichments.py --status
 
 # The runner automatically executes this full pipeline:
-# Phase 1 (API): subjects → gutenberg → librivox → hathitrust
+# Phase 1 (API): subjects → gutenberg → librivox → hathitrust → wikipedia_books → descriptions
 # Phase 2 (post): tags → copyright → categories → dedupe → stubs → stats → index
 ```
 

--- a/scripts/run-all-enrichments.py
+++ b/scripts/run-all-enrichments.py
@@ -47,7 +47,21 @@ ENRICHMENT_SOURCES = {
     "wikipedia_books": {
         "script": "enrich-wikipedia-books.py",
         "args": [],
-        "description": "Wikipedia descriptions for books missing them",
+        # Wikipedia is a narrow first pass: it uniquely also supplies a
+        # cover_url when one is missing. enrich-descriptions.py (below) is
+        # the canonical multi-strategy description filler that runs after
+        # it; the additive JSON merge means the two never overwrite each
+        # other — Wikipedia just gets first crack at the easy hits.
+        "description": "Wikipedia descriptions (+ covers) for books missing them",
+    },
+    "descriptions": {
+        "script": "enrich-descriptions.py",
+        "args": [],
+        # Canonical description path (issue #184): consolidated 5-strategy
+        # fallback (OL work → OL editions → Google Books → OL first_sentence
+        # → Gutenberg full-text). Runs last so it only touches descriptions
+        # still missing after every other source.
+        "description": "Consolidated 5-strategy description fallback",
     },
 }
 


### PR DESCRIPTION
## What

Addresses item 4 of #184: `enrich-descriptions.py` (the consolidated 5-strategy description filler) was documented as canonical but wired into **no** runner — `run-all-enrichments.py` only used the narrower `enrich-wikipedia-books.py`.

This adds `enrich-descriptions.py` to `ENRICHMENT_SOURCES` as the canonical description path.

## Sequencing change

It's inserted into the **main API-scan loop** (not the post-enrichment phase), because it's an API-calling scanner with its own resumable enrichment state, exactly like the other sources. The full Phase-1 sequence is now:

```
subjects → gutenberg → librivox → hathitrust → wikipedia_books → descriptions
```

`descriptions` runs **last** so it only touches descriptions still missing after every other source.

## Relationship to enrich-wikipedia-books.py

`enrich-wikipedia-books.py` is **kept** in the loop, not removed:

- It uniquely also fills a missing `cover_url` (with portrait-aspect guarding), which `enrich-descriptions.py` does not do.
- Both write the `description` field, but the base class uses an **additive JSON merge** (never overwrites a non-empty field), so they don't fight: Wikipedia gets first crack at the easy hits, then the consolidated 5-strategy fallback (OL work → OL editions → Google Books → OL first_sentence → Gutenberg full-text) fills the remainder.

So `enrich-descriptions.py` is now the canonical description path; `enrich-wikipedia-books.py` is effectively a narrow first description pass that also handles covers.

## Docs

- `CLAUDE.md`: updated runner sequence line + added a Post-enrichment note on the canonical description path.
- `scripts/README.md`: updated the enrichment table (marked `enrich-descriptions.py` canonical, clarified Wikipedia's role) and the stale usage Phase-1 sequence comment.

## Verification

- `enrich-descriptions.py --help` confirms standard `--limit` CLI (always applies via additive merge; no separate `--apply`/dry-run flag).
- `run-all-enrichments.py` imports cleanly; `ENRICHMENT_SOURCES` now lists `descriptions`.
- `python3 scripts/run-all-enrichments.py --status` shows the new `descriptions` source row.
- `cd scripts && python3 -m pytest -q` → **442 passed**.
- No full enrichment scan was run (avoids live API calls).

relates to #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)