### PR TITLE
feat(home): publication-timeline teaser → /stats (#124 STATS-REDESIGN)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,17 @@ const books = await getCollection('books');
 const readPct = Math.round(100 * stats.reading_progress.read / stats.total_books);
 const yearsToFinish = Math.round(stats.bookshelf.estimated_reading_hours / 8 / 365 * 10) / 10;
 const yearSpan = stats.newest_year - stats.oldest_year;
+
+// Compact "when the books are from" sparkline — a teaser for the full
+// timeline + nationalities map on /stats (#124 STATS-REDESIGN). Post-1700
+// decades only (pre-1700 is a sparse long tail that flattens the bars);
+// the full breakdown incl. ancient works lives on the stats page.
+const teaserDecades = stats.timeline.filter(t => t.decade >= 1700);
+const teaserMax = Math.max(1, ...teaserDecades.map(t => t.count));
+const nationalityCount = stats.nationality_distribution.length;
+const oldestLine = stats.oldest_year < 0
+  ? `${Math.abs(stats.oldest_year)} BC`
+  : String(stats.oldest_year);
 ---
 
 <Layout title="Home">
@@ -91,6 +102,33 @@ const yearSpan = stats.newest_year - stats.oldest_year;
     </div>
   </section>
 
+  <!-- When the Books Are From — compact timeline teaser → /stats (#124) -->
+  <hr class="section-divider" />
+  <section class="py-8">
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-2">
+      <h2 class="heading-md">When the Books Are From</h2>
+      <a href={`${base}stats/`} class="ext-link text-sm" style="text-decoration: underline">
+        The full damage: timeline &amp; nationalities map →
+      </a>
+    </div>
+    <a href={`${base}stats/`} class="stats-teaser-link" aria-label="See the full publication timeline and nationalities map on the stats page">
+      <div class="card stats-teaser">
+        <div class="stats-sparkline" aria-hidden="true">
+          {teaserDecades.map(t => (
+            <span
+              class="stats-sparkline-bar"
+              style={`height: ${Math.max((t.count / teaserMax) * 100, 3)}%`}
+              title={`${t.decade}s: ${t.count} ${t.count === 1 ? 'book' : 'books'}`}
+            ></span>
+          ))}
+        </div>
+        <p class="text-xs text-dim text-mono mt-3">
+          Each bar is a decade, 1700s–2020s · oldest work {oldestLine} · authors from {nationalityCount} nationalities
+        </p>
+      </div>
+    </a>
+  </section>
+
   <!-- Featured Must-Reads -->
   {(() => {
     const mustReads = books.filter(b => b.data.priority === 1 && b.data.cover_url);
@@ -126,3 +164,35 @@ const yearSpan = stats.newest_year - stats.oldest_year;
     <a href={`${base}categories/`} class="btn btn-outline">Explore Categories</a>
   </section>
 </Layout>
+
+<style>
+  .stats-teaser-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+  }
+  .stats-teaser {
+    padding: 1rem 1.25rem;
+    transition: border-color 200ms ease, transform 200ms ease;
+  }
+  .stats-teaser-link:hover .stats-teaser,
+  .stats-teaser-link:focus-visible .stats-teaser {
+    border-color: var(--border-strong);
+  }
+  /* Compact decade sparkline — bars share width, height encodes book count. */
+  .stats-sparkline {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 64px;
+  }
+  .stats-sparkline-bar {
+    flex: 1 1 0;
+    min-width: 2px;
+    background: var(--pop-purple);
+    border-radius: 1px 1px 0 0;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .stats-teaser { transition: none; }
+  }
+</style>


### PR DESCRIPTION
Completes the last open item of #124 (#STATS-REDESIGN).

**Finding:** the full publication timeline ("When the Books Are From", per-decade bars) and the nationalities world map already exist on **/stats** ("The Damage"). The issue's original wording ("replace the home 'By the Numbers' block") predates that page.

**Per maintainer decision:** add a **compact teaser** on the home page that links to the full `/stats` viz, and **keep** the fun "By the Numbers" badges.

## Change (home page only)
- A compact decade **sparkline** (post-1700, bar height = books/decade) in a card, the whole thing a link to `/stats`.
- One-line caption: "Each bar is a decade, 1700s–2020s · oldest work {N BC} · authors from {N} nationalities".
- Heading + an explicit "The full damage: timeline & nationalities map →" link.
- Reuses `stats.timeline` / `stats.nationality_distribution` (already build-generated). Scoped `<style>`; `prefers-reduced-motion` respected. "By the Numbers" badges retained.

## Verification
`npm run typecheck` → 0 errors (astro 7). Gated by the on-PR build.

Closes #124's #STATS-REDESIGN — with this, the epic is fully complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)