### PR TITLE
chore(content): migrate legacy subjects → subject_facet; enrich-tags reads facet (#124)

### DIFF
--- a/scripts/test_data_integrity.py
+++ b/scripts/test_data_integrity.py
@@ -104,6 +104,26 @@ class TestBookIntegrity:
                     nulls.append(f"{Path(f).name}: {k} is null")
         assert len(nulls) == 0, f"Null values found:\n" + "\n".join(nulls[:10])
 
+    def test_no_legacy_subjects_field(self):
+        """No book JSON may carry the legacy `subjects` field (epic #124).
+
+        `subjects` was never part of the content schema (only `subject_facet`
+        is — see src/content.config.ts), so Astro already stripped it. The 34
+        files that still carried it were migrated: the 2 without a curated
+        `subject_facet` had their values promoted into it, the other 32 had the
+        redundant key dropped. Enrich-tags.py and recategorize.py read
+        `subject_facet`, so the legacy field has no remaining reader. This guard
+        keeps it from creeping back in.
+        """
+        offenders = []
+        for f, b in load_all_books():
+            if "subjects" in b:
+                offenders.append(Path(f).name)
+        assert not offenders, (
+            "Legacy `subjects` key found — migrate to `subject_facet` (#124):\n"
+            + "\n".join(offenders[:10])
+        )
+
     def test_valid_priority(self):
         bad = []
         for f, b in load_all_books():

--- a/src/content/books/emile.json
+++ b/src/content/books/emile.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": 1762,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "ddc": [
     "370.1",
     "848.5",

--- a/src/content/books/existentialism-is-a-humanism.json
+++ b/src/content/books/existentialism-is-a-humanism.json
@@ -44,8 +44,5 @@
   "cover_cached_at": "2026-05-03T01:14:03+00:00",
   "ddc": [
     "100"
-  ],
-  "subjects": [
-    "r/philosophy Reading List"
   ]
 }

--- a/src/content/books/five-dialogues.json
+++ b/src/content/books/five-dialogues.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": -399,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "ol_work_key": "/works/OL24630946W",
   "ddc": [
     "888.4"

--- a/src/content/books/flowers-for-algernon.json
+++ b/src/content/books/flowers-for-algernon.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1966,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "[Fic]",
     "813",

--- a/src/content/books/furies-of-calderon.json
+++ b/src/content/books/furies-of-calderon.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 2004,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813"
   ],

--- a/src/content/books/gone-with-the-wind.json
+++ b/src/content/books/gone-with-the-wind.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1936,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "ddc": [
     "810",
     "428.6",

--- a/src/content/books/guide-for-the-perplexed.json
+++ b/src/content/books/guide-for-the-perplexed.json
@@ -49,8 +49,5 @@
   "cover_cached_at": "2026-05-03T01:18:41+00:00",
   "ddc": [
     "100"
-  ],
-  "subjects": [
-    "r/philosophy Reading List"
   ]
 }

--- a/src/content/books/heir-to-the-empire.json
+++ b/src/content/books/heir-to-the-empire.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1991,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54"
   ],

--- a/src/content/books/homeland.json
+++ b/src/content/books/homeland.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1990,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54"
   ],

--- a/src/content/books/how-to-live.json
+++ b/src/content/books/how-to-live.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": 2010,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "lcc": [
     "PQ-1643.00000000",
     "PQ-1643.00000000.B34 2010",

--- a/src/content/books/how-to-tell-the-birds-from-the-flowers-and-other-woodcuts.json
+++ b/src/content/books/how-to-tell-the-birds-from-the-flowers-and-other-woodcuts.json
@@ -14,9 +14,6 @@
   "pages": 72,
   "google_books_url": "https://play.google.com/store/books/details?id=oIVyF8j0I7QC&source=gbs_api",
   "language": "eng",
-  "subjects": [
-    "Wit and Humor"
-  ],
   "copyright_status": "public_domain",
   "isbn": "9780484129985",
   "ol_work_key": "/works/OL22507585W",

--- a/src/content/books/introduction-to-probability.json
+++ b/src/content/books/introduction-to-probability.json
@@ -11,18 +11,6 @@
   "first_published": 2002,
   "language": "eng",
   "reading_status": "want",
