### PR TITLE
fix(authors): strip trailing comma from split byline segments (#210)

### DIFF
--- a/scripts/generate-author-stubs.py
+++ b/scripts/generate-author-stubs.py
@@ -108,7 +108,9 @@ def _comma_sub_split(segment: str) -> list[str]:
     # Only treat commas as author separators when there's clear evidence of a
     # "First Last, First Last" list: 2+ sub-parts carry 2+ tokens. Otherwise the
     # commas belong to a single name (catalog notation, org suffix, initials).
-    return raw if len(multi_token) >= 2 else [segment.strip()]
+    # Strip a trailing comma left by an upstream strong-separator split
+    # ("Aho, Lam, Sethi, and Ullman" → segment "Aho, Lam, Sethi,") — #210.
+    return raw if len(multi_token) >= 2 else [segment.strip().rstrip(",").strip()]
 
 
 def split_authors(name: str) -> list[str]:

--- a/scripts/test_author_split.py
+++ b/scripts/test_author_split.py
@@ -46,8 +46,9 @@ PARITY_CASES: dict[str, list[str]] = {
         "Carolyn Thomson",
         "Peter Dans",
     ],
-    # single-token last-name list stays intact (no 2-token evidence)
-    "Aho, Lam, Sethi, and Ullman": ["Aho, Lam, Sethi,", "Ullman"],
+    # single-token last-name list stays intact (no 2-token evidence);
+    # trailing comma stripped (#210)
+    "Aho, Lam, Sethi, and Ullman": ["Aho, Lam, Sethi", "Ullman"],
     # --- #198 regressions: mixed comma + and/& + slash ---
     "Alexander Hamilton, James Madison, and John Jay": [
         "Alexander Hamilton",

--- a/src/content/authors/aho-lam-sethi.json
+++ b/src/content/authors/aho-lam-sethi.json
@@ -1,5 +1,5 @@
 {
-  "name": "Aho, Lam, Sethi,",
+  "name": "Aho, Lam, Sethi",
   "slug": "aho-lam-sethi",
   "book_count": 1,
   "bio": "family name"

--- a/src/pages/books/[slug].astro
+++ b/src/pages/books/[slug].astro
@@ -284,8 +284,8 @@ if (currentLcc) {
       {/* Classification (#124 DISPLAY-CLASS) — surfaces the library
           classification data we collect but never showed: Dewey (DDC) and
           Library of Congress (LCC) call numbers plus faceted subjects. LCC is
-          formatted via the shared lccDisplay() helper used by the spine label
-          and virtual shelf (OL stores it sort-padded). Subjects render as
+          formatted via the local lccDisplay() helper also used by the spine
+          label and virtual shelf (OL stores it sort-padded). Subjects render as
           plain tags — there is no /subjects/ index page to link to. The whole
           section is omitted unless at least one field is present. */}
       {((book.ddc && book.ddc.length > 0) || (book.lcc && book.lcc.length > 0) || (book.subject_facet && book.subject_facet.length > 0)) && (

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -295,8 +295,9 @@ describe('parseAuthors', () => {
 
   it('leaves single-token last-name lists intact', () => {
     // No 2-token evidence → "Aho, Lam, Sethi" is not a "First Last" list.
+    // Trailing comma stripped (#210).
     const r = parseAuthors('Aho, Lam, Sethi, and Ullman');
-    expect(r.parts).toEqual(['Aho, Lam, Sethi,', 'Ullman']);
+    expect(r.parts).toEqual(['Aho, Lam, Sethi', 'Ullman']);
   });
 });
 
@@ -324,7 +325,7 @@ describe('parseAuthors / split_authors parity contract (#198)', () => {
       'Calm Publications Staff, Kevin Crane, Carolyn Thomson, Peter Dans',
       ['Calm Publications Staff', 'Kevin Crane', 'Carolyn Thomson', 'Peter Dans'],
     ],
-    ['Aho, Lam, Sethi, and Ullman', ['Aho, Lam, Sethi,', 'Ullman']],
+    ['Aho, Lam, Sethi, and Ullman', ['Aho, Lam, Sethi', 'Ullman']],
     [
       'Alexander Hamilton, James Madison, and John Jay',
       ['Alexander Hamilton', 'James Madison', 'John Jay'],

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -163,7 +163,9 @@ function commaSubSplit(segment: string): string[] {
   // Only treat commas as author separators when there's clear evidence of a
   // "First Last, First Last" list: ≥2 sub-parts carry 2+ tokens. Otherwise the
   // commas belong to a single name (catalog notation, org suffix, initials).
-  return multiToken.length >= 2 ? raw : [segment.trim()];
+  // Strip a trailing comma left by an upstream strong-separator split
+  // ("Aho, Lam, Sethi, and Ullman" → segment "Aho, Lam, Sethi,") — #210.
+  return multiToken.length >= 2 ? raw : [segment.trim().replace(/,+\s*$/, '').trim()];
 }
 
 export function parseAuthors(name: string): AuthorParts {


### PR DESCRIPTION
From the post-merge regression sweep of #206/#209.

**LOW-2 (fixed):** `split_authors("Aho, Lam, Sethi, and Ullman")` → `["Aho, Lam, Sethi,", "Ullman"]` left a trailing comma on the kept segment (malformed name/slug). Now stripped in `_comma_sub_split`/`commaSubSplit` (Python + TS, parity preserved); PARITY_CASES + the vitest case updated. Renamed the affected record `"Aho, Lam, Sethi," → "Aho, Lam, Sethi"` and reran `generate-author-stubs` (orphan + book_count integrity tests pass).

**NIT-1 (fixed):** corrected the inaccurate "shared helper" comment for the local (non-exported) `lccDisplay()` in `books/[slug].astro`.

**Won't-fix (documented on #210):**
- **LOW-1** (person + corporate co-author kept whole) — disqualifying any `&` would wrongly split legitimate corporate names ("Procter & Gamble", "Smith & Sons, Inc."); the conservative keep-whole is correct and the orphan guard backstops genuine person-loss.
- **NIT-2** (`dt`/`dd` in a `div`) — follows the page-wide `detail-section` convention; fixing one card would be inconsistent.

## Verification
481 Python + 85 JS tests pass; typecheck 0 errors.

Closes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)