### PR TITLE
feat(books): surface original-publication, translator, awards & adaptations on detail page (#124, #184)

### DIFF
--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -85,6 +85,20 @@ if (book.series?.name && book.series.position) {
   }
 }
 
+// Human-readable label for an adaptation medium (#184). Kept inline to avoid
+// touching src/utils/formatting.ts (parseAuthors change in flight there).
+const ADAPTATION_TYPE_LABELS: Record<string, string> = {
+  film: 'Film',
+  tv: 'TV',
+  stage: 'Stage',
+  radio: 'Radio',
+  opera: 'Opera',
+  other: 'Adaptation',
+};
+function adaptationTypeLabel(type: string): string {
+  return ADAPTATION_TYPE_LABELS[type] ?? 'Adaptation';
+}
+
 const currentLcc = book.lcc?.[0] ?? null;
 let shelfNeighbors: Array<{ slug: string; title: string; author: string; cover_url?: string; lcc: string }> = [];
 if (currentLcc) {
@@ -174,6 +188,10 @@ if (currentLcc) {
           ));
         })()}</p>
 
+        {book.translator && (
+          <p class="text-dim text-sm mb-4">translated by {book.translator}</p>
+        )}
+
         <div class="flex flex-wrap items-center gap-2 mb-4">
           {book.reading_status && (
             <span class={statusClass(book.reading_status)}>
@@ -193,11 +211,22 @@ if (currentLcc) {
           )}
         </div>
 
-        {book.original_title && book.original_title.toLowerCase() !== book.title.toLowerCase() && (
+        {/* Original publication — consolidated work-level provenance. Only
+            renders when there's something to say beyond the edition we link to:
+            an original title, original-language publisher, or both. The hero
+            already shows the publication year as a meta-tag below. */}
+        {((book.original_title && book.original_title.toLowerCase() !== book.title.toLowerCase()) || book.original_publisher) && (
           <p class="text-dim text-sm mb-3">
-            Originally <i lang={book.original_language || undefined}>{book.original_title}</i>
-            {book.original_language && book.original_language !== 'eng' && (
-              <span> · {languageLabel(book.original_language)}</span>
+            {book.original_title && book.original_title.toLowerCase() !== book.title.toLowerCase() ? (
+              <>
+                Originally published as <i lang={book.original_language || undefined}>«{book.original_title}»</i>
+                {book.original_language && book.original_language !== 'eng' && (
+                  <span> ({languageLabel(book.original_language)})</span>
+                )}
+                {book.original_publisher && <span>, {book.original_publisher}</span>}
+              </>
+            ) : (
+              <>Originally published by {book.original_publisher}</>
             )}
           </p>
         )}
@@ -211,9 +240,6 @@ if (currentLcc) {
             <span class="meta-tag">
               First published {formatYear(book.first_published, book.first_published_circa)}
             </span>
-          )}
-          {book.original_publisher && (
-            <span class="meta-tag">{book.original_publisher}</span>
           )}
           {book.pages && (
             <span class="meta-tag">{book.pages} pages</span>
@@ -275,7 +301,7 @@ if (currentLcc) {
 
       {/* This edition — what the user is actually reading. Distinct from
           the work-level metadata above (year, original title). */}
-      {(book.isbn || book.language || book.translator || (book.first_edition_isbn !== undefined && book.first_edition_isbn !== null && book.first_edition_isbn !== book.isbn)) && (
+      {(book.isbn || book.language || (book.first_edition_isbn !== undefined && book.first_edition_isbn !== null && book.first_edition_isbn !== book.isbn)) && (
         <div class="detail-section">
           <dt class="text-dim text-sm mb-2">This edition</dt>
           <dd class="flex flex-wrap gap-3 text-xs items-center">
@@ -284,9 +310,6 @@ if (currentLcc) {
             )}
             {book.language && (
               <span>{languageLabel(book.language)}</span>
-            )}
-            {book.translator && (
-              <span>Translated by {book.translator}</span>
             )}
             {book.first_edition_isbn !== undefined && book.first_edition_isbn !== null && book.first_edition_isbn !== book.isbn && (
               <span class="text-dim text-mono">First-edition ISBN: {book.first_edition_isbn}</span>
@@ -384,6 +407,28 @@ if (currentLcc) {
           )}
         </a>
       </nav>
+    )}
+
+    <!-- Adaptations (#184) — curated film/TV/stage/etc. derived from this work -->
+    {book.adaptations && book.adaptations.length > 0 && (
+      <section class="mb-8">
+        <h2 class="heading-md mb-2">Adaptations</h2>
+        <p class="text-dim text-sm mb-4">
+          Works adapted from <i>{book.title}</i>.
+        </p>
+        <ul class="adaptation-list">
+          {book.adaptations
+            .slice()
+            .sort((a, b) => (a.year ?? 9999) - (b.year ?? 9999))
+            .map(a => (
+              <li class="adaptation-item">
+                <span class="meta-tag text-xs">{adaptationTypeLabel(a.type)}</span>
+                <span class="adaptation-title">{a.title}</span>
+                {a.year !== undefined && <span class="text-dim text-sm"> ({a.year})</span>}
+              </li>
+            ))}
+        </ul>
+      </section>
     )}
 
     <!-- On the Same Shelf — LCC-adjacent neighbors -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1016,6 +1016,26 @@ a:hover { color: var(--pop-pink); }
 .series-nav-label { font-size: 0.7rem; color: var(--text-dim); letter-spacing: 0.02em; text-transform: uppercase; }
 .series-nav-title { font-size: 0.95rem; font-weight: 600; line-height: 1.2; }
 
+/* Adaptations list (#184) — curated film/TV/stage works derived from a book */
+.adaptation-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+.adaptation-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: var(--border-width) solid var(--border);
+  background: var(--bg-surface);
+}
+.adaptation-title { font-weight: 600; }
+
 /* Book detail page layout */
 .book-detail-layout {
   display: flex; flex-wrap: wrap; gap: 1.5rem;


### PR DESCRIPTION
Surfaces book metadata that was already collected in JSON but never rendered (#124), and adds the long-unused **Adaptations** UI (#184) — resolving the "hand-curated but 0 UI references" flag by *using* the `adaptations` field rather than dropping it.

All sections are guarded on field presence (`{book.field && ...}`) and reuse existing utility classes (`meta-tag`, `heading-md`, `detail-section`, `text-dim`, etc.). No changes to `src/utils/formatting.ts` (avoids the in-flight `parseAuthors` change) — the one tiny helper lives inline in the `.astro` file.

## Sections added / changed

### 1. Adaptations (#184) — NEW
A guarded "Adaptations" section listing curated film/TV/stage/etc. works derived from the book, sorted by year, each with a medium label (`Film`/`TV`/`Stage`/`Radio`/`Opera`/`Adaptation`), title, and year. Matches the `content.config.ts` schema enum exactly (`type: 'film'|'tv'|'stage'|'radio'|'opera'|'other'`).
- *No book currently carries `adaptations` data in the repo (0 files), so the section renders for none today; verified end-to-end against a temporary fixture on `dune` (1984 film, 2000 TV, 2021 film) — sorts and labels correctly. The field is now wired so curated data shows the moment it lands.*

### 2. Original publication (#124)
Consolidated the scattered `original_title` / `original_language` / `original_publisher` into one labeled line: *"Originally published as «{original_title}» ({language}), {publisher}"*. Removed the now-redundant `original_publisher` meta-tag. `first_published_circa` continues to render via the existing `formatYear(..., circa)` ("c. YEAR") on the publication-year meta-tag.
- Example: **Being and Nothingness** (`being-and-nothingness-2`) → "Originally published as «L'être et le néant» (French), Éditions Gallimard".

### 3. Translator (#124)
Surfaced *"translated by {translator}"* directly under the byline (was previously only buried in the "This edition" block; that duplicate is removed).
- Example: **1Q84** (`1q84`) → "translated by Jay Rubin".

### 4. Awards (#124)
Already rendered as `meta-tag` award links mirroring the author page pattern (`/awards/{slug}/`); confirmed working.
- Example: **Being and Nothingness** → "Le Monde's 100 Books of the Century"; **Wolf Hall** → "Booker Prize (2009)".

## Verification
- `npm run typecheck` → **0 errors** (1 pre-existing hint in unrelated `stacks/[class].astro`)
- `npm test` → **63 passed**
- `npm run build` → compiled past "Building static entrypoints" and rendered pages cleanly; spot-checked rendered HTML for all four sections (original-publication block, translator byline, award links, and the adaptations fixture on `dune`).

relates to #124, #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)