### PR TITLE
feat(stats): interactive hover on home sparkline + world map

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -111,22 +111,31 @@ const oldestLine = stats.oldest_year < 0
         The full damage: timeline &amp; nationalities map →
       </a>
     </div>
-    <a href={`${base}stats/`} class="stats-teaser-link" aria-label="See the full publication timeline and nationalities map on the stats page">
-      <div class="card stats-teaser">
-        <div class="stats-sparkline" aria-hidden="true">
-          {teaserDecades.map(t => (
-            <span
-              class="stats-sparkline-bar"
-              style={`height: ${Math.max((t.count / teaserMax) * 100, 3)}%`}
-              title={`${t.decade}s: ${t.count} ${t.count === 1 ? 'book' : 'books'}`}
-            ></span>
-          ))}
-        </div>
-        <p class="text-xs text-dim text-mono mt-3">
-          Each bar is a decade, 1700s–2020s · oldest work {oldestLine} · authors from {nationalityCount} nationalities
-        </p>
+    <div class="card stats-teaser">
+      <div class="flex justify-between items-baseline mb-2 gap-2">
+        <span class="text-xs text-dim text-mono">books by first-edition decade</span>
+        <span id="sparkline-readout" class="text-xs text-mono text-muted" aria-live="polite">hover a decade →</span>
       </div>
-    </a>
+      <div class="stats-sparkline" id="home-sparkline">
+        {teaserDecades.map(t => (
+          <span
+            class="stats-sparkline-bar"
+            data-decade={t.decade}
+            data-count={t.count}
+            style={`height: ${Math.max((t.count / teaserMax) * 100, 3)}%`}
+            title={`${t.decade}s: ${t.count} ${t.count === 1 ? 'book' : 'books'}`}
+          ></span>
+        ))}
+      </div>
+      <div class="stats-sparkline-axis" aria-hidden="true">
+        <span>1700s</span>
+        <span>2020s</span>
+      </div>
+      <p class="text-xs text-dim mt-3">
+        Oldest work {oldestLine} · authors from {nationalityCount} nationalities ·
+        <a href={`${base}stats/`} class="ext-link" style="text-decoration: underline">see the full breakdown →</a>
+      </p>
+    </div>
   </section>
 
   <!-- Featured Must-Reads -->
@@ -166,19 +175,7 @@ const oldestLine = stats.oldest_year < 0
 </Layout>
 
 <style>
-  .stats-teaser-link {
-    display: block;
-    text-decoration: none;
-    color: inherit;
-  }
-  .stats-teaser {
-    padding: 1rem 1.25rem;
-    transition: border-color 200ms ease, transform 200ms ease;
-  }
-  .stats-teaser-link:hover .stats-teaser,
-  .stats-teaser-link:focus-visible .stats-teaser {
-    border-color: var(--border-strong);
-  }
+  .stats-teaser { padding: 1rem 1.25rem; }
   /* Compact decade sparkline — bars share width, height encodes book count. */
   .stats-sparkline {
     display: flex;
@@ -191,8 +188,41 @@ const oldestLine = stats.oldest_year < 0
     min-width: 2px;
     background: var(--pop-purple);
     border-radius: 1px 1px 0 0;
+    opacity: 0.85;
+    transition: opacity 120ms ease, background-color 120ms ease;
+    cursor: default;
+  }
+  .stats-sparkline-bar:hover {
+    opacity: 1;
+    background: var(--pop-cyan);
+  }
+  .stats-sparkline-axis {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 4px;
+    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    color: var(--text-dim);
   }
   @media (prefers-reduced-motion: reduce) {
-    .stats-teaser { transition: none; }
+    .stats-sparkline-bar { transition: none; }
   }
 </style>
+
+<script is:inline>
+  // Home sparkline: live decade readout on hover (view-transition-safe).
+  document.addEventListener('astro:page-load', () => {
+    const spark = document.getElementById('home-sparkline');
+    const readout = document.getElementById('sparkline-readout');
+    if (!spark || !readout) return;
+    const prompt = 'hover a decade →';
+    readout.textContent = prompt;
+    spark.addEventListener('pointerover', (e) => {
+      const bar = e.target.closest('.stats-sparkline-bar');
+      if (!bar) return;
+      const n = Number(bar.dataset.count);
+      readout.textContent = `${bar.dataset.decade}s — ${n.toLocaleString()} ${n === 1 ? 'book' : 'books'}`;
+    });
+    spark.addEventListener('pointerleave', () => { readout.textContent = prompt; });
+  });
+</script>

--- a/src/pages/stats.astro
+++ b/src/pages/stats.astro
@@ -57,6 +57,17 @@ for (const b of allBooks) {
 }
 const mapMax = Math.max(1, ...Object.values(countryBookCounts));
 