-  "subjects": [
-    "Probabilities",
-    "Random variables",
-    "Stochastic processes",
-    "Stochastik",
-    "Probabilidade",
-    "Processos estocásticos",
-    "Sannolikhet",
-    "Stokastiska processer",
-    "Qa273 .b454 2008",
-    "519.2"
-  ],
   "copyright_status": "in_copyright",
   "isbn": "9781886529236",
   "subject_facet": [

--- a/src/content/books/just-and-unjust-wars.json
+++ b/src/content/books/just-and-unjust-wars.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": 1977,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "ddc": [
     "172",
     "355.02"

--- a/src/content/books/kushiels-dart.json
+++ b/src/content/books/kushiels-dart.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 2001,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54",
     "813.6"

--- a/src/content/books/lord-fouls-bane.json
+++ b/src/content/books/lord-fouls-bane.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1977,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54"
   ],

--- a/src/content/books/magician-apprentice.json
+++ b/src/content/books/magician-apprentice.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1982,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ol_work_key": "/works/OL27396849W",
   "ddc": [
     "813.54"

--- a/src/content/books/moravagine.json
+++ b/src/content/books/moravagine.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1926,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "ddc": [
     "843.912"
   ],

--- a/src/content/books/my-childhood.json
+++ b/src/content/books/my-childhood.json
@@ -11,9 +11,6 @@
   "first_published": 1915,
   "language": "eng",
   "reading_status": "read",
-  "subjects": [
-    "Gorky, maksim, 1868-1936"
-  ],
   "copyright_status": "public_domain",
   "isbn": "9780241261958",
   "lcc": [

--- a/src/content/books/no-exit.json
+++ b/src/content/books/no-exit.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": 1944,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "ddc": [
     "842.91",
     "842.912"

--- a/src/content/books/no-orchids-for-miss-blandish.json
+++ b/src/content/books/no-orchids-for-miss-blandish.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1939,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "ddc": [
     "823.91"
   ],

--- a/src/content/books/on-the-genealogy-of-morality.json
+++ b/src/content/books/on-the-genealogy-of-morality.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": 1887,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "subject_facet": [
     "Asceticism",
     "Ethics",

--- a/src/content/books/our-lady-of-the-flowers.json
+++ b/src/content/books/our-lady-of-the-flowers.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1943,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "copyright_status": "likely_public_domain",
   "_provenance": {
     "cover_url": "wikipedia_book_v1",

--- a/src/content/books/outlander.json
+++ b/src/content/books/outlander.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1991,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54"
   ],

--- a/src/content/books/ozymandias-and-other-poems.json
+++ b/src/content/books/ozymandias-and-other-poems.json
@@ -13,7 +13,7 @@
   "cover_url": "/tsundoku/cached/covers/ozymandias-and-other-poems.jpg",
   "cover_url_large": "/tsundoku/cached/covers/ozymandias-and-other-poems.jpg",
   "pages": 518,
-  "subjects": [
+  "subject_facet": [
     "English poetry"
   ],
   "google_books_url": "https://play.google.com/store/books/details?id=O4MVAAAAYAAJ&source=gbs_api",

--- a/src/content/books/pawn-of-prophecy.json
+++ b/src/content/books/pawn-of-prophecy.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1982,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54",
     "823.91"

--- a/src/content/books/silence-of-the-sea.json
+++ b/src/content/books/silence-of-the-sea.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1942,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "ddc": [
     "843.91",
     "843.914"

--- a/src/content/books/the-abyss.json
+++ b/src/content/books/the-abyss.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1968,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "ddc": [
     "891.7",
     "843.912"

--- a/src/content/books/the-crystal-cave.json
+++ b/src/content/books/the-crystal-cave.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1970,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "823",
     "823.914"

--- a/src/content/books/the-dhammapada.json
+++ b/src/content/books/the-dhammapada.json
@@ -18,7 +18,7 @@
   "pages": 0,
   "first_published": -300,
   "language": "eng",
-  "subjects": [
+  "subject_facet": [
     "r/philosophy Reading List"
   ],
   "ol_work_key": "/works/OL20214655W",

--- a/src/content/books/the-diary-of-a-young-girl.json
+++ b/src/content/books/the-diary-of-a-young-girl.json
@@ -17,9 +17,6 @@
   "pages": 0,
   "first_published": 1947,
   "language": "eng",
-  "subjects": [
-    "Le Monde 100 Books of the Century"
-  ],
   "ddc": [
     "940.53088296"
   ],

--- a/src/content/books/the-interpretation-of-dreams.json
+++ b/src/content/books/the-interpretation-of-dreams.json
@@ -18,9 +18,6 @@
   "pages": 0,
   "first_published": 1900,
   "language": "eng",
-  "subjects": [
-    "r/philosophy Reading List"
-  ],
   "ddc": [
     "154.63",
     "135.383",

--- a/src/content/books/the-marriage-of-east-and-west.json
+++ b/src/content/books/the-marriage-of-east-and-west.json
@@ -11,9 +11,6 @@
   "cover_url": "/tsundoku/cached/covers/the-marriage-of-east-and-west.jpg",
   "cover_url_large": "/tsundoku/cached/covers/the-marriage-of-east-and-west.jpg",
   "pages": 232,
-  "subjects": [
-    "Religion"
-  ],
   "google_books_url": "http://books.google.com/books?id=-H_YAAAAMAAJ&dq=The+Marriage+of+East+and+West+Bede+Griffiths&hl=&source=gbs_api",
   "reading_status": "read",
   "copyright_status": "in_copyright",

--- a/src/content/books/the-princess-bride.json
+++ b/src/content/books/the-princess-bride.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1973,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54"
   ],

--- a/src/content/books/wizards-first-rule.json
+++ b/src/content/books/wizards-first-rule.json
@@ -19,9 +19,6 @@
   "pages": 0,
   "first_published": 1994,
   "language": "eng",
-  "subjects": [
-    "NPR Top 100 Science Fiction and Fantasy"
-  ],
   "ddc": [
     "813.54"
   ],


### PR DESCRIPTION
## Summary

Migrates the legacy `subjects` field off all book JSON and locks it out with a data-integrity guard. `subjects` was never part of the content schema (only `subject_facet` is — `src/content.config.ts`), so Astro already stripped it at build; this removes the dead stored field and confirms every reader now uses the curated facet.

## Migration counts (34 files)

- **2 real migrations** — files with no curated `subject_facet`; their `subjects` values were promoted into `subject_facet` (dedup, order preserved, key replaced in place):
  - `src/content/books/the-dhammapada.json`
  - `src/content/books/ozymandias-and-other-poems.json`
- **32 redundant-drop** — files that already had `subject_facet`; the redundant `subjects` key was simply removed (raw subjects **not** merged into the curated facet).

Diff is surgical: `34 files changed, 2 insertions(+), 107 deletions(-)`. The only additions are the 2 `subject_facet` renames. No other field touched — explicit `first_edition_isbn: null` values were preserved (an earlier `save_book`-style pass would have stripped them; the final migration does not).

## Scripts changed

- **`scripts/test_data_integrity.py`** — added `TestBookIntegrity.test_no_legacy_subjects_field`, asserting no book JSON carries the legacy `subjects` key. Verified it fails on an injected regression and passes on the migrated tree.

## #REWRITE-TAGS status

`scripts/enrich-tags.py` **already reads `subject_facet`** (in both `tag_report()` and `main()`); `scripts/recategorize.py` and `scripts/generate-search-index.py` likewise already read `subject_facet`. No stored-`subjects` reader remained, so the rewrite portion required no further code change — it was already landed.

## Upstream-API reads left intact (flagged)

These read API responses, **not** the stored book field, so they were deliberately left unchanged:

- `scripts/enrich-gutenberg.py:66` — `result.get("subjects")` is the **Gutendex API** response; written to `_gutenberg_subjects`, which `enrichment_base.py` merges into `subject_facet`.
- `scripts/enrich.py:152` — `doc.get("subject")` from the **Open Library** search doc; written to `subject_facet`.
- `scripts/enrich-gaps.py:73` — same OL `doc.get("subject")` API pattern.
- `scripts/test_json_merge.py` — uses `"subjects"` only as an arbitrary test field name.

## Verification

- `cd scripts && python3 -m pytest -q` → **459 passed** (incl. the new guard).
- `npm run typecheck` → **0 errors** (1 pre-existing unrelated hint in `src/pages/stacks/[class].astro`).
- Full build skipped (CI validates); no live enrichment scan run.

relates to #124 (#MIGRATE-SUBJECTS, #REWRITE-TAGS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)