### PR TITLE
fix(a11y,seo): absolute og:image + twitter tags, reduced-motion transitions, homepage H1 (#201, #202)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,6 +15,11 @@ interface Props {
 const { title, description = `${stats.total_books.toLocaleString()} books cataloged, ${Math.round(100 * stats.reading_progress.read / stats.total_books)}% actually read — the rest are aspirational`, image } = Astro.props;
 const base = import.meta.env.BASE_URL;
 const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
+// og:image / twitter:image must be absolute URLs. Cover/photo values are
+// root-relative cached paths (e.g. /tsundoku/cached/covers/x.jpg); resolve
+// them against the site origin. Already-absolute upstream URLs pass through
+// unchanged. See #201.
+const ogImage = image && Astro.site ? new URL(image, Astro.site).href : (image || undefined);
 ---
 
 <!doctype html>
@@ -27,8 +32,11 @@ const siteUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : '';
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     {siteUrl && <meta property="og:url" content={siteUrl} />}
-    {image && <meta property="og:image" content={image} />}
-    <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+    {ogImage && <meta property="og:image" content={ogImage} />}
+    <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
+    <meta name="twitter:title" content={`${title} — Tsundoku`} />
+    <meta name="twitter:description" content={description} />
+    {ogImage && <meta name="twitter:image" content={ogImage} />}
     {siteUrl && <link rel="canonical" href={siteUrl} />}
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,8 +15,8 @@ const yearSpan = stats.newest_year - stats.oldest_year;
 <Layout title="Home">
   <!-- Hero -->
   <section class="py-12 text-center">
-    <h1 class="heading-xl mb-2">積ん読</h1>
-    <p class="hero-subtitle text-mono">TSUNDOKU</p>
+    <h1 class="heading-xl mb-2"><span lang="ja">積ん読</span><span class="sr-only">Tsundoku</span></h1>
+    <p class="hero-subtitle text-mono" aria-hidden="true">TSUNDOKU</p>
     <p class="text-muted mb-4 max-w-xl mx-auto">
       Everything I've read or want to read. Not meticulously curated — just a lifelong habit of
       accumulating books faster than I can finish them.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1173,4 +1173,13 @@ body::before {
     animation-duration: 0.01ms !important;
     animation-delay: 0ms !important;
   }
+
+  /* Astro view transitions animate on the ::view-transition-* pseudo tree,
+     which the universal selector above does NOT match. Disable the
+     cross-fade/slide and named cover/author morphs explicitly. See #202. */
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
 }


### PR DESCRIPTION
Three concrete fixes from the frontend a11y/SEO review.

### #201 — social previews (HIGH)
`og:image`/`twitter:image` were emitted with root-relative cached paths (e.g. `/tsundoku/cached/covers/x.jpg`), which the Open Graph spec rejects → Facebook/Slack/Discord/LinkedIn/iMessage showed no preview image on shared book/author links. Now resolved to absolute via `new URL(image, Astro.site)` (already-absolute upstream URLs pass through). Added the missing `twitter:image`, `twitter:title`, `twitter:description`.

### #202 — reduced-motion (HIGH, a11y / WCAG 2.3.3)
The `prefers-reduced-motion` override targets `*`, which does **not** match Astro's `::view-transition-*` pseudo-element tree — so the per-navigation cross-fade/slide and the named cover/author morphs still animated for motion-sensitive users. Added an explicit `::view-transition-*` `animation: none` rule.

### #201 / M1 — homepage H1 (a11y)
The sole `<h1>` was Japanese-only (`積ん読`). Now `<span lang="ja">積ん読</span><span class="sr-only">Tsundoku</span>` so the document's primary heading has accessible Latin text; the visible `TSUNDOKU` subtitle is `aria-hidden` to avoid SR duplication.

Remaining medium/low items (search `aria-live` region, RandomBook's 1 MB refetch → needs a `random-slugs.json`, ⌘K hydration timing, search close button) stay tracked on **#203**.

## Verification
`npm run typecheck` → 0 errors (under astro 7). Gated by the on-PR build.

Closes #201, #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)