### PR TITLE
fix(a11y,perf): persistent search live-region, close button, RandomBook slug index (#203)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ data/enrichment-deadletter.jsonl
 
 # Generated at build time
 public/search-index.json
+public/random-slugs.json
 public/browse-data.json
 data/.~lock.*
 

--- a/scripts/generate-search-index.py
+++ b/scripts/generate-search-index.py
@@ -12,6 +12,9 @@ from pathlib import Path
 BOOKS_DIR = Path(__file__).parent.parent / "src" / "content" / "books"
 AUTHORS_DIR = Path(__file__).parent.parent / "src" / "content" / "authors"
 OUTPUT = Path(__file__).parent.parent / "public" / "search-index.json"
+# Tiny companion index: just the book URL paths, so RandomBook.svelte can
+# pick a random book without downloading the full ~1MB search index (#203).
+RANDOM_SLUGS_OUTPUT = Path(__file__).parent.parent / "public" / "random-slugs.json"
 
 
 def main() -> None:
@@ -68,6 +71,14 @@ def main() -> None:
     OUTPUT.write_text(json.dumps(items, separators=(",", ":")))
 
     print(f"Search index: {len(items)} items ({OUTPUT.stat().st_size // 1024}KB)")
+
+    # Companion random-slugs index: book URL paths only.
+    book_urls = [item["u"] for item in items if item["y"] == "book"]
+    RANDOM_SLUGS_OUTPUT.write_text(json.dumps(book_urls, separators=(",", ":")))
+    print(
+        f"Random slugs: {len(book_urls)} books "
+        f"({RANDOM_SLUGS_OUTPUT.stat().st_size // 1024}KB)"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/test_generate_search_index.py
+++ b/scripts/test_generate_search_index.py
@@ -1,0 +1,87 @@
+"""Tests for generate-search-index.py, including the companion
+random-slugs.json emitted for RandomBook.svelte (#203)."""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Module name has a hyphen, so import via spec.
+_spec = importlib.util.spec_from_file_location(
+    "generate_search_index", Path(__file__).parent / "generate-search-index.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _write_book(books_dir: Path, slug: str, title: str) -> None:
+    (books_dir / f"{slug}.json").write_text(
+        json.dumps(
+            {
+                "title": title,
+                "author": "Some Author",
+                "category": "Fiction",
+                "slug": slug,
+            }
+        )
+    )
+
+
+def _write_author(authors_dir: Path, slug: str, name: str) -> None:
+    (authors_dir / f"{slug}.json").write_text(
+        json.dumps({"name": name, "slug": slug, "book_count": 1})
+    )
+
+
+def _run_with_fixtures(tmp_path, monkeypatch):
+    books_dir = tmp_path / "books"
+    authors_dir = tmp_path / "authors"
+    books_dir.mkdir()
+    authors_dir.mkdir()
+    _write_book(books_dir, "dune", "Dune")
+    _write_book(books_dir, "1984", "1984")
+    _write_author(authors_dir, "frank-herbert", "Frank Herbert")
+
+    search_out = tmp_path / "search-index.json"
+    random_out = tmp_path / "random-slugs.json"
+
+    monkeypatch.setattr(mod, "BOOKS_DIR", books_dir)
+    monkeypatch.setattr(mod, "AUTHORS_DIR", authors_dir)
+    monkeypatch.setattr(mod, "OUTPUT", search_out)
+    monkeypatch.setattr(mod, "RANDOM_SLUGS_OUTPUT", random_out)
+
+    mod.main()
+    return search_out, random_out
+
+
+class TestRandomSlugs:
+    def test_emits_random_slugs_file(self, tmp_path, monkeypatch):
+        _, random_out = _run_with_fixtures(tmp_path, monkeypatch)
+        assert random_out.exists()
+
+    def test_random_slugs_are_book_urls_only(self, tmp_path, monkeypatch):
+        _, random_out = _run_with_fixtures(tmp_path, monkeypatch)
+        slugs = json.loads(random_out.read_text())
+        assert set(slugs) == {"books/dune/", "books/1984/"}
+        # Authors must never appear in the random-book index.
+        assert all(u.startswith("books/") for u in slugs)
+
+    def test_random_slugs_is_plain_array_of_strings(self, tmp_path, monkeypatch):
+        _, random_out = _run_with_fixtures(tmp_path, monkeypatch)
+        slugs = json.loads(random_out.read_text())
+        assert isinstance(slugs, list)
+        assert all(isinstance(u, str) for u in slugs)
+
+    def test_search_index_still_includes_authors(self, tmp_path, monkeypatch):
+        search_out, _ = _run_with_fixtures(tmp_path, monkeypatch)
+        items = json.loads(search_out.read_text())
+        types = {i["y"] for i in items}
+        assert "book" in types
+        assert "author" in types
+
+    def test_random_slugs_smaller_than_search_index(self, tmp_path, monkeypatch):
+        search_out, random_out = _run_with_fixtures(tmp_path, monkeypatch)
+        assert random_out.stat().st_size < search_out.stat().st_size

--- a/src/components/RandomBook.svelte
+++ b/src/components/RandomBook.svelte
@@ -3,13 +3,13 @@
 
   async function goToRandom() {
     try {
-      const res = await fetch(`${baseUrl}search-index.json`);
+      // Tiny dedicated index (KB, not the ~1MB search index) of book URL paths.
+      const res = await fetch(`${baseUrl}random-slugs.json`);
       if (!res.ok) return;
-      const items: { u: string; y: string }[] = await res.json();
-      const books = items.filter(i => i.y === 'book');
-      if (books.length === 0) return;
-      const idx = Math.floor(Math.random() * books.length);
-      window.location.href = `${baseUrl}${books[idx].u}`;
+      const slugs: string[] = await res.json();
+      if (slugs.length === 0) return;
+      const idx = Math.floor(Math.random() * slugs.length);
+      window.location.href = `${baseUrl}${slugs[idx]}`;
     } catch {
       // Silently fail — button just doesn't navigate
     }

--- a/src/components/SearchModal.svelte
+++ b/src/components/SearchModal.svelte
@@ -50,6 +50,16 @@
       .slice(0, 12);
   });
 
+  // Persistent live-region text. Lives at the component root (always in the
+  // DOM) so screen readers reliably announce result-count changes — a live
+  // region must already exist before its text mutates (#203).
+  let announcement = $derived(() => {
+    if (!open || !loaded || query.length < 2) return '';
+    const n = results().length;
+    if (n === 0) return 'No results';
+    return `${n} ${n === 1 ? 'result' : 'results'}`;
+  });
+
   async function loadIndex() {
     if (loaded) return;
     loadError = false;
@@ -126,6 +136,10 @@
   </svg>
 </button>
 
+<!-- Persistent live region: always in the DOM so SR announcements fire
+     reliably when its text changes (#203 M2). -->
+<span class="sr-only" aria-live="polite" role="status">{announcement()}</span>
+
 {#if open}
   <div
     class="overlay"
@@ -156,6 +170,16 @@
           onkeydown={handleResultKeydown}
         />
         <kbd class="kbd-hint">ESC</kbd>
+        <button
+          type="button"
+          class="modal-close"
+          aria-label="Close search"
+          onclick={close}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
 
       <div id="search-results" class="results-list" role="listbox">
@@ -203,7 +227,9 @@
           <span><kbd class="kbd">esc</kbd> close</span>
         </div>
         {#if loaded && query.length >= 2}
-          <span class="results-count" aria-live="polite">{results().length} {results().length === 1 ? 'result' : 'results'}</span>
+          <!-- Visible count only; announcements come from the persistent
+               sr-only live region above to avoid double-announcing (#203 M2). -->
+          <span class="results-count">{results().length} {results().length === 1 ? 'result' : 'results'}</span>
         {/if}
       </div>
     </div>
@@ -296,6 +322,28 @@
     .kbd-hint {
       display: inline;
     }
+  }
+
+  .modal-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0.375rem;
+    color: var(--text-dim);
+    background: none;
+    border: none;
+    cursor: pointer;
+    transition: color 80ms ease;
+  }
+
+  .modal-close:hover {
+    color: var(--text);
+  }
+
+  .modal-close svg {
+    width: 1.125rem;
+    height: 1.125rem;
   }
 
   /* --- Results list --- */


### PR DESCRIPTION
Implements three clear-win items from #203 (skips M3 — the `client:idle`→`client:load` tradeoff for ⌘K is debatable and left as-is).

## M2 — Persistent search results-count live region (`SearchModal.svelte`)
The `aria-live="polite"` results count was rendered **inside** `{#if loaded && query.length >= 2}`, so the live region didn't pre-exist in the DOM — a requirement for screen readers to reliably announce changes.

**Fix:** an always-present `sr-only` `aria-live="polite"` `role="status"` region at the component root whose text changes ("12 results" / "No results" / ""), independent of the conditional visible UI. The visible footer count is kept as a purely visual indicator (its now-redundant `aria-live` was removed to prevent double-announcing).

## M5 — Labelled Close button (`SearchModal.svelte`)
Escape and backdrop-click already worked, but there was no discoverable close affordance. Added a visible `<button aria-label="Close search">` (× icon) in the modal search bar that calls the existing `close()` handler, styled to match the existing modal chrome. It sits inside the focus trap so keyboard Tab cycling reaches it.

## M4 — RandomBook no longer refetches the full search index (`RandomBook.svelte`)
RandomBook fetched the entire `search-index.json` on **every click** just to pick one random book URL.

**Fix:** `generate-search-index.py` now also emits `public/random-slugs.json` in the same pass (the cleaner single-script option) — a plain JSON array of book URL paths only. `RandomBook.svelte` fetches that instead, picks a random entry, and navigates. Silent-fail error handling preserved.

**Payload before/after:**
| File | Size |
|---|---|
| `search-index.json` (old fetch) | **1056 KB** |
| `random-slugs.json` (new fetch) | **~100 KB** (3,584 book URLs) |

~10× smaller per click. `random-slugs.json` is gitignored alongside `search-index.json` (both generated at build time). A new `scripts/test_generate_search_index.py` covers the companion output (book-URLs-only, plain string array, smaller than the search index).

## Verification
- `npm run typecheck` → **0 errors** (1 pre-existing unrelated hint in `stacks/[class].astro`)
- `npm test` → **63 passed**
- `cd scripts && python3 -m pytest -q` → **463 passed** (458 existing + 5 new)
- Generator run confirms: `Random slugs: 3584 books (100KB)` vs `Search index: 5483 items (1056KB)`
- Full `npm run build` skipped per request; on-PR CI build will validate.

relates to #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)