+// Per-country author counts (distinct authors with that primary nationality)
+// for the map hover tooltip, alongside the book counts the fill encodes.
+const countryAuthorCounts: Record<string, number> = {};
+for (const code of authorPrimaryNat.values()) {
+  countryAuthorCounts[code] = (countryAuthorCounts[code] ?? 0) + 1;
+}
+const mapTooltipData: Record<string, { label: string; books: number; authors: number }> = {};
+for (const [code, books] of Object.entries(countryBookCounts)) {
+  mapTooltipData[code] = { label: nationalityLabel(code), books, authors: countryAuthorCounts[code] ?? 0 };
+}
+
 const worldMapSvg = await fs.readFile(
   path.resolve(process.cwd(), 'src/data/world-map.svg'),
   'utf-8',
@@ -168,6 +179,10 @@ ${mapFillRules}
       <div class="card card-padded-lg mb-4">
         <Fragment set:html={worldMapSvg} />
       </div>
+      <p class="text-xs text-dim mb-4">Hover a highlighted country for its counts. Shading is by book count (√-scaled).</p>
+
+      <script type="application/json" id="map-data" set:html={JSON.stringify(mapTooltipData)}></script>
+      <div id="map-tooltip" class="map-tooltip" role="status" aria-live="polite" hidden></div>
 
       <div class="card card-padded-lg">
         {stats.nationality_distribution.map(n => (
@@ -338,3 +353,49 @@ ${mapFillRules}
     Snapshot as of {new Date(stats.generated_at).toLocaleDateString()}. The pile has probably grown since then.
   </p>
 </Layout>
+
+<style>
+  .world-map path[data-country] { cursor: default; }
+  .map-tooltip {
+    position: fixed;
+    z-index: 50;
+    pointer-events: none;
+    padding: 0.35rem 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text);
+    background: var(--bg-elevated);
+    border: var(--border-width) solid var(--border-strong);
+    border-radius: 4px;
+    box-shadow: var(--shadow-2);
+    white-space: nowrap;
+    transform: translate(12px, 12px);
+  }
+  .map-tooltip[hidden] { display: none; }
+</style>
+
+<script is:inline>
+  // World-map hover tooltip: country label + book/author counts, following the
+  // cursor. Re-binds on every view-transition navigation (astro:page-load).
+  document.addEventListener('astro:page-load', () => {
+    const dataEl = document.getElementById('map-data');
+    const tip = document.getElementById('map-tooltip');
+    const svg = document.querySelector('.world-map');
+    if (!dataEl || !tip || !svg) return;
+    let data = {};
+    try { data = JSON.parse(dataEl.textContent || '{}'); } catch (_) { return; }
+
+    svg.addEventListener('pointermove', (e) => {
+      const path = e.target.closest('path[data-country]');
+      const d = path && data[path.getAttribute('data-country')];
+      if (!d) { tip.hidden = true; return; }
+      const books = d.books.toLocaleString();
+      const authors = d.authors.toLocaleString();
+      tip.textContent = `${d.label} — ${books} ${d.books === 1 ? 'book' : 'books'} · ${authors} ${d.authors === 1 ? 'author' : 'authors'}`;
+      tip.hidden = false;
+      tip.style.left = e.clientX + 'px';
+      tip.style.top = e.clientY + 'px';
+    });
+    svg.addEventListener('pointerleave', () => { tip.hidden = true; });
+  });
+</script>


### PR DESCRIPTION
Addresses the UX feedback that the new stats viz wasn't legible — confusing caption, no hover affordance on either the home sparkline or the `/stats` world map.

## Home sparkline (`index.astro`)
- **Live decade readout on hover** — "1960s — 236 books" (was: a static caption mixing decade + nationality facts). Resets to "hover a decade →".
- Bar **hover highlight** (purple → cyan) + **end axis labels** (1700s … 2020s) for orientation.
- Replaced the whole-card `<a>` with an explicit "see the full breakdown →" link so per-bar hover isn't swallowed.

## World map (`/stats`)
- **Cursor-following tooltip** on country hover: **"American — 783 books · 337 authors"** — adds author counts alongside the book counts the fill already encodes. Hides on leave.
- Added a "Hover a highlighted country for its counts" hint.

## Verified in-browser (dev server)
- Sparkline: 33 decade bars; `pointerover` → readout updates; `pointerleave` → resets ✅
- Map: 42 countries with data; hover US → tooltip "American — 783 books · 337 authors", shows then hides ✅

Both use the existing `astro:page-load` script pattern (view-transition-safe, matches the Layout mobile-menu script). `prefers-reduced-motion` respected. `npm run typecheck` → 0 errors. Gated by the on-PR build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)