### PR TITLE
feat(enrichment): populate book adaptations from Wikidata P144 (#184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,11 @@ Computed from existing metadata (no API calls):
 2. **Open Library** — covers, year, subjects, OCLC, page counts
 3. **Google Books** — descriptions, ISBNs, categories
 4. **Wikipedia** — author bios and photos
-5. **Project Gutenberg** (Gutendex) — free reading links (public domain only)
-6. **LibriVox** — free audiobook links (public domain only)
-7. **HathiTrust** — digitized full texts + rights metadata
-8. **WorldCat** — library catalog links (via OCLC ID)
+5. **Wikidata** — structured metadata via P648 (year/publisher/awards/series) and **adaptations via P144 "based on"** (`scripts/enrich-adaptations.py`)
+6. **Project Gutenberg** (Gutendex) — free reading links (public domain only)
+7. **LibriVox** — free audiobook links (public domain only)
+8. **HathiTrust** — digitized full texts + rights metadata
+9. **WorldCat** — library catalog links (via OCLC ID)
 
 ## Key Patterns
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ Canonical inventory of all Python scripts. Referenced by CLAUDE.md and README.md
 | `enrich-ol-firstedition.py` | Open Library | First-edition anchor: editions consensus, original_*, representative_edition |
 | `enrich-wikidata-book.py` | Wikidata SPARQL | Year corrections, original_publisher, awards, series via P648 |
 | `enrich-wikidata-author.py` | Wikidata SPARQL | Nationality, alternate names, movements, awards, VIAF via P648 |
+| `enrich-adaptations.py` | Wikidata SPARQL | `adaptations` (film/tv/stage/radio/opera/other) via P144 "based on" — batched, resumable (#184) |
 | `recategorize.py` | Internal (DDC/LCC + tags) | Computes category from DDC/LCC primary, falls back to tag heuristics |
 | `enrich-gutenberg.py` | Project Gutenberg (Gutendex) | Free reading links for public domain books |
 | `enrich-librivox.py` | LibriVox | Free audiobook links for public domain books |

--- a/scripts/enrich-adaptations.py
+++ b/scripts/enrich-adaptations.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Wikidata-driven adaptations enrichment for books — issue #184.
+
+Populates the `adaptations` field on books from Wikidata property P144
+("based on"). A film / TV series / play / radio drama / opera that adapts a
+book carries `P144 → <the book's work QID>`. For every book with a
+`wikidata_qid` and no adaptations yet, we query Wikidata for items pointing
+at it via P144, classify each by its P31 (instance-of) into the schema's
+type enum {film, tv, stage, radio, opera, other}, and read title + year.
+
+Queries are BATCHED (VALUES ?book { wd:Q1 wd:Q2 ... }, ~40 books/request)
+via scripts/wikidata.adaptations_for_batch — one request per batch, not per
+book — and cached on disk, so re-runs are free and rate-limit friendly. A
+batch that fails transiently (rate-limit/timeout) stops the run cleanly so a
+re-run resumes at exactly that batch.
+
+Writes are additive (never overwrite a non-empty `adaptations`) and tag
+provenance as `wikidata_adaptations_v1`.
+
+Resumable: extends EnrichmentScript, so it records scan position per book
+slug in data/enrichment-state.json under source `wikidata_adaptations` and
+resumes where it left off on the next run.
+
+Usage:
+  python scripts/enrich-adaptations.py                 # process all candidates
+  python scripts/enrich-adaptations.py --limit 100     # first validation batch
+"""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from enrichment_base import EnrichmentScript
+from enrichment_state import EnrichmentState
+from json_merge import provenance_merge, save_json
+from wikidata import adaptations_for_batch, ADAPTATIONS_BATCH_SIZE
+
+
+SOURCE = "wikidata_adaptations_v1"  # provenance tag
+BATCH_BOOKS = ADAPTATIONS_BATCH_SIZE  # books/request (small → fast queries, no hang)
+# Stop the run after this many consecutive failed batches (sustained WDQS
+# outage). The scan is resumable, so a re-run picks up where it left off.
+MAX_CONSECUTIVE_FAILURES = 3
+
+
+class AdaptationsEnrichment(EnrichmentScript):
+    """Populate `adaptations` from Wikidata P144 (batched SPARQL)."""
+
+    @property
+    def source_name(self) -> str:
+        # State key (distinct from the provenance tag SOURCE).
+        return "wikidata_adaptations"
+
+    @property
+    def enrichment_field(self) -> str:
+        return "adaptations"
+
+    def search(self, book: dict):
+        """Unused — we override run() to batch. Kept to satisfy the ABC."""
+        return None
+
+    def filter_unenriched(self, books):
+        """Only books that have a wikidata_qid and no adaptations yet."""
+        return [
+            (bp, b)
+            for bp, b in books
+            if b.get("wikidata_qid") and not b.get("adaptations")
+        ]
+
+    def run(self, limit: int = 0) -> None:
+        """Batched main loop with state tracking and additive merge.
+
+        Overrides the base per-book loop: P144 lookups are far cheaper when
+        batched, so we resolve adaptations for ~40 books per SPARQL request,
+        then apply results book-by-book (recording scan state for resume).
+        """
+        state = EnrichmentState(self.source_name)
+        all_books = self.load_books()
+        state.set_total_books(len(all_books))
+
+        unenriched = self.filter_unenriched(all_books)
+        candidates = [
+            (bp, b) for bp, b in unenriched
+            if state.should_scan(b.get("slug", ""))
+        ]
+        # Keep alphabetical (slug) order so resume-by-slug stays monotonic.
+        candidates.sort(key=lambda pb: pb[1].get("slug", ""))
+
+        print(f"[{self.source_name}] {len(unenriched)} books with wikidata_qid "
+              f"and no {self.enrichment_field}")
+        if len(candidates) < len(unenriched):
+            print(f"  Resuming from '{state.last_scanned_slug}' "
+                  f"({len(unenriched) - len(candidates)} already scanned today)")
+
+        if limit > 0:
+            candidates = candidates[:limit]
+
+        found = 0
+        total_adaptations = 0
+        processed = 0
+        failed_batches = 0
+        consecutive_failures = 0
+        # The resume pointer may only advance through the contiguous prefix of
+        # successfully-queried books. Once any batch fails we stop recording
+        # scans so a re-run retries from the first un-queried book — even
+        # though we keep processing later batches (their writes are additive
+        # and safe). `seen_failure` latches that state.
+        seen_failure = False
+
+        for start in range(0, len(candidates), BATCH_BOOKS):
+            batch = candidates[start:start + BATCH_BOOKS]
+            qid_to_books: dict[str, list[tuple[Path, dict]]] = {}
+            for bp, b in batch:
+                qid_to_books.setdefault(b["wikidata_qid"], []).append((bp, b))
+
+            print(f"  [{processed + 1}-{processed + len(batch)}/{len(candidates)}] "
+                  f"querying P144 for {len(qid_to_books)} QIDs...", flush=True)
+
+            try:
+                results = adaptations_for_batch(list(qid_to_books.keys()))
+            except Exception as e:  # unexpected — treat as a batch failure
+                self._log_error("search_error", f"batch@{start}", str(e))
+                results = None
+
+            if results is None:
+                # Transient failure (rate-limit / timeout — now bounded by the
+                # http_retry timeout, so this returns rather than hanging).
+                # Dead-letter the batch, skip it, and keep going; but latch
+                # seen_failure so the resume pointer never advances past these
+                # un-queried books. A long outage trips the consecutive-failure
+                # cap and stops the run cleanly.
+                failed_batches += 1
+                consecutive_failures += 1
+                processed += len(batch)
+                self._log_error("rate_limited", f"batch@{start}",
+                                "SPARQL batch failed; dead-lettered, will retry on resume")
+                self._deadletter(
+                    url=f"sparql:P144:batch@{start}",
+                    status=0,
+                    error_type="rate_limited",
+                    message=f"adaptations batch of {len(batch)} books failed",
+                )
+                seen_failure = True
+                print(f"      … batch failed (transient); dead-lettered, "
+                      f"will retry on resume")
+                if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                    print(f"      ✗ {MAX_CONSECUTIVE_FAILURES} consecutive "
+                          f"failures — stopping. Re-run to resume.")
+                    break
+                time.sleep(self.rate_limit)
+                continue
+
+            consecutive_failures = 0
+            for bp, b in batch:
+                processed += 1
+                qid = b["wikidata_qid"]
+                adaptations = results.get(qid)
+                matched = False
+                if adaptations:
+                    changed, _audit = provenance_merge(
+                        b, {"adaptations": adaptations}, source=SOURCE,
+                    )
+                    if changed:
+                        save_json(bp, b)
+                        found += 1
+                        total_adaptations += len(adaptations)
+                        matched = True
+                        types = ",".join(sorted({a["type"] for a in adaptations}))
+                        print(f"      ✓ {b['slug'][:40]}: "
+                              f"{len(adaptations)} ({types})")
+                # Advance the resume pointer only while we're still in the
+                # contiguous successful prefix (no earlier batch failed).
+                if not seen_failure:
+                    state.record_scan(b.get("slug", ""), matched=matched)
+
+            state.save()  # checkpoint after each batch so resume is cheap
+            time.sleep(self.rate_limit)
+
+        state.save()
+        print(f"\nDone: {found} books got adaptations "
+              f"({total_adaptations} total) out of {processed} scanned; "
+              f"{failed_batches} batch(es) deferred")
+        print(state.summary())
+
+
+if __name__ == "__main__":
+    AdaptationsEnrichment.cli()

--- a/scripts/run-all-enrichments.py
+++ b/scripts/run-all-enrichments.py
@@ -63,6 +63,14 @@ ENRICHMENT_SOURCES = {
         # still missing after every other source.
         "description": "Consolidated 5-strategy description fallback",
     },
+    "adaptations": {
+        "script": "enrich-adaptations.py",
+        "args": [],
+        # Wikidata P144 "based on": film/TV/stage/radio/opera adaptations for
+        # books carrying a wikidata_qid. Batched SPARQL (~40 books/request),
+        # cached, resumable. Only touches books with no adaptations yet.
+        "description": "Book adaptations from Wikidata P144 (#184)",
+    },
 }
 
 # Safety limits

--- a/scripts/test_enrich_adaptations.py
+++ b/scripts/test_enrich_adaptations.py
@@ -1,0 +1,315 @@
+"""Tests for Wikidata P144 adaptations parsing (issue #184).
+
+Mocks the SPARQL layer (wikidata._sparql) — no network. Asserts that a
+synthetic SPARQL results payload parses into correct {type, title, year}
+objects: every type mapping, missing-year, dedup, multi-P31 priority,
+the per-book cap, and label==QID skipping.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import wikidata
+from wikidata import (
+    adaptations_for_books,
+    adaptations_for_batch,
+    _classify_adaptation_types,
+    _year_from_iso,
+    MAX_ADAPTATIONS_PER_BOOK,
+)
+
+
+# --- SPARQL payload helpers ------------------------------------------------
+
+def _row(book_qid, work_qid, label, *, date=None, inception=None, p31=None):
+    """Build one SPARQL result row (one P31 per row) matching the real shape."""
+    b = {
+        "book": {"value": f"http://www.wikidata.org/entity/{book_qid}"},
+        "work": {"value": f"http://www.wikidata.org/entity/{work_qid}"},
+        "workLabel": {"value": label},
+    }
+    if date is not None:
+        b["date"] = {"value": date}
+    if inception is not None:
+        b["inception"] = {"value": inception}
+    if p31 is not None:
+        b["p31"] = {"value": f"http://www.wikidata.org/entity/{p31}"}
+    return b
+
+
+def _binding(book_qid, work_qid, label, *, date=None, inception=None, p31s=()):
+    """Expand one logical work (which may have several P31 classes) into the
+    one-row-per-P31 shape the live query returns. Returns a list of rows."""
+    if not p31s:
+        return [_row(book_qid, work_qid, label, date=date, inception=inception)]
+    return [
+        _row(book_qid, work_qid, label, date=date, inception=inception, p31=q)
+        for q in p31s
+    ]
+
+
+def _results(rows_or_groups):
+    """Accept a flat list of rows and/or lists-of-rows (from _binding) and
+    flatten into the SPARQL results shape."""
+    flat = []
+    for item in rows_or_groups:
+        if isinstance(item, list):
+            flat.extend(item)
+        else:
+            flat.append(item)
+    return {"results": {"bindings": flat}}
+
+
+def _patch_sparql(monkeypatch, payload):
+    """Force adaptations_for_books to use `payload` for every batch and skip
+    the disk cache (call the fetch closure directly)."""
+    monkeypatch.setattr(wikidata, "_sparql", lambda q: payload)
+    # Bypass the on-disk cache so the patched _sparql is actually exercised.
+    monkeypatch.setattr(
+        wikidata, "cached_fetch", lambda source, key, fetch, **kw: fetch()
+    )
+
+
+# --- _year_from_iso --------------------------------------------------------
+
+class TestYearFromIso:
+    def test_iso_datetime(self):
+        assert _year_from_iso("1965-08-01T00:00:00Z") == 1965
+
+    def test_year_only(self):
+        assert _year_from_iso("1984") == 1984
+
+    def test_bce_negative(self):
+        assert _year_from_iso("-0428-00-00T00:00:00Z") == -428
+
+    def test_none(self):
+        assert _year_from_iso(None) is None
+
+    def test_garbage(self):
+        assert _year_from_iso("not-a-date") is None
+
+
+# --- _classify_adaptation_types -------------------------------------------
+
+class TestClassify:
+    def test_film(self):
+        assert _classify_adaptation_types(["Q11424"]) == "film"
+
+    def test_tv_series(self):
+        assert _classify_adaptation_types(["Q5398426"]) == "tv"
+
+    def test_stage_play(self):
+        assert _classify_adaptation_types(["Q25379"]) == "stage"
+
+    def test_radio_drama(self):
+        assert _classify_adaptation_types(["Q2635894"]) == "radio"
+
+    def test_opera(self):
+        assert _classify_adaptation_types(["Q1344"]) == "opera"
+
+    def test_unknown_is_other(self):
+        assert _classify_adaptation_types(["Q9999999"]) == "other"
+
+    def test_empty_is_other(self):
+        assert _classify_adaptation_types([]) == "other"
+
+    def test_tv_wins_over_film_for_television_film(self):
+        # A work tagged both 'film' (Q11424) and 'television film' (Q93204)
+        # must resolve to tv per the fixed priority.
+        assert _classify_adaptation_types(["Q11424", "Q93204"]) == "tv"
+
+    def test_film_wins_over_stage_when_both_present(self):
+        assert _classify_adaptation_types(["Q25379", "Q11424"]) == "film"
+
+
+# --- adaptations_for_books (the parser) -----------------------------------
+
+class TestAdaptationsForBooks:
+    def test_each_type_mapping(self, monkeypatch):
+        payload = _results([
+            _binding("Q1", "QF", "A Film", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+            _binding("Q1", "QT", "A Series", date="2000-01-01T00:00:00Z", p31s=["Q5398426"]),
+            _binding("Q1", "QS", "A Play", date="1990-01-01T00:00:00Z", p31s=["Q25379"]),
+            _binding("Q1", "QR", "A Radio Drama", date="1955-01-01T00:00:00Z", p31s=["Q2635894"]),
+            _binding("Q1", "QO", "An Opera", date="1875-01-01T00:00:00Z", p31s=["Q1344"]),
+            _binding("Q1", "QX", "Something Else", date="2010-01-01T00:00:00Z", p31s=["Q9999999"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        got = {(a["type"], a["title"], a.get("year")) for a in out["Q1"]}
+        assert got == {
+            ("opera", "An Opera", 1875),
+            ("radio", "A Radio Drama", 1955),
+            ("film", "A Film", 1984),
+            ("stage", "A Play", 1990),
+            ("tv", "A Series", 2000),
+            ("other", "Something Else", 2010),
+        }
+
+    def test_sorted_by_year(self, monkeypatch):
+        payload = _results([
+            _binding("Q1", "QO", "An Opera", date="1875-01-01T00:00:00Z", p31s=["Q1344"]),
+            _binding("Q1", "QF", "A Film", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+            _binding("Q1", "QR", "A Radio", date="1955-01-01T00:00:00Z", p31s=["Q2635894"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        years = [a["year"] for a in out["Q1"]]
+        assert years == sorted(years)
+
+    def test_missing_year_omitted_and_sorted_last(self, monkeypatch):
+        payload = _results([
+            _binding("Q1", "QF", "Dated Film", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+            _binding("Q1", "QN", "Undated Film", p31s=["Q11424"]),  # no date/inception
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        adaptations = out["Q1"]
+        # Undated entry has no 'year' key and sorts last.
+        assert "year" not in adaptations[-1]
+        assert adaptations[-1]["title"] == "Undated Film"
+        assert adaptations[0]["year"] == 1984
+
+    def test_inception_fallback_when_no_publication_date(self, monkeypatch):
+        payload = _results([
+            _binding("Q1", "QF", "A Film", inception="1971-01-01T00:00:00Z", p31s=["Q11424"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        assert out["Q1"][0]["year"] == 1971
+
+    def test_dedup_by_type_title_year(self, monkeypatch):
+        # Two distinct work QIDs with identical (type,title,year) → one entry.
+        payload = _results([
+            _binding("Q1", "QA", "Same Film", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+            _binding("Q1", "QB", "Same Film", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        assert len(out["Q1"]) == 1
+
+    def test_multi_p31_rows_for_same_work_merge(self, monkeypatch):
+        # GROUP_CONCAT normally collapses P31s, but if the endpoint returns
+        # the work over multiple rows we still merge P31 + fill year.
+        payload = _results([
+            _binding("Q1", "QW", "TV Film", date="2000-01-01T00:00:00Z", p31s=["Q11424"]),
+            _binding("Q1", "QW", "TV Film", p31s=["Q93204"]),  # television film
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        assert len(out["Q1"]) == 1
+        assert out["Q1"][0]["type"] == "tv"  # tv wins over film
+        assert out["Q1"][0]["year"] == 2000
+
+    def test_label_equal_to_qid_is_skipped(self, monkeypatch):
+        # SERVICE label returns the QID when no label exists — not a title.
+        payload = _results([
+            _binding("Q1", "QW", "QW", date="2000-01-01T00:00:00Z", p31s=["Q11424"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1"])
+        assert "Q1" not in out  # nothing usable
+
+    def test_cap_per_book(self, monkeypatch):
+        bindings = [
+            _binding("Q1", f"QW{i}", f"Film {i:02d}",
+                     date=f"19{50 + i:02d}-01-01T00:00:00Z", p31s=["Q11424"])
+            for i in range(MAX_ADAPTATIONS_PER_BOOK + 5)
+        ]
+        _patch_sparql(monkeypatch, _results(bindings))
+        out = adaptations_for_books(["Q1"])
+        assert len(out["Q1"]) == MAX_ADAPTATIONS_PER_BOOK
+
+    def test_multiple_books(self, monkeypatch):
+        payload = _results([
+            _binding("Q1", "QF1", "Film One", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+            _binding("Q2", "QF2", "Film Two", date="1990-01-01T00:00:00Z", p31s=["Q11424"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_books(["Q1", "Q2"])
+        assert out["Q1"][0]["title"] == "Film One"
+        assert out["Q2"][0]["title"] == "Film Two"
+
+    def test_no_qids_returns_empty(self, monkeypatch):
+        # Non-Q inputs are dropped before any query.
+        out = adaptations_for_books(["", "notaqid", None])
+        assert out == {}
+
+    def test_no_results_returns_empty(self, monkeypatch):
+        _patch_sparql(monkeypatch, _results([]))
+        assert adaptations_for_books(["Q1"]) == {}
+
+
+class TestBatchFailureContract:
+    """adaptations_for_batch must distinguish 'no data' (empty dict) from a
+    transient query failure (None) so the enricher can resume correctly."""
+
+    def test_transient_failure_returns_none(self, monkeypatch):
+        # _sparql returns None on timeout/429-after-backoff.
+        monkeypatch.setattr(wikidata, "_sparql", lambda q: None)
+        monkeypatch.setattr(
+            wikidata, "cached_fetch", lambda source, key, fetch, **kw: fetch()
+        )
+        calls = []
+        monkeypatch.setattr(
+            wikidata, "cache_invalidate",
+            lambda source, key: calls.append((source, key)),
+        )
+        assert adaptations_for_batch(["Q1", "Q2"]) is None
+        # The poisoned-negative cache entry is invalidated so a resumed run
+        # re-queries rather than trusting a false "no adaptations".
+        assert calls and calls[0][0] == "wikidata_adaptations_v1"
+
+    def test_empty_result_returns_empty_dict_not_none(self, monkeypatch):
+        # A genuine empty result is a truthy {results:{bindings:[]}} → {}.
+        _patch_sparql(monkeypatch, _results([]))
+        assert adaptations_for_batch(["Q1"]) == {}
+
+    def test_batch_with_data(self, monkeypatch):
+        payload = _results([
+            _binding("Q1", "QF", "A Film", date="1984-01-01T00:00:00Z", p31s=["Q11424"]),
+        ])
+        _patch_sparql(monkeypatch, payload)
+        out = adaptations_for_batch(["Q1"])
+        assert out == {"Q1": [{"type": "film", "title": "A Film", "year": 1984}]}
+
+    def test_non_q_inputs_dropped(self, monkeypatch):
+        assert adaptations_for_batch(["", "x", None]) == {}
+
+
+class TestSparqlTimeoutHandling:
+    """The SPARQL transport must return None on a hung/timed-out endpoint
+    rather than blocking — it routes through http_retry.fetch_with_retry,
+    which always applies a bounded timeout."""
+
+    def test_timeout_returns_none(self, monkeypatch):
+        # fetch_with_retry returns (None, 0, {}) on a network timeout.
+        monkeypatch.setattr(wikidata, "fetch_with_retry", lambda url, **kw: (None, 0, {}))
+        monkeypatch.setattr(wikidata, "_pace", lambda: None)
+        assert wikidata._sparql("SELECT * WHERE { ?s ?p ?o }") is None
+
+    def test_success_parses_json(self, monkeypatch):
+        body = b'{"results": {"bindings": []}}'
+        monkeypatch.setattr(wikidata, "fetch_with_retry", lambda url, **kw: (body, 200, {}))
+        monkeypatch.setattr(wikidata, "_pace", lambda: None)
+        assert wikidata._sparql("SELECT * WHERE { ?s ?p ?o }") == {
+            "results": {"bindings": []}
+        }
+
+    def test_malformed_body_returns_none(self, monkeypatch):
+        monkeypatch.setattr(wikidata, "fetch_with_retry", lambda url, **kw: (b"not json", 200, {}))
+        monkeypatch.setattr(wikidata, "_pace", lambda: None)
+        assert wikidata._sparql("SELECT * WHERE { ?s ?p ?o }") is None
+
+    def test_429_after_budget_capped_retry_then_none(self, monkeypatch):
+        # Sustained 429 (fetch_with_retry exhausted its budget, status 429).
+        # _sparql does a capped minute-backoff retry then gives up — never
+        # loops forever. Stub sleep so the test is fast.
+        monkeypatch.setattr(wikidata, "fetch_with_retry", lambda url, **kw: (None, 429, {}))
+        monkeypatch.setattr(wikidata, "_pace", lambda: None)
+        sleeps = []
+        monkeypatch.setattr(wikidata._time, "sleep", lambda s: sleeps.append(s))
+        assert wikidata._sparql("SELECT * WHERE { ?s ?p ?o }") is None
+        assert 0 < len(sleeps) <= wikidata.SPARQL_MAX_429_RETRIES

--- a/scripts/wikidata.py
+++ b/scripts/wikidata.py
@@ -36,7 +36,8 @@ from urllib.request import urlopen, Request
 sys.path.insert(0, str(Path(__file__).parent))
 
 from enrichment_config import USER_AGENT
-from http_cache import cached_fetch
+from http_cache import cached_fetch, invalidate as cache_invalidate
+from http_retry import fetch_with_retry
 
 
 SPARQL_URL = "https://query.wikidata.org/sparql"
@@ -66,42 +67,54 @@ def _pace() -> None:
     _last_call_ts = _time.monotonic()
 
 
+# How many times to retry a 429 before giving up. WDQS occasionally enters
+# an aggressive "1 request / minute" mode during outages; a few patient
+# retries that honor Retry-After let a batch eventually succeed instead of
+# being skipped (and re-queried only on a later run).
+SPARQL_MAX_429_RETRIES = 5
+
+
 def _sparql(query: str) -> dict | None:
     """Execute a SPARQL query, return parsed JSON or None on error.
 
-    Respects 2 RPS limit and the Retry-After header on 429.
+    Routes the request through ``http_retry.fetch_with_retry`` so it always
+    has a bounded socket timeout (``REQUEST_TIMEOUT``) and honors Retry-After
+    / exponential backoff on 429/503 — a slow or non-responding WDQS endpoint
+    returns ``None`` instead of blocking forever (the raw ``urlopen`` path
+    could stall indefinitely on a trickled response body, hanging the scan).
+
+    Respects the inter-call pacing. ``fetch_with_retry`` does its own
+    429-aware retries; we leave SPARQL_MAX_429_RETRIES for the dedicated
+    minute-backoff outage path below as a final, capped fallback. Non-429
+    errors and parse failures return None.
     """
-    _pace()
     url = f"{SPARQL_URL}?query={quote_plus(query)}&format=json"
-    req = Request(
-        url,
-        headers={
-            "User-Agent": WIKIDATA_UA,
-            "Accept": "application/sparql-results+json",
-        },
-    )
-    try:
-        with urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
-            return json.loads(resp.read())
-    except HTTPError as e:
-        if e.code == 429:
-            retry = e.headers.get("Retry-After")
-            wait_s = SPARQL_BACKOFF_429_S
+    headers = {
+        "User-Agent": WIKIDATA_UA,
+        "Accept": "application/sparql-results+json",
+    }
+    for attempt in range(SPARQL_MAX_429_RETRIES + 1):
+        _pace()
+        body, status, _resp_headers = fetch_with_retry(
+            url,
+            user_agent=WIKIDATA_UA,
+            timeout=REQUEST_TIMEOUT,
+            extra_headers=headers,
+        )
+        if body is not None:
             try:
-                wait_s = max(wait_s, int(retry)) if retry else wait_s
-            except (TypeError, ValueError):
-                pass
-            _time.sleep(wait_s)
-            # One retry after the backoff
-            _pace()
-            try:
-                with urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
-                    return json.loads(resp.read())
-            except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
+                return json.loads(body)
+            except (json.JSONDecodeError, ValueError):
                 return None
+        # body is None → permanent/exhausted failure. For a sustained-outage
+        # 429 (status 429 after fetch_with_retry burned its budget), do a
+        # capped minute-level backoff and retry the whole request; otherwise
+        # give up immediately.
+        if status == 429 and attempt < SPARQL_MAX_429_RETRIES:
+            _time.sleep(SPARQL_BACKOFF_429_S)
+            continue
         return None
-    except (URLError, TimeoutError, OSError, json.JSONDecodeError):
-        return None
+    return None
 
 
 def _qids_by_p648(keys: list[str], olid_path_prefix: str) -> dict[str, str]:
@@ -483,6 +496,207 @@ def fields_for_author(qid: str, entity: dict) -> dict:
             break
 
     return out
+
+
+# ---------------------------------------------------------------------------
+# Adaptations (P144 "based on") — issue #184
+# ---------------------------------------------------------------------------
+
+# The book schema enum is {film, tv, stage, radio, opera, other}. We classify
+# the adaptation's P31 (instance-of) QID into one of those buckets. An
+# unmapped P31 (or no P31) maps to 'other' so we never emit an out-of-enum
+# value the content collection would reject. Conflicts are resolved by the
+# fixed priority in _classify_adaptation_types (tv > film > opera > stage >
+# radio) — e.g. a "television film" lands deterministically on 'tv'.
+P31_TYPE_MAP: dict[str, str] = {
+    # film
+    "Q11424": "film", "Q24862": "film", "Q202866": "film", "Q24869": "film",
+    "Q229390": "film", "Q18011172": "film", "Q130232": "film",
+    "Q1054574": "film", "Q959790": "film", "Q1361932": "film",  # comedy film
+    "Q645928": "film",  # epic film
+    # tv (television films map to tv)
+    "Q5398426": "tv", "Q1259759": "tv", "Q581714": "tv", "Q63952888": "tv",
+    "Q1107": "tv", "Q117467246": "tv", "Q15416": "tv", "Q21191270": "tv",
+    "Q526877": "tv", "Q1366112": "tv", "Q220898": "tv", "Q93204": "tv",
+    "Q506240": "tv", "Q5398427": "tv",  # television drama series
+    # stage
+    "Q25379": "stage", "Q2743": "stage", "Q43099500": "stage", "Q11635": "stage",
+    "Q188451": "stage", "Q5398472": "stage", "Q7777573": "stage", "Q7777570": "stage",
+    "Q7777577": "stage",  # theatrical adaptation variants
+    # radio
+    "Q2635894": "radio", "Q1320047": "radio", "Q14406742": "radio", "Q3736046": "radio",
+    # opera
+    "Q1344": "opera", "Q1278123": "opera",
+}
+
+# Bucket for any P31 not in the map but which is still clearly a creative work
+# we want to keep. Currently we keep everything (unmapped → 'other'); the cap
+# and dedup keep volume sane.
+MAX_ADAPTATIONS_PER_BOOK = 12
+
+# Books per P144 SPARQL request. Kept small (20) so a single batch's query
+# stays cheap and well under the 60s endpoint timeout even during WDQS load —
+# a heavy 40-book fan-out across P144/P31/P577 was a hang risk.
+ADAPTATIONS_BATCH_SIZE = 20
+
+
+def _classify_adaptation_types(p31_qids: list[str]) -> str:
+    """Pick a schema type from a work's instance-of QIDs.
+
+    A work can be instance-of several classes (e.g. both 'film' and 'drama
+    film'). We prefer the most specific recognizable medium, with a fixed
+    priority so a "television film" lands on 'tv' deterministically. Unknown
+    or empty → 'other'.
+    """
+    matched = [P31_TYPE_MAP[q] for q in p31_qids if q in P31_TYPE_MAP]
+    if not matched:
+        return "other"
+    # Priority order when a work is tagged with multiple media classes.
+    for pref in ("tv", "film", "opera", "stage", "radio"):
+        if pref in matched:
+            return pref
+    return "other"
+
+
+def adaptations_for_books(qids: Iterable[str]) -> dict[str, list[dict]]:
+    """Map book QIDs → list of {type, title, year?} adaptations via P144.
+
+    For each adaptation work `?w` where `?w wdt:P144 wd:<book>`, we pull:
+      * its English label (title)
+      * a year from P577 (publication date) or, failing that, P571 (inception)
+      * its P31 instance-of QIDs, classified into the schema type enum
+
+    Queries are batched with a VALUES ?book clause (~40 books/request) to
+    stay well under the 60s SPARQL timeout and be rate-limit friendly.
+    Results are cached via http_cache. Each book's list is deduped by
+    (type, title, year), sorted by year (None last), and capped.
+    """
+    cleaned = sorted({q for q in qids if q and q.startswith("Q")})
+    if not cleaned:
+        return {}
+
+    out: dict[str, list[dict]] = {}
+    batch_size = ADAPTATIONS_BATCH_SIZE
+    for start in range(0, len(cleaned), batch_size):
+        batch = cleaned[start:start + batch_size]
+        batch_result = adaptations_for_batch(batch)
+        if batch_result is None:
+            continue  # transient failure for this batch — skip its books
+        out.update(batch_result)
+    return out
+
+
+def adaptations_for_batch(batch: list[str]) -> dict[str, list[dict]] | None:
+    """Query one batch of book QIDs for P144 adaptations.
+
+    Returns a dict {book_qid: [{type, title, year?}, ...]} for the books in
+    `batch` that have adaptations (books with none are simply absent), or
+    ``None`` when the query failed transiently (timeout / network / 429 after
+    backoff). The None signal lets the caller leave those books un-scanned so
+    a resumed run re-queries them, instead of recording them as "no data".
+    """
+    batch = [q for q in batch if q and q.startswith("Q")]
+    if not batch:
+        return {}
+
+    values = " ".join(f"wd:{q}" for q in batch)
+    # One row per (work, P31). We fetch the English label with a direct
+    # rdfs:label + LANG() filter rather than the wikibase:label SERVICE:
+    # the SERVICE combined with GROUP BY makes this query 100x+ slower
+    # (it can blow the 60s endpoint timeout for a 40-book batch). We
+    # aggregate the multiple-P31 rows back into one work in Python below.
+    query = f"""
+    SELECT ?book ?work ?workLabel ?date ?inception ?p31 WHERE {{
+      VALUES ?book {{ {values} }}
+      ?work wdt:P144 ?book .
+      OPTIONAL {{ ?work wdt:P31 ?p31 . }}
+      OPTIONAL {{ ?work wdt:P577 ?date . }}
+      OPTIONAL {{ ?work wdt:P571 ?inception . }}
+      ?work rdfs:label ?workLabel . FILTER(LANG(?workLabel) = "en")
+    }}
+    """
+    cache_key = f"adaptations:{','.join(sorted(batch))}"
+    data = cached_fetch(
+        "wikidata_adaptations_v1",
+        cache_key,
+        lambda q=query: _sparql(q),
+    )
+    if data is None:
+        # _sparql returns None only on a transient failure (timeout, network,
+        # or 429 after backoff) — never for a genuine empty result (that's a
+        # truthy {results:{bindings:[]}}). Don't let the negative get cached
+        # as a false "no adaptations": invalidate so a resumed run re-queries.
+        cache_invalidate("wikidata_adaptations_v1", cache_key)
+        return None
+
+    # Accumulate raw rows per book: {book_qid: {work_qid: {title, year, p31s}}}
+    raw: dict[str, dict[str, dict]] = {}
+    for b in (data.get("results", {}) or {}).get("bindings", []) or []:
+        book_qid = b.get("book", {}).get("value", "").rsplit("/", 1)[-1]
+        work_qid = b.get("work", {}).get("value", "").rsplit("/", 1)[-1]
+        if not book_qid or not work_qid:
+            continue
+        label = b.get("workLabel", {}).get("value")
+        # No English label → can't form a usable title; skip the row.
+        if not label or label == work_qid:
+            continue
+        year = _year_from_iso(b.get("date", {}).get("value")) \
+            or _year_from_iso(b.get("inception", {}).get("value"))
+        p31 = b.get("p31", {}).get("value", "")
+        p31_qid = p31.rsplit("/", 1)[-1] if p31 else None
+
+        book_bucket = raw.setdefault(book_qid, {})
+        existing = book_bucket.get(work_qid)
+        if existing is None:
+            book_bucket[work_qid] = {
+                "title": label,
+                "year": year,
+                "p31s": [p31_qid] if p31_qid else [],
+            }
+        else:
+            # Another P31 row for the same work — accumulate P31s and
+            # fill a missing year if this row carries one.
+            if p31_qid and p31_qid not in existing["p31s"]:
+                existing["p31s"].append(p31_qid)
+            if existing.get("year") is None and year is not None:
+                existing["year"] = year
+
+    # Reduce raw rows to clean, deduped, sorted, capped adaptation lists.
+    out: dict[str, list[dict]] = {}
+    for book_qid, works in raw.items():
+        adaptations = []
+        seen: set[tuple] = set()
+        for work in works.values():
+            entry: dict = {
+                "type": _classify_adaptation_types(work["p31s"]),
+                "title": work["title"],
+            }
+            if work.get("year") is not None:
+                entry["year"] = work["year"]
+            key = (entry["type"], entry["title"], entry.get("year"))
+            if key in seen:
+                continue
+            seen.add(key)
+            adaptations.append(entry)
+        # Sort by year (None last), then title for stability.
+        adaptations.sort(key=lambda a: (a.get("year") is None, a.get("year") or 0, a["title"]))
+        if adaptations:
+            out[book_qid] = adaptations[:MAX_ADAPTATIONS_PER_BOOK]
+    return out
+
+
+def _year_from_iso(value: str | None) -> int | None:
+    """Extract a year int from a SPARQL xsd:dateTime literal like
+    '1965-08-01T00:00:00Z' or '-0428-...'. Returns None when unparseable."""
+    if not value or not isinstance(value, str):
+        return None
+    sign = -1 if value.startswith("-") else 1
+    body = value.lstrip("+-")
+    year_str = body.split("-", 1)[0]
+    try:
+        return int(year_str) * sign
+    except ValueError:
+        return None
 
 
 def resolve_qid_labels(qids: Iterable[str], lang: str = "en") -> dict[str, str]:

--- a/src/content/books/a-canticle-for-leibowitz.json
+++ b/src/content/books/a-canticle-for-leibowitz.json
@@ -89,7 +89,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "original_publisher": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 72,
   "first_published_circa": false,
@@ -110,5 +111,12 @@
   ],
   "cover_url_source": "https://covers.openlibrary.org/b/id/10221348-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/10221348-L.jpg",
-  "cover_cached_at": "2026-05-03T00:51:23+00:00"
+  "cover_cached_at": "2026-05-03T00:51:23+00:00",
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "A Canticle for Comiket",
+      "year": 2025
+    }
+  ]
 }

--- a/src/content/books/a-clash-of-kings.json
+++ b/src/content/books/a-clash-of-kings.json
@@ -93,7 +93,8 @@
     "original_language": "wikidata_v1",
     "original_publisher": "wikidata_v1",
     "awards": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 76,
   "first_published_circa": false,
@@ -118,5 +119,17 @@
   },
   "cover_url_source": "https://covers.openlibrary.org/b/id/8231751-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/8231751-L.jpg",
-  "cover_cached_at": "2026-05-03T00:51:27+00:00"
+  "cover_cached_at": "2026-05-03T00:51:27+00:00",
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "Game of Thrones, season 2",
+      "year": 2012
+    },
+    {
+      "type": "other",
+      "title": "A Clash of Kings",
+      "year": 2017
+    }
+  ]
 }

--- a/src/content/books/a-clockwork-orange.json
+++ b/src/content/books/a-clockwork-orange.json
@@ -121,7 +121,8 @@
     "original_publisher": "wikidata_v1",
     "awards": "wikidata_v1",
     "cover_url": "ol_editions_v1",
-    "cover_url_large": "ol_editions_v1"
+    "cover_url_large": "ol_editions_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 136,
   "first_published_circa": false,
@@ -146,5 +147,27 @@
   ],
   "cover_url_source": "https://covers.openlibrary.org/b/id/14121728-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/14121728-L.jpg",
-  "cover_cached_at": "2026-05-03T00:51:28+00:00"
+  "cover_cached_at": "2026-05-03T00:51:28+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "Vinyl",
+      "year": 1965
+    },
+    {
+      "type": "film",
+      "title": "A Clockwork Orange",
+      "year": 1971
+    },
+    {
+      "type": "other",
+      "title": "A Clockwork Orange: A Play with Music",
+      "year": 1987
+    },
+    {
+      "type": "other",
+      "title": "A-Lex",
+      "year": 2009
+    }
+  ]
 }

--- a/src/content/books/a-connecticut-yankee-in-king-arthur-s-court.json
+++ b/src/content/books/a-connecticut-yankee-in-king-arthur-s-court.json
@@ -172,7 +172,8 @@
     "representative_edition_key": "ol_firstedition_v1",
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
-    "original_language": "wikidata_v1"
+    "original_language": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 400,
   "first_published_circa": false,
@@ -182,5 +183,46 @@
   "original_title": "A Connecticut Yankee in King Arthur's Court",
   "original_language": "eng",
   "cover_url_source": "https://books.google.com/books/content?id=yTXKP6sCic8C&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:51:32+00:00"
+  "cover_cached_at": "2026-05-03T00:51:32+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "A Connecticut Yankee in King Arthur's Court",
+      "year": 1921
+    },
+    {
+      "type": "film",
+      "title": "A Connecticut Yankee",
+      "year": 1931
+    },
+    {
+      "type": "film",
+      "title": "A Connecticut Yankee in King Arthur's Court",
+      "year": 1949
+    },
+    {
+      "type": "tv",
+      "title": "A Connecticut Yankee in King Arthur's Court",
+      "year": 1978
+    },
+    {
+      "type": "film",
+      "title": "Unidentified Flying Oddball",
+      "year": 1979
+    },
+    {
+      "type": "film",
+      "title": "New Adventures of a Yankee in King Arthur's Court",
+      "year": 1988
+    },
+    {
+      "type": "tv",
+      "title": "A Knight in Camelot",
+      "year": 1998
+    },
+    {
+      "type": "other",
+      "title": "A Connecticut Yankee"
+    }
+  ]
 }

--- a/src/content/books/a-damsel-in-distress.json
+++ b/src/content/books/a-damsel-in-distress.json
@@ -59,7 +59,8 @@
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
-    "original_publisher": "wikidata_v1"
+    "original_publisher": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 48,
   "first_published_circa": false,
@@ -70,5 +71,21 @@
   "original_language": "eng",
   "original_publisher": "George H. Doran Company",
   "cover_url_source": "https://books.google.com/books/content?id=kllyOAAACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:51:33+00:00"
+  "cover_cached_at": "2026-05-03T00:51:33+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "A Damsel in Distress",
+      "year": 1919
+    },
+    {
+      "type": "film",
+      "title": "A Damsel in Distress",
+      "year": 1937
+    },
+    {
+      "type": "other",
+      "title": "A Damsel in Distress"
+    }
+  ]
 }

--- a/src/content/books/a-farewell-to-arms.json
+++ b/src/content/books/a-farewell-to-arms.json
@@ -133,7 +133,8 @@
     "representative_edition_key": "ol_firstedition_v1",
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
-    "original_language": "wikidata_v1"
+    "original_language": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 181,
   "first_published_circa": false,
@@ -144,5 +145,22 @@
   "original_language": "eng",
   "cover_url_source": "https://covers.openlibrary.org/b/id/7226599-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/7226599-L.jpg",
-  "cover_cached_at": "2026-05-03T00:51:48+00:00"
+  "cover_cached_at": "2026-05-03T00:51:48+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "A Farewell to Arms",
+      "year": 1932
+    },
+    {
+      "type": "film",
+      "title": "A Farewell to Arms",
+      "year": 1957
+    },
+    {
+      "type": "tv",
+      "title": "A Farewell to Arms",
+      "year": 1966
+    }
+  ]
 }

--- a/src/content/books/a-game-of-thrones.json
+++ b/src/content/books/a-game-of-thrones.json
@@ -121,7 +121,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "awards": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 135,
   "first_published_circa": false,
@@ -145,5 +146,12 @@
   },
   "cover_url_source": "https://covers.openlibrary.org/b/id/9269962-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/9269962-L.jpg",
-  "cover_cached_at": "2026-05-03T00:51:54+00:00"
+  "cover_cached_at": "2026-05-03T00:51:54+00:00",
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "Game of Thrones, season 1",
+      "year": 2011
+    }
+  ]
 }

--- a/src/content/books/a-portrait-of-the-artist-as-a-young-man.json
+++ b/src/content/books/a-portrait-of-the-artist-as-a-young-man.json
@@ -179,7 +179,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "original_publisher": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 400,
   "first_edition_isbn": null,
@@ -195,5 +196,12 @@
   ],
   "cover_url_source": "https://covers.openlibrary.org/b/id/9328410-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/9328410-L.jpg",
-  "cover_cached_at": "2026-05-03T00:52:25+00:00"
+  "cover_cached_at": "2026-05-03T00:52:25+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "A Portrait of the Artist as a Young Man",
+      "year": 1977
+    }
+  ]
 }

--- a/src/content/books/a-princess-of-mars.json
+++ b/src/content/books/a-princess-of-mars.json
@@ -94,7 +94,8 @@
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 400,
   "first_published_circa": false,
@@ -107,5 +108,17 @@
     "name": "Barsoom"
   },
   "cover_url_source": "https://books.google.com/books/content?id=ws18cmj5ic0C&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:52:26+00:00"
+  "cover_cached_at": "2026-05-03T00:52:26+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "Princess of Mars",
+      "year": 2009
+    },
+    {
+      "type": "film",
+      "title": "John Carter",
+      "year": 2012
+    }
+  ]
 }

--- a/src/content/books/a-storm-of-swords.json
+++ b/src/content/books/a-storm-of-swords.json
@@ -84,7 +84,8 @@
     "original_language": "wikidata_v1",
     "original_publisher": "wikidata_v1",
     "awards": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 57,
   "first_published_circa": false,
@@ -109,5 +110,17 @@
   },
   "cover_url_source": "https://covers.openlibrary.org/b/id/15124196-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/15124196-L.jpg",
-  "cover_cached_at": "2026-05-03T00:52:43+00:00"
+  "cover_cached_at": "2026-05-03T00:52:43+00:00",
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "Game of Thrones, season 3",
+      "year": 2013
+    },
+    {
+      "type": "other",
+      "title": "Game of Thrones, season 4",
+      "year": 2014
+    }
+  ]
 }

--- a/src/content/books/a-streetcar-named-desire.json
+++ b/src/content/books/a-streetcar-named-desire.json
@@ -85,7 +85,8 @@
     "representative_edition_key": "ol_firstedition_v1",
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 69,
   "first_published_circa": false,
@@ -101,5 +102,32 @@
   ],
   "cover_url_source": "https://covers.openlibrary.org/b/id/8422967-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/8422967-L.jpg",
-  "cover_cached_at": "2026-05-03T00:52:46+00:00"
+  "cover_cached_at": "2026-05-03T00:52:46+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "A Streetcar Named Desire",
+      "year": 1951
+    },
+    {
+      "type": "film",
+      "title": "Linje Lusta",
+      "year": 1981
+    },
+    {
+      "type": "film",
+      "title": "The Prey",
+      "year": 1986
+    },
+    {
+      "type": "other",
+      "title": "A Streetcar Named Desire",
+      "year": 2000
+    },
+    {
+      "type": "film",
+      "title": "The Desire",
+      "year": 2002
+    }
+  ]
 }

--- a/src/content/books/a-tale-of-two-cities.json
+++ b/src/content/books/a-tale-of-two-cities.json
@@ -278,7 +278,8 @@
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
-    "original_publisher": "wikidata_v1"
+    "original_publisher": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 400,
   "first_edition_isbn": null,
@@ -289,5 +290,63 @@
   "original_publisher": "Chapman and Hall",
   "cover_url_source": "https://covers.openlibrary.org/b/id/13301713-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/13301713-L.jpg",
-  "cover_cached_at": "2026-05-03T00:52:49+00:00"
+  "cover_cached_at": "2026-05-03T00:52:49+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "A Tale of Two Cities",
+      "year": 1907
+    },
+    {
+      "type": "film",
+      "title": "A Tale of Two Cities",
+      "year": 1911
+    },
+    {
+      "type": "film",
+      "title": "A Tale of Two Cities",
+      "year": 1917
+    },
+    {
+      "type": "film",
+      "title": "A Tale of Two Cities",
+      "year": 1922
+    },
+    {
+      "type": "film",
+      "title": "The Only Way",
+      "year": 1927
+    },
+    {
+      "type": "film",
+      "title": "A Tale of Two Cities",
+      "year": 1935
+    },
+    {
+      "type": "film",
+      "title": "A Tale of Two Cities",
+      "year": 1958
+    },
+    {
+      "type": "tv",
+      "title": "A Tale of Two Cities",
+      "year": 1980
+    },
+    {
+      "type": "other",
+      "title": "A Tale of Two Cities"
+    },
+    {
+      "type": "tv",
+      "title": "A Tale of Two Cities"
+    },
+    {
+      "type": "other",
+      "title": "The Only Way"
+    },
+    {
+      "type": "other",
+      "title": "Two Cities"
+    }
+  ]
 }

--- a/src/content/books/against-the-fall-of-night.json
+++ b/src/content/books/against-the-fall-of-night.json
@@ -41,7 +41,8 @@
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
-    "original_publisher": "wikidata_v1"
+    "original_publisher": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 8,
   "first_published_circa": false,
@@ -53,5 +54,17 @@
   "original_publisher": "Gnome Press",
   "cover_url_source": "https://covers.openlibrary.org/b/id/5541403-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/5541403-L.jpg",
-  "cover_cached_at": "2026-05-03T00:53:30+00:00"
+  "cover_cached_at": "2026-05-03T00:53:30+00:00",
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "The City and the Stars",
+      "year": 1956
+    },
+    {
+      "type": "other",
+      "title": "Beyond the Fall of Night",
+      "year": 1990
+    }
+  ]
 }

--- a/src/content/books/alice-adams.json
+++ b/src/content/books/alice-adams.json
@@ -79,7 +79,8 @@
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 174,
   "first_published_circa": false,
@@ -95,5 +96,12 @@
     }
   ],
   "cover_url_source": "https://books.google.com/books/content?id=hn5LAAAAIAAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:53:47+00:00"
+  "cover_cached_at": "2026-05-03T00:53:47+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "Alice Adams",
+      "year": 1935
+    }
+  ]
 }

--- a/src/content/books/alice-s-adventures-in-wonderland.json
+++ b/src/content/books/alice-s-adventures-in-wonderland.json
@@ -492,7 +492,8 @@
     "original_title": "wikidata_v1",
     "first_published_circa": "wikidata_v1",
     "original_publisher": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 400,
   "first_edition_isbn": null,
@@ -508,5 +509,67 @@
     }
   ],
   "cover_url_source": "https://books.google.com/books/content?id=btIQAAAAYAAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:53:47+00:00"
+  "cover_cached_at": "2026-05-03T00:53:47+00:00",
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "The Nursery \"Alice\"",
+      "year": 1890
+    },
+    {
+      "type": "other",
+      "title": "A New Alice in the Old Wonderland",
+      "year": 1895
+    },
+    {
+      "type": "other",
+      "title": "Alice's Adventures in Wonderland retold in words of one syllable",
+      "year": 1905
+    },
+    {
+      "type": "film",
+      "title": "Alice in Wonderland",
+      "year": 1915
+    },
+    {
+      "type": "other",
+      "title": "Alice in Wonderland",
+      "year": 1915
+    },
+    {
+      "type": "other",
+      "title": "Alice in Wonderland",
+      "year": 1916
+    },
+    {
+      "type": "film",
+      "title": "Alice in Wonderland",
+      "year": 1933
+    },
+    {
+      "type": "film",
+      "title": "Alice in Wonderland",
+      "year": 1949
+    },
+    {
+      "type": "film",
+      "title": "Alice in Wonderland",
+      "year": 1951
+    },
+    {
+      "type": "other",
+      "title": "White Rabbit",
+      "year": 1967
+    },
+    {
+      "type": "other",
+      "title": "Curious Alice",
+      "year": 1971
+    },
+    {
+      "type": "film",
+      "title": "Alice's Adventures in Wonderland",
+      "year": 1972
+    }
+  ]
 }

--- a/src/content/books/all-systems-red.json
+++ b/src/content/books/all-systems-red.json
@@ -50,7 +50,8 @@
     "original_language": "wikidata_v1",
     "awards": "wikidata_v1",
     "series": "wikidata_v1",
-    "ddc": "derived_v1"
+    "ddc": "derived_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 9,
   "first_published_circa": false,
@@ -89,5 +90,11 @@
   "cover_cached_at": "2026-05-03T00:53:52+00:00",
   "ddc": [
     "808.83876"
+  ],
+  "adaptations": [
+    {
+      "type": "other",
+      "title": "Murderbot season 1"
+    }
   ]
 }

--- a/src/content/books/all-the-pretty-horses.json
+++ b/src/content/books/all-the-pretty-horses.json
@@ -75,7 +75,8 @@
     "representative_edition_key": "ol_firstedition_v1",
     "wikidata_qid": "wikidata_v1",
     "awards": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 37,
   "first_published_circa": false,
@@ -95,5 +96,12 @@
   },
   "cover_url_source": "https://covers.openlibrary.org/b/id/9296904-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/9296904-L.jpg",
-  "cover_cached_at": "2026-05-03T00:53:54+00:00"
+  "cover_cached_at": "2026-05-03T00:53:54+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "All the Pretty Horses",
+      "year": 2000
+    }
+  ]
 }

--- a/src/content/books/american-gods.json
+++ b/src/content/books/american-gods.json
@@ -93,7 +93,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "awards": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 72,
   "first_published_circa": false,
@@ -132,5 +133,11 @@
   },
   "cover_url_source": "https://covers.openlibrary.org/b/id/8494659-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/8494659-L.jpg",
-  "cover_cached_at": "2026-05-03T00:54:02+00:00"
+  "cover_cached_at": "2026-05-03T00:54:02+00:00",
+  "adaptations": [
+    {
+      "type": "tv",
+      "title": "American Gods"
+    }
+  ]
 }

--- a/src/content/books/american-pastoral.json
+++ b/src/content/books/american-pastoral.json
@@ -67,7 +67,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "awards": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 27,
   "first_published_circa": false,
@@ -86,5 +87,12 @@
   },
   "cover_url_source": "https://covers.openlibrary.org/b/id/9322643-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/9322643-L.jpg",
-  "cover_cached_at": "2026-05-03T00:54:04+00:00"
+  "cover_cached_at": "2026-05-03T00:54:04+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "American Pastoral",
+      "year": 2016
+    }
+  ]
 }

--- a/src/content/books/americanah.json
+++ b/src/content/books/americanah.json
@@ -104,7 +104,8 @@
     "representative_edition_key": "ol_firstedition_v1",
     "wikidata_qid": "wikidata_v1",
     "original_language": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 56,
   "first_published_circa": false,
@@ -131,5 +132,11 @@
   ],
   "cover_url_source": "https://covers.openlibrary.org/b/id/8474037-M.jpg",
   "cover_url_large_source": "https://covers.openlibrary.org/b/id/8474037-L.jpg",
-  "cover_cached_at": "2026-05-03T00:54:07+00:00"
+  "cover_cached_at": "2026-05-03T00:54:07+00:00",
+  "adaptations": [
+    {
+      "type": "tv",
+      "title": "Americanah"
+    }
+  ]
 }

--- a/src/content/books/an-american-tragedy.json
+++ b/src/content/books/an-american-tragedy.json
@@ -127,7 +127,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "original_publisher": "wikidata_v1",
-    "awards": "wikidata_v1"
+    "awards": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 210,
   "first_published_circa": false,
@@ -143,5 +144,26 @@
     }
   ],
   "cover_url_source": "https://books.google.com/books/content?id=qkKVEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:54:08+00:00"
+  "cover_cached_at": "2026-05-03T00:54:08+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "An American Tragedy",
+      "year": 1931
+    },
+    {
+      "type": "film",
+      "title": "A Place in the Sun",
+      "year": 1951
+    },
+    {
+      "type": "film",
+      "title": "Avana Ivan",
+      "year": 1962
+    },
+    {
+      "type": "other",
+      "title": "An American Tragedy"
+    }
+  ]
 }

--- a/src/content/books/an-ideal-husband.json
+++ b/src/content/books/an-ideal-husband.json
@@ -53,7 +53,8 @@
     "representative_edition_key": "ol_firstedition_v1",
     "wikidata_qid": "wikidata_v1",
     "original_title": "wikidata_v1",
-    "original_language": "wikidata_v1"
+    "original_language": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 56,
   "first_published_circa": false,
@@ -64,5 +65,26 @@
   "original_language": "eng",
   "cover_url_source": "https://books.google.com/books/content?id=MapWGG3WJQgC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
   "cover_url_large_source": "https://books.google.com/books/content?id=MapWGG3WJQgC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:54:21+00:00"
+  "cover_cached_at": "2026-05-03T00:54:21+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "An Ideal Husband",
+      "year": 1980
+    },
+    {
+      "type": "film",
+      "title": "An Ideal Husband",
+      "year": 1998
+    },
+    {
+      "type": "film",
+      "title": "An Ideal Husband",
+      "year": 1999
+    },
+    {
+      "type": "stage",
+      "title": "Ein idealer Gatte. Schauspiel in vier Akten"
+    }
+  ]
 }

--- a/src/content/books/an-unsuitable-job-for-a-woman.json
+++ b/src/content/books/an-unsuitable-job-for-a-woman.json
@@ -71,7 +71,8 @@
     "original_title": "wikidata_v1",
     "original_language": "wikidata_v1",
     "original_publisher": "wikidata_v1",
-    "series": "wikidata_v1"
+    "series": "wikidata_v1",
+    "adaptations": "wikidata_adaptations_v1"
   },
   "editions_count": 60,
   "first_published_circa": false,
@@ -85,5 +86,16 @@
   },
   "cover_url_source": "https://books.google.com/books/content?id=iGDEghq3ZPcC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
   "cover_url_large_source": "https://books.google.com/books/content?id=iGDEghq3ZPcC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-  "cover_cached_at": "2026-05-03T00:54:22+00:00"
+  "cover_cached_at": "2026-05-03T00:54:22+00:00",
+  "adaptations": [
+    {
+      "type": "film",
+      "title": "An Unsuitable Job for a Woman",
+      "year": 1982
+    },
+    {
+      "type": "tv",
+      "title": "An Unsuitable Job for a Woman"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds a Wikidata-driven enricher that populates the previously-empty `adaptations` field on books, plus fixes a real SPARQL-hang bug it surfaced.

**Source — Wikidata P144 ("based on").** A film / TV series / play / radio drama / opera that adapts a book carries `P144 → <book's work QID>`. For each book with a `wikidata_qid` we batch-query Wikidata for items `?w` where `?w wdt:P144 wd:<book>`, then read each adaptation's English label (title), year (P577 publication date, else P571 inception), and P31 (instance-of) classes.

## Type mapping (P31 → schema enum)

The schema enum is `{film, tv, stage, radio, opera, other}`. We classify by P31:

| Bucket | Example P31 classes |
|---|---|
| `film` | film (Q11424), animated/short/feature/drama/comedy/epic film |
| `tv` | television series (Q5398426), miniseries, animated/anime series, television film, web series, OVA |
| `stage` | play (Q25379), musical (Q2743), theatrical production/adaptation |
| `radio` | radio drama (Q2635894), radio program/series |
| `opera` | opera (Q1344), operetta |
| `other` | anything else "based on" the work (RPGs, sequels, parodies, songs…) |

A work tagged with multiple media classes resolves deterministically by priority **tv > film > opera > stage > radio** (so a "television film" lands on `tv`). **Any unrecognized P31 (or none) maps to `other`** — we never emit an out-of-enum value the content collection would reject. Per book: deduped by `(type, title, year)`, sorted by year, capped at 12.

## Coverage (this run)

- **23 books populated** with **74 adaptations** (40 film, 8 tv, 1 stage, 25 other).
- **80 / 1275 candidate books scanned.** WDQS was aggressively rate-limiting (active outage) during the run, so coverage is partial.
- **Fully resumable** via `data/enrichment-state.json` (`last_scanned_slug`). Just re-run `python3 scripts/enrich-adaptations.py` to continue from where it stopped — now that the hang is fixed, the rest can be backfilled later.

### Spot-checks
- **A Tale of Two Cities** → 12 adaptations (film + TV, 1907–…)
- **Alice's Adventures in Wonderland** → 12 (film/other)
- **A Clockwork Orange** → 1971 film (+ stage/other)
- **A Connecticut Yankee in King Arthur's Court** → films + TV across 1921–1998

## Hang fix (important)

The enricher surfaced a latent bug in the shared `wikidata._sparql`: it used raw `urllib.urlopen`, whose per-operation socket timeout does **not** bound total duration — a non-responding / trickling WDQS endpoint could block `resp.read()` indefinitely and hang the whole scan. `_sparql` now routes through `http_retry.fetch_with_retry`, which always applies a bounded timeout + Retry-After/backoff. The sustained-429 fallback is a **capped** minute-backoff retry (never an unbounded loop). Batch size lowered 40 → 20 to keep each query cheap. A failed batch is dead-lettered and skipped without advancing the resume pointer; the run stops after 3 consecutive failures.

## Wiring & docs
- Added to `scripts/run-all-enrichments.py` (Phase-1 source).
- Documented in `scripts/README.md` and `CLAUDE.md` (data sources + pipeline).

## Verification
- `cd scripts && python3 -m pytest -q` → **491 passed** (33 new in `test_enrich_adaptations.py`, incl. type mappings, missing-year, dedup, cap, batch-failure-vs-empty contract, and SPARQL-timeout handling — network fully mocked).
- `npm run typecheck` (astro check) → **0 errors** — the 23 populated book JSONs validate against the `adaptations` enum.

Closes #184 (adaptations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